### PR TITLE
22 add XI-IATI

### DIFF
--- a/xml/OrganisationRegistrationAgency.xml
+++ b/xml/OrganisationRegistrationAgency.xml
@@ -331,9 +331,9 @@
     <codelist-item public-database="1">
       <code>XI-IATI</code>
       <category>XI</category>
-      <name>International Aid Transparency Initiative</name>
-      <url></url>
-      <description></description>
+      <name>International Aid Transparency Initiative Organisation Identifier</name>
+      <url>http://iatistandard.org/codelists/IATIOrganisationIdentifier/</url>
+      <description>XI-IATI is a list of organisation identifiers that is maintained by the IATI Secretariat. Any publisher may apply to the IATI Technical Team for an identifier to be generated.</description>
     </codelist-item>
     <codelist-item public-database="1">
       <code>XM-DAC</code>


### PR DESCRIPTION
Adds XI-IATI as a registration agency. This should be ready to merge, but then there will need to:

Update the non-embedded changelog text: https://github.com/IATI/IATI-Guidance/blob/master/en/upgrades/nonembedded-codelist-changelog.rst
Update the tests (tests is currently on it's own branch)

AND it's still unclear as to when this merge should happen in relation to the release of 2.01 which is due on 16th Oct 2014
