### PR TITLE
[#17] Add description to country list

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -1,6 +1,13 @@
 <codelist name="Country"   xml:lang="en" complete="0">
     <metadata>
         <name>Country</name>
+        <description>
+            The Country codelist is generated from the ISO 3166-1 part of the
+            ISO 3166 standard. The standard makes allowance, alongside the
+            officially assigned codes, for code elements to be expanded by
+            using either reserved codes or user-assigned codes. IATI currently
+            defines additional codes in the XA -XZ range.
+        </description>
         <url>http://www.iso.org/iso/home/standards/country_codes.htm</url>
     </metadata>
     <codelist-items>


### PR DESCRIPTION
This explains that IATI lists some user assigned codes in the XA - XZ
range (currently just XK - Kosovo)
