### PR TITLE
Pull external codes automatically including withdrawn (historic) codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ before_install:
     - sudo apt-get update -qq
     - sudo apt-get install -qq libxml2-utils
 script:
-    - wget "https://raw.githubusercontent.com/IATI/IATI-Codelists/version-2.01/codelist.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Codelists/version-2.01/xml.xsd"; xmllint --schema codelist.xsd --noout xml/*
+    - wget "https://raw.githubusercontent.com/IATI/IATI-Codelists/historic-codes/codelist.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Codelists/historic-codes/xml.xsd"; xmllint --schema codelist.xsd --noout xml/*
 

--- a/convert.py
+++ b/convert.py
@@ -103,7 +103,6 @@ for country in countries.findall('country'):
 # Ensure that historic codes come after current codes
 for country in countries.findall('country'):
     if country.find('status').text in ['formerly-used', 'transitionally-reserved']:
-        add_code(country.find('alpha-2-code').text, country, country.find('validity-end-date').text)
         add_code(country.find('alpha-4-code').text, country, country.find('validity-end-date').text)
 
 indent(template.getroot(), 0, 4)

--- a/convert.py
+++ b/convert.py
@@ -97,3 +97,41 @@ for country in countries.findall('country'):
 indent(template.getroot(), 0, 4)
 template.write('xml/Country.xml', pretty_print=True)
 
+
+
+"""
+
+ISO Currency Alpha Code
+
+"""
+
+template = ET.parse('templates/Currency.xml', ET.XMLParser(remove_blank_text=True))
+codelist_items = template.find('codelist-items')
+
+currency_codes = {}
+country_currencies = ET.parse('source/table_a1.xml')
+for country_currency in country_currencies.find('CcyTbl').findall('CcyNtry'):
+    currency_name = country_currency.find('CcyNm').text
+    if currency_name == 'No universal currency':
+        continue
+    currency_code = country_currency.find('Ccy').text
+    if currency_code in currency_codes:
+        assert currency_codes[currency_code] == currency_name
+    else:
+        currency_codes[currency_code] = currency_name
+
+for currency_code, currency_name in sorted(currency_codes.items()):
+    codelist_item = ET.Element('codelist-item')
+
+    code = ET.Element('code')
+    code.text = currency_code
+    codelist_item.append(code)
+    
+    name = ET.Element('name')
+    name.text = currency_name
+    codelist_item.append(name)
+
+    codelist_items.append(codelist_item)
+
+template.write('xml/Currency.xml', pretty_print=True)
+

--- a/convert.py
+++ b/convert.py
@@ -128,10 +128,13 @@ for currency_code, currency_name in sorted(currency_codes.items()):
     codelist_item.append(code)
     
     name = ET.Element('name')
-    name.text = currency_name
     codelist_item.append(name)
+    narrative = ET.Element('narrative')
+    narrative.text = currency_name
+    name.append(narrative)
 
     codelist_items.append(codelist_item)
 
+indent(template.getroot(), 0, 4)
 template.write('xml/Currency.xml', pretty_print=True)
 

--- a/convert.py
+++ b/convert.py
@@ -27,5 +27,23 @@ for registry in media_types.findall('{http://www.iana.org/assignments}registry')
 
         codelist_items.append(codelist_item)
 
+# Adapted from code at http://effbot.org/zone/element-lib.htm
+def indent(elem, level=0, shift=2):
+    i = "\n" + level*" "*shift
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + " "*shift
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level+1, shift)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+
+indent(template.getroot(), 0, 4)
+
 template.write('xml/FileFormat.xml', pretty_print=True)
 

--- a/convert.py
+++ b/convert.py
@@ -8,6 +8,22 @@ Note not all external codelists are converted automatically yet.
 
 from lxml import etree as ET
 
+# Adapted from code at http://effbot.org/zone/element-lib.htm
+def indent(elem, level=0, shift=2):
+    i = "\n" + level*" "*shift
+    if len(elem):
+        if not elem.text or not elem.text.strip():
+            elem.text = i + " "*shift
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+        for elem in elem:
+            indent(elem, level+1, shift)
+        if not elem.tail or not elem.tail.strip():
+            elem.tail = i
+    else:
+        if level and (not elem.tail or not elem.tail.strip()):
+            elem.tail = i
+
 """
 
 IANA Media Types (FileFormat)
@@ -33,24 +49,7 @@ for registry in media_types.findall('{http://www.iana.org/assignments}registry')
 
         codelist_items.append(codelist_item)
 
-# Adapted from code at http://effbot.org/zone/element-lib.htm
-def indent(elem, level=0, shift=2):
-    i = "\n" + level*" "*shift
-    if len(elem):
-        if not elem.text or not elem.text.strip():
-            elem.text = i + " "*shift
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-        for elem in elem:
-            indent(elem, level+1, shift)
-        if not elem.tail or not elem.tail.strip():
-            elem.tail = i
-    else:
-        if level and (not elem.tail or not elem.tail.strip()):
-            elem.tail = i
-
 indent(template.getroot(), 0, 4)
-
 template.write('xml/FileFormat.xml', pretty_print=True)
 
 
@@ -75,21 +74,26 @@ for country in countries.findall('country'):
         code.text = country.find('alpha-2-code').text
         codelist_item.append(code)
         
+        name = ET.Element('name')
+        codelist_item.append(name)
         for short_name in country.findall('short-name'):
             if XML_LANG in short_name.attrib:
-                name = ET.Element('name')
-                name.attrib[XML_LANG] = short_name.attrib[XML_LANG]
-                name.text = short_name.text
-                codelist_item.append(name)
+                narrative = ET.Element('narrative')
+                narrative.attrib[XML_LANG] = short_name.attrib[XML_LANG]
+                narrative.text = short_name.text
+                name.append(narrative)
 
+        description = ET.Element('description')
+        codelist_item.append(description)
         for full_name in country.findall('full-name'):
             if XML_LANG in full_name.attrib:
-                description = ET.Element('description')
-                description.attrib[XML_LANG] = full_name.attrib[XML_LANG]
-                description.text = full_name.text
-                codelist_item.append(description)
+                narrative = ET.Element('narrative')
+                narrative.attrib[XML_LANG] = full_name.attrib[XML_LANG]
+                narrative.text = full_name.text
+                description.append(narrative)
 
         codelist_items.append(codelist_item)
 
+indent(template.getroot(), 0, 4)
 template.write('xml/Country.xml', pretty_print=True)
 

--- a/convert.py
+++ b/convert.py
@@ -102,7 +102,7 @@ for country in countries.findall('country'):
 
 # Ensure that historic codes come after current codes
 for country in countries.findall('country'):
-    if country.find('status').text == 'formerly-used':
+    if country.find('status').text in ['formerly-used', 'transitionally-reserved']:
         add_code(country.find('alpha-2-code').text, country, country.find('validity-end-date').text)
         add_code(country.find('alpha-4-code').text, country, country.find('validity-end-date').text)
 

--- a/convert.py
+++ b/convert.py
@@ -2,11 +2,17 @@
 
 Converts codelist files from external sources into the format used by IATI.
 
-Currently only supports the IANA Media Types code list (FileFormat).
+Note not all external codelists are converted automatically yet.
 
 """
 
 from lxml import etree as ET
+
+"""
+
+IANA Media Types (FileFormat)
+
+"""
 
 template = ET.parse('templates/FileFormat.xml', ET.XMLParser(remove_blank_text=True))
 codelist_items = template.find('codelist-items')
@@ -46,4 +52,44 @@ def indent(elem, level=0, shift=2):
 indent(template.getroot(), 0, 4)
 
 template.write('xml/FileFormat.xml', pretty_print=True)
+
+
+
+"""
+
+ISO Country Alpha 2
+
+"""
+
+XML_LANG = '{http://www.w3.org/XML/1998/namespace}lang'
+
+template = ET.parse('templates/Country.xml', ET.XMLParser(remove_blank_text=True))
+codelist_items = template.find('codelist-items')
+
+countries = ET.parse('source/iso_country_codes.xml')
+for country in countries.findall('country'):
+    if country.find('status').text == 'officially-assigned':
+        codelist_item = ET.Element('codelist-item')
+
+        code = ET.Element('code')
+        code.text = country.find('alpha-2-code').text
+        codelist_item.append(code)
+        
+        for short_name in country.findall('short-name'):
+            if XML_LANG in short_name.attrib:
+                name = ET.Element('name')
+                name.attrib[XML_LANG] = short_name.attrib[XML_LANG]
+                name.text = short_name.text
+                codelist_item.append(name)
+
+        for full_name in country.findall('full-name'):
+            if XML_LANG in full_name.attrib:
+                description = ET.Element('description')
+                description.attrib[XML_LANG] = full_name.attrib[XML_LANG]
+                description.text = full_name.text
+                codelist_item.append(description)
+
+        codelist_items.append(codelist_item)
+
+template.write('xml/Country.xml', pretty_print=True)
 

--- a/convert.py
+++ b/convert.py
@@ -40,7 +40,7 @@ for registry in media_types.findall('{http://www.iana.org/assignments}registry')
         codelist_item = ET.Element('codelist-item')
 
         code = ET.Element('code')
-        code.text = registry_id + '/' + record.find('{http://www.iana.org/assignments}name').text
+        code.text = registry_id + '/' + record.find('{http://www.iana.org/assignments}name').text.split(' ')[0]
         codelist_item.append(code)
 
         category = ET.Element('category')

--- a/get.sh
+++ b/get.sh
@@ -1,3 +1,4 @@
 mkdir source
 wget "https://www.iana.org/assignments/media-types/media-types.xml" -O source/media-types.xml
 wget "http://www.currency-iso.org/dam/downloads/table_a1.xml" -O source/table_a1.xml
+wget "http://www.currency-iso.org/dam/downloads/table_a3.xml" -O source/table_a3.xml

--- a/get.sh
+++ b/get.sh
@@ -1,1 +1,3 @@
+mkdir source
 wget "https://www.iana.org/assignments/media-types/media-types.xml" -O source/media-types.xml
+wget "http://www.currency-iso.org/dam/downloads/table_a1.xml" -O source/table_a1.xml

--- a/templates/Country.xml
+++ b/templates/Country.xml
@@ -1,0 +1,7 @@
+<codelist name="Country" xml:lang="en" complete="0">
+  <metadata>
+    <name>Country</name>
+    <url>http://www.iso.org/iso/home/standards/country_codes.htm</url>
+  </metadata>
+  <codelist-items/>
+</codelist>

--- a/templates/Country.xml
+++ b/templates/Country.xml
@@ -1,7 +1,9 @@
 <codelist name="Country" xml:lang="en" complete="0">
-  <metadata>
-    <name>Country</name>
-    <url>http://www.iso.org/iso/home/standards/country_codes.htm</url>
-  </metadata>
-  <codelist-items/>
+    <metadata>
+        <name>
+            <narrative>Country</narrative>
+        </name>
+        <url>http://www.iso.org/iso/home/standards/country_codes.htm</url>
+    </metadata>
+    <codelist-items/>
 </codelist>

--- a/templates/Country.xml
+++ b/templates/Country.xml
@@ -5,5 +5,12 @@
         </name>
         <url>http://www.iso.org/iso/home/standards/country_codes.htm</url>
     </metadata>
-    <codelist-items/>
+    <codelist-items>
+        <codelist-item>
+            <code>XK</code>
+            <name>
+                <narrative xml:lang="en">Kosovo</narrative>
+            </name>
+        </codelist-item>
+    </codelist-items>
 </codelist>

--- a/templates/Currency.xml
+++ b/templates/Currency.xml
@@ -1,0 +1,8 @@
+<codelist name="Currency"   xml:lang="en" complete="1">
+  <metadata>
+    <name>Currency</name>
+    <description>ISO 4217 Currency used for all transactions and budgets</description>
+    <url>http://www.iso.org/iso/home/standards/currency_codes.htm</url>
+  </metadata>
+  <codelist-items/>
+</codelist>

--- a/templates/Currency.xml
+++ b/templates/Currency.xml
@@ -1,7 +1,7 @@
 <codelist name="Currency"     xml:lang="en" complete="1">
     <metadata>
         <name>
-            <narrative>>Currency</narrative>
+            <narrative>Currency</narrative>
         </name>
         <description>
             <narrative>ISO 4217 Currency used for all transactions and budgets</narrative>

--- a/templates/Currency.xml
+++ b/templates/Currency.xml
@@ -1,8 +1,12 @@
-<codelist name="Currency"   xml:lang="en" complete="1">
-  <metadata>
-    <name>Currency</name>
-    <description>ISO 4217 Currency used for all transactions and budgets</description>
-    <url>http://www.iso.org/iso/home/standards/currency_codes.htm</url>
-  </metadata>
-  <codelist-items/>
+<codelist name="Currency"     xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>>Currency</narrative>
+        </name>
+        <description>
+            <narrative>ISO 4217 Currency used for all transactions and budgets</narrative>
+        </description>
+        <url>http://www.iso.org/iso/home/standards/currency_codes.htm</url>
+    </metadata>
+    <codelist-items/>
 </codelist>

--- a/templates/FileFormat.xml
+++ b/templates/FileFormat.xml
@@ -1,8 +1,12 @@
 <codelist name="FileFormat" xml:lang="en" complete="1">
-  <metadata>
-    <name>File Format</name>
-      <description>File format of published documents.</description>
-      <url>http://www.iana.org/assignments/media-types</url>
-  </metadata>
-  <codelist-items/>
+    <metadata>
+        <name>
+            <narrative>File Format</narrative>
+        </name>
+        <description>
+            <narrative>File format of published documents.</narrative>
+        </description>
+        <url>http://www.iana.org/assignments/media-types</url>
+    </metadata>
+    <codelist-items/>
 </codelist>

--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -3,1523 +3,2725 @@
         <name>
             <narrative>Country</narrative>
         </name>
-        <description>
-            <narrative>
-            The Country codelist is generated from the ISO 3166-1 part of the
-            ISO 3166 standard. The standard makes allowance, alongside the
-            officially assigned codes, for code elements to be expanded by
-            using either reserved codes or user-assigned codes. IATI currently
-            defines additional codes in the XA -XZ range.
-        </narrative>
-        </description>
         <url>http://www.iso.org/iso/home/standards/country_codes.htm</url>
     </metadata>
     <codelist-items>
         <codelist-item>
-            <code>AF</code>
-            <name>
-                <narrative>AFGHANISTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AX</code>
-            <name>
-                <narrative>ÅLAND ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AL</code>
-            <name>
-                <narrative>ALBANIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>DZ</code>
-            <name>
-                <narrative>ALGERIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AS</code>
-            <name>
-                <narrative>AMERICAN SAMOA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
             <code>AD</code>
             <name>
-                <narrative>ANDORRA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AO</code>
-            <name>
-                <narrative>ANGOLA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AI</code>
-            <name>
-                <narrative>ANGUILLA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AQ</code>
-            <name>
-                <narrative>ANTARCTICA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AG</code>
-            <name>
-                <narrative>ANTIGUA AND BARBUDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AR</code>
-            <name>
-                <narrative>ARGENTINA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AM</code>
-            <name>
-                <narrative>ARMENIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AW</code>
-            <name>
-                <narrative>ARUBA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AU</code>
-            <name>
-                <narrative>AUSTRALIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AT</code>
-            <name>
-                <narrative>AUSTRIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AZ</code>
-            <name>
-                <narrative>AZERBAIJAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BS</code>
-            <name>
-                <narrative>BAHAMAS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BH</code>
-            <name>
-                <narrative>BAHRAIN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BD</code>
-            <name>
-                <narrative>BANGLADESH</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BB</code>
-            <name>
-                <narrative>BARBADOS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BY</code>
-            <name>
-                <narrative>BELARUS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BE</code>
-            <name>
-                <narrative>BELGIUM</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BZ</code>
-            <name>
-                <narrative>BELIZE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BJ</code>
-            <name>
-                <narrative>BENIN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BM</code>
-            <name>
-                <narrative>BERMUDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BT</code>
-            <name>
-                <narrative>BHUTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BO</code>
-            <name>
-                <narrative>BOLIVIA, PLURINATIONAL STATE OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BQ</code>
-            <name>
-                <narrative>BONAIRE, SAINT EUSTATIUS AND SABA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BA</code>
-            <name>
-                <narrative>BOSNIA AND HERZEGOVINA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BW</code>
-            <name>
-                <narrative>BOTSWANA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BV</code>
-            <name>
-                <narrative>BOUVET ISLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BR</code>
-            <name>
-                <narrative>BRAZIL</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IO</code>
-            <name>
-                <narrative>BRITISH INDIAN OCEAN TERRITORY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BN</code>
-            <name>
-                <narrative>BRUNEI DARUSSALAM</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BG</code>
-            <name>
-                <narrative>BULGARIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BF</code>
-            <name>
-                <narrative>BURKINA FASO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BI</code>
-            <name>
-                <narrative>BURUNDI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KH</code>
-            <name>
-                <narrative>CAMBODIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CM</code>
-            <name>
-                <narrative>CAMEROON</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CA</code>
-            <name>
-                <narrative>CANADA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CV</code>
-            <name>
-                <narrative>CAPE VERDE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KY</code>
-            <name>
-                <narrative>CAYMAN ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CF</code>
-            <name>
-                <narrative>CENTRAL AFRICAN REPUBLIC</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TD</code>
-            <name>
-                <narrative>CHAD</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CL</code>
-            <name>
-                <narrative>CHILE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CN</code>
-            <name>
-                <narrative>CHINA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CX</code>
-            <name>
-                <narrative>CHRISTMAS ISLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CC</code>
-            <name>
-                <narrative>COCOS (KEELING) ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CO</code>
-            <name>
-                <narrative>COLOMBIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KM</code>
-            <name>
-                <narrative>COMOROS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CG</code>
-            <name>
-                <narrative>CONGO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CD</code>
-            <name>
-                <narrative>CONGO, THE DEMOCRATIC REPUBLIC OF THE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CK</code>
-            <name>
-                <narrative>COOK ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CR</code>
-            <name>
-                <narrative>COSTA RICA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CI</code>
-            <name>
-                <narrative>CÔTE D'IVOIRE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>HR</code>
-            <name>
-                <narrative>CROATIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CU</code>
-            <name>
-                <narrative>CUBA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CW</code>
-            <name>
-                <narrative>CURAÇAO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CY</code>
-            <name>
-                <narrative>CYPRUS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CZ</code>
-            <name>
-                <narrative>CZECH REPUBLIC</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>DK</code>
-            <name>
-                <narrative>DENMARK</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>DJ</code>
-            <name>
-                <narrative>DJIBOUTI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>DM</code>
-            <name>
-                <narrative>DOMINICA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>DO</code>
-            <name>
-                <narrative>DOMINICAN REPUBLIC</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>EC</code>
-            <name>
-                <narrative>ECUADOR</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>EG</code>
-            <name>
-                <narrative>EGYPT</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SV</code>
-            <name>
-                <narrative>EL SALVADOR</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GQ</code>
-            <name>
-                <narrative>EQUATORIAL GUINEA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ER</code>
-            <name>
-                <narrative>ERITREA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>EE</code>
-            <name>
-                <narrative>ESTONIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ET</code>
-            <name>
-                <narrative>ETHIOPIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>FK</code>
-            <name>
-                <narrative>FALKLAND ISLANDS (MALVINAS)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>FO</code>
-            <name>
-                <narrative>FAROE ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>FJ</code>
-            <name>
-                <narrative>FIJI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>FI</code>
-            <name>
-                <narrative>FINLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>FR</code>
-            <name>
-                <narrative>FRANCE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GF</code>
-            <name>
-                <narrative>FRENCH GUIANA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PF</code>
-            <name>
-                <narrative>FRENCH POLYNESIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TF</code>
-            <name>
-                <narrative>FRENCH SOUTHERN TERRITORIES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GA</code>
-            <name>
-                <narrative>GABON</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GM</code>
-            <name>
-                <narrative>GAMBIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GE</code>
-            <name>
-                <narrative>GEORGIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>DE</code>
-            <name>
-                <narrative>GERMANY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GH</code>
-            <name>
-                <narrative>GHANA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GI</code>
-            <name>
-                <narrative>GIBRALTAR</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GR</code>
-            <name>
-                <narrative>GREECE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GL</code>
-            <name>
-                <narrative>GREENLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GD</code>
-            <name>
-                <narrative>GRENADA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GP</code>
-            <name>
-                <narrative>GUADELOUPE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GU</code>
-            <name>
-                <narrative>GUAM</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GT</code>
-            <name>
-                <narrative>GUATEMALA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GG</code>
-            <name>
-                <narrative>GUERNSEY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GN</code>
-            <name>
-                <narrative>GUINEA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GW</code>
-            <name>
-                <narrative>GUINEA-BISSAU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GY</code>
-            <name>
-                <narrative>GUYANA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>HT</code>
-            <name>
-                <narrative>HAITI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>HM</code>
-            <name>
-                <narrative>HEARD ISLAND AND MCDONALD ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>VA</code>
-            <name>
-                <narrative>HOLY SEE (VATICAN CITY STATE)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>HN</code>
-            <name>
-                <narrative>HONDURAS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>HK</code>
-            <name>
-                <narrative>HONG KONG</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>HU</code>
-            <name>
-                <narrative>HUNGARY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IS</code>
-            <name>
-                <narrative>ICELAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IN</code>
-            <name>
-                <narrative>INDIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ID</code>
-            <name>
-                <narrative>INDONESIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IR</code>
-            <name>
-                <narrative>IRAN, ISLAMIC REPUBLIC OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IQ</code>
-            <name>
-                <narrative>IRAQ</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IE</code>
-            <name>
-                <narrative>IRELAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IM</code>
-            <name>
-                <narrative>ISLE OF MAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IL</code>
-            <name>
-                <narrative>ISRAEL</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>IT</code>
-            <name>
-                <narrative>ITALY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>JM</code>
-            <name>
-                <narrative>JAMAICA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>JP</code>
-            <name>
-                <narrative>JAPAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>JE</code>
-            <name>
-                <narrative>JERSEY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>JO</code>
-            <name>
-                <narrative>JORDAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KZ</code>
-            <name>
-                <narrative>KAZAKHSTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KE</code>
-            <name>
-                <narrative>KENYA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KI</code>
-            <name>
-                <narrative>KIRIBATI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KP</code>
-            <name>
-                <narrative>KOREA, DEMOCRATIC PEOPLE'S REPUBLIC OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KR</code>
-            <name>
-                <narrative>KOREA, REPUBLIC OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>XK</code>
-            <name>
-                <narrative>KOSOVO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KW</code>
-            <name>
-                <narrative>KUWAIT</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KG</code>
-            <name>
-                <narrative>KYRGYZSTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LA</code>
-            <name>
-                <narrative>LAO PEOPLE'S DEMOCRATIC REPUBLIC</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LV</code>
-            <name>
-                <narrative>LATVIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LB</code>
-            <name>
-                <narrative>LEBANON</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LS</code>
-            <name>
-                <narrative>LESOTHO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LR</code>
-            <name>
-                <narrative>LIBERIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LY</code>
-            <name>
-                <narrative>LIBYAN ARAB JAMAHIRIYA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LI</code>
-            <name>
-                <narrative>LIECHTENSTEIN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LT</code>
-            <name>
-                <narrative>LITHUANIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LU</code>
-            <name>
-                <narrative>LUXEMBOURG</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MO</code>
-            <name>
-                <narrative>MACAO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MK</code>
-            <name>
-                <narrative>MACEDONIA, THE FORMER YUGOSLAV REPUBLIC OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MG</code>
-            <name>
-                <narrative>MADAGASCAR</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MW</code>
-            <name>
-                <narrative>MALAWI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MY</code>
-            <name>
-                <narrative>MALAYSIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MV</code>
-            <name>
-                <narrative>MALDIVES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ML</code>
-            <name>
-                <narrative>MALI</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MT</code>
-            <name>
-                <narrative>MALTA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MH</code>
-            <name>
-                <narrative>MARSHALL ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MQ</code>
-            <name>
-                <narrative>MARTINIQUE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MR</code>
-            <name>
-                <narrative>MAURITANIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MU</code>
-            <name>
-                <narrative>MAURITIUS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>YT</code>
-            <name>
-                <narrative>MAYOTTE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MX</code>
-            <name>
-                <narrative>MEXICO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>FM</code>
-            <name>
-                <narrative>MICRONESIA, FEDERATED STATES OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MD</code>
-            <name>
-                <narrative>MOLDOVA, REPUBLIC OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MC</code>
-            <name>
-                <narrative>MONACO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MN</code>
-            <name>
-                <narrative>MONGOLIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ME</code>
-            <name>
-                <narrative>MONTENEGRO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MS</code>
-            <name>
-                <narrative>MONTSERRAT</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MA</code>
-            <name>
-                <narrative>MOROCCO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MZ</code>
-            <name>
-                <narrative>MOZAMBIQUE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MM</code>
-            <name>
-                <narrative>MYANMAR</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NA</code>
-            <name>
-                <narrative>NAMIBIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NR</code>
-            <name>
-                <narrative>NAURU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NP</code>
-            <name>
-                <narrative>NEPAL</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NL</code>
-            <name>
-                <narrative>NETHERLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>AN</code>
-            <name>
-                <narrative>NETHERLAND ANTILLES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NC</code>
-            <name>
-                <narrative>NEW CALEDONIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NZ</code>
-            <name>
-                <narrative>NEW ZEALAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NI</code>
-            <name>
-                <narrative>NICARAGUA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NE</code>
-            <name>
-                <narrative>NIGER</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NG</code>
-            <name>
-                <narrative>NIGERIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NU</code>
-            <name>
-                <narrative>NIUE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NF</code>
-            <name>
-                <narrative>NORFOLK ISLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MP</code>
-            <name>
-                <narrative>NORTHERN MARIANA ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>NO</code>
-            <name>
-                <narrative>NORWAY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>OM</code>
-            <name>
-                <narrative>OMAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PK</code>
-            <name>
-                <narrative>PAKISTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PW</code>
-            <name>
-                <narrative>PALAU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PS</code>
-            <name>
-                <narrative>PALESTINIAN TERRITORY, OCCUPIED</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PA</code>
-            <name>
-                <narrative>PANAMA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PG</code>
-            <name>
-                <narrative>PAPUA NEW GUINEA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PY</code>
-            <name>
-                <narrative>PARAGUAY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PE</code>
-            <name>
-                <narrative>PERU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PH</code>
-            <name>
-                <narrative>PHILIPPINES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PN</code>
-            <name>
-                <narrative>PITCAIRN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PL</code>
-            <name>
-                <narrative>POLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PT</code>
-            <name>
-                <narrative>PORTUGAL</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PR</code>
-            <name>
-                <narrative>PUERTO RICO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>QA</code>
-            <name>
-                <narrative>QATAR</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>RE</code>
-            <name>
-                <narrative>REUNION</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>RO</code>
-            <name>
-                <narrative>ROMANIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>RU</code>
-            <name>
-                <narrative>RUSSIAN FEDERATION</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>RW</code>
-            <name>
-                <narrative>RWANDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>BL</code>
-            <name>
-                <narrative>SAINT BARTHÉLEMY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SH</code>
-            <name>
-                <narrative>SAINT HELENA, ASCENSION AND TRISTAN DA CUNHA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>KN</code>
-            <name>
-                <narrative>SAINT KITTS AND NEVIS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LC</code>
-            <name>
-                <narrative>SAINT LUCIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>MF</code>
-            <name>
-                <narrative>SAINT MARTIN (FRENCH PART)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>PM</code>
-            <name>
-                <narrative>SAINT PIERRE AND MIQUELON</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>VC</code>
-            <name>
-                <narrative>SAINT VINCENT AND THE GRENADINES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>WS</code>
-            <name>
-                <narrative>SAMOA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SM</code>
-            <name>
-                <narrative>SAN MARINO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ST</code>
-            <name>
-                <narrative>SAO TOME AND PRINCIPE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SA</code>
-            <name>
-                <narrative>SAUDI ARABIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SN</code>
-            <name>
-                <narrative>SENEGAL</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>RS</code>
-            <name>
-                <narrative>SERBIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SC</code>
-            <name>
-                <narrative>SEYCHELLES</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SL</code>
-            <name>
-                <narrative>SIERRA LEONE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SG</code>
-            <name>
-                <narrative>SINGAPORE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SX</code>
-            <name>
-                <narrative>SINT MAARTEN (DUTCH PART)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SK</code>
-            <name>
-                <narrative>SLOVAKIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SI</code>
-            <name>
-                <narrative>SLOVENIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SB</code>
-            <name>
-                <narrative>SOLOMON ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SO</code>
-            <name>
-                <narrative>SOMALIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ZA</code>
-            <name>
-                <narrative>SOUTH AFRICA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>GS</code>
-            <name>
-                <narrative>SOUTH GEORGIA AND THE SOUTH SANDWICH ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SS</code>
-            <name>
-                <narrative>SOUTH SUDAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>ES</code>
-            <name>
-                <narrative>SPAIN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LK</code>
-            <name>
-                <narrative>SRI LANKA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SD</code>
-            <name>
-                <narrative>SUDAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SR</code>
-            <name>
-                <narrative>SURINAME</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SJ</code>
-            <name>
-                <narrative>SVALBARD AND JAN MAYEN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SZ</code>
-            <name>
-                <narrative>SWAZILAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SE</code>
-            <name>
-                <narrative>SWEDEN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>CH</code>
-            <name>
-                <narrative>SWITZERLAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>SY</code>
-            <name>
-                <narrative>SYRIAN ARAB REPUBLIC</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TW</code>
-            <name>
-                <narrative>TAIWAN, PROVINCE OF CHINA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TJ</code>
-            <name>
-                <narrative>TAJIKISTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TZ</code>
-            <name>
-                <narrative>TANZANIA, UNITED REPUBLIC OF</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TH</code>
-            <name>
-                <narrative>THAILAND</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TL</code>
-            <name>
-                <narrative>TIMOR-LESTE</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TG</code>
-            <name>
-                <narrative>TOGO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TK</code>
-            <name>
-                <narrative>TOKELAU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TO</code>
-            <name>
-                <narrative>TONGA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TT</code>
-            <name>
-                <narrative>TRINIDAD AND TOBAGO</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TN</code>
-            <name>
-                <narrative>TUNISIA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TR</code>
-            <name>
-                <narrative>TURKEY</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TM</code>
-            <name>
-                <narrative>TURKMENISTAN</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TC</code>
-            <name>
-                <narrative>TURKS AND CAICOS ISLANDS</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>TV</code>
-            <name>
-                <narrative>TUVALU</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>UG</code>
-            <name>
-                <narrative>UGANDA</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>UA</code>
-            <name>
-                <narrative>UKRAINE</narrative>
-            </name>
+                <narrative xml:lang="ca">Andorra</narrative>
+                <narrative xml:lang="fr">Andorre (l')</narrative>
+                <narrative xml:lang="en">Andorra</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la Principaut&#233; d'Andorre</narrative>
+                <narrative xml:lang="en">the Principality of Andorra</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
             <code>AE</code>
             <name>
-                <narrative>UNITED ARAB EMIRATES</narrative>
+                <narrative xml:lang="ar">Al Im&#257;r&#257;t</narrative>
+                <narrative xml:lang="fr">&#201;mirats arabes unis (les)</narrative>
+                <narrative xml:lang="en">United Arab Emirates (the)</narrative>
             </name>
+            <description>
+                <narrative xml:lang="fr">les &#201;mirats arabes unis</narrative>
+                <narrative xml:lang="en">the United Arab Emirates</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>GB</code>
+            <code>AF</code>
             <name>
-                <narrative>UNITED KINGDOM</narrative>
+                <narrative xml:lang="fa">Afgh&#257;nest&#257;n</narrative>
+                <narrative xml:lang="ps">Afgh&#257;nist&#257;n</narrative>
+                <narrative xml:lang="fr">Afghanistan (l')</narrative>
+                <narrative xml:lang="en">Afghanistan</narrative>
             </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique islamique d'Afghanistan</narrative>
+                <narrative xml:lang="en">the Islamic Republic of Afghanistan</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>US</code>
+            <code>AG</code>
             <name>
-                <narrative>UNITED STATES</narrative>
+                <narrative xml:lang="en">Antigua and Barbuda</narrative>
+                <narrative xml:lang="fr">Antigua-et-Barbuda</narrative>
             </name>
+            <description/>
         </codelist-item>
         <codelist-item>
-            <code>UM</code>
+            <code>AI</code>
             <name>
-                <narrative>UNITED STATES MINOR OUTLYING ISLANDS</narrative>
+                <narrative xml:lang="en">Anguilla</narrative>
+                <narrative xml:lang="fr">Anguilla</narrative>
             </name>
+            <description/>
         </codelist-item>
         <codelist-item>
-            <code>UY</code>
+            <code>AL</code>
             <name>
-                <narrative>URUGUAY</narrative>
+                <narrative xml:lang="sq">Shqip&#235;ria, Shqip&#235;ri</narrative>
+                <narrative xml:lang="fr">Albanie (l')</narrative>
+                <narrative xml:lang="en">Albania</narrative>
             </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique d'Albanie</narrative>
+                <narrative xml:lang="en">the Republic of Albania</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>UZ</code>
+            <code>AM</code>
             <name>
-                <narrative>UZBEKISTAN</narrative>
+                <narrative xml:lang="hy">Hayastan</narrative>
+                <narrative xml:lang="en">Armenia</narrative>
+                <narrative xml:lang="fr">Arm&#233;nie (l')</narrative>
             </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Armenia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Arm&#233;nie</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>VU</code>
+            <code>AO</code>
             <name>
-                <narrative>VANUATU</narrative>
+                <narrative xml:lang="pt">Angola</narrative>
+                <narrative xml:lang="en">Angola</narrative>
+                <narrative xml:lang="fr">Angola (l')</narrative>
             </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Angola</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Angola</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>VE</code>
+            <code>AQ</code>
             <name>
-                <narrative>VENEZUELA, BOLIVARIAN REPUBLIC OF</narrative>
+                <narrative xml:lang="en">Antarctica</narrative>
+                <narrative xml:lang="fr">Antarctique (l')</narrative>
             </name>
+            <description/>
         </codelist-item>
         <codelist-item>
-            <code>VN</code>
+            <code>AR</code>
             <name>
-                <narrative>VIET NAM</narrative>
+                <narrative xml:lang="es">Argentina (la)</narrative>
+                <narrative xml:lang="en">Argentina</narrative>
+                <narrative xml:lang="fr">Argentine (l')</narrative>
             </name>
+            <description>
+                <narrative xml:lang="en">the Argentine Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique argentine</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>VG</code>
+            <code>AS</code>
             <name>
-                <narrative>VIRGIN ISLANDS, BRITISH</narrative>
+                <narrative xml:lang="en">American Samoa</narrative>
+                <narrative xml:lang="fr">Samoa am&#233;ricaines (les)</narrative>
             </name>
+            <description/>
         </codelist-item>
         <codelist-item>
-            <code>VI</code>
+            <code>AT</code>
             <name>
-                <narrative>VIRGIN ISLANDS, U.S.</narrative>
+                <narrative xml:lang="de">&#214;sterreich</narrative>
+                <narrative xml:lang="en">Austria</narrative>
+                <narrative xml:lang="fr">Autriche (l')</narrative>
             </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Austria</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Autriche</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
-            <code>WF</code>
+            <code>AU</code>
             <name>
-                <narrative>WALLIS AND FUTUNA</narrative>
+                <narrative xml:lang="en">Australia</narrative>
+                <narrative xml:lang="fr">Australie (l')</narrative>
             </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>AW</code>
+            <name>
+                <narrative xml:lang="nl">Aruba</narrative>
+                <narrative xml:lang="en">Aruba</narrative>
+                <narrative xml:lang="fr">Aruba</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>AX</code>
+            <name>
+                <narrative xml:lang="sv">&#197;land</narrative>
+                <narrative xml:lang="en">&#197;land Islands</narrative>
+                <narrative xml:lang="fr">&#197;land(les &#206;les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>AZ</code>
+            <name>
+                <narrative xml:lang="az">Az&#601;rbaycan</narrative>
+                <narrative xml:lang="en">Azerbaijan</narrative>
+                <narrative xml:lang="fr">Azerba&#239;djan (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Azerbaijan</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Azerba&#239;djan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BA</code>
+            <name>
+                <narrative xml:lang="bs">Bosna i Hercegovina</narrative>
+                <narrative xml:lang="hr">Bosna i Hercegovina</narrative>
+                <narrative xml:lang="sr">Bosna i Hercegovina</narrative>
+                <narrative xml:lang="en">Bosnia and Herzegovina</narrative>
+                <narrative xml:lang="fr">Bosnie-Herz&#233;govine (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BB</code>
+            <name>
+                <narrative xml:lang="en">Barbados</narrative>
+                <narrative xml:lang="fr">Barbade (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BD</code>
+            <name>
+                <narrative xml:lang="en">Bangladesh</narrative>
+                <narrative xml:lang="bn">B&#257;&#7745;l&#257;desh</narrative>
+                <narrative xml:lang="fr">Bangladesh (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the People's Republic of Bangladesh</narrative>
+                <narrative xml:lang="fr">la R&#233;publique populaire du Bangladesh</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BE</code>
+            <name>
+                <narrative xml:lang="en">Belgium</narrative>
+                <narrative xml:lang="de">Belgien</narrative>
+                <narrative xml:lang="fr">Belgique (la)</narrative>
+                <narrative xml:lang="nl">Belgi&#235;</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Belgium</narrative>
+                <narrative xml:lang="fr">le Royaume de Belgique</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BF</code>
+            <name>
+                <narrative xml:lang="fr">Burkina (le)</narrative>
+                <narrative xml:lang="en">Burkina Faso</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Burkina Faso</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BG</code>
+            <name>
+                <narrative xml:lang="en">Bulgaria</narrative>
+                <narrative xml:lang="bg">Bulgaria</narrative>
+                <narrative xml:lang="fr">Bulgarie (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Bulgaria</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Bulgarie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BH</code>
+            <name>
+                <narrative xml:lang="en">Bahrain</narrative>
+                <narrative xml:lang="ar">Al Ba&#7721;rayn</narrative>
+                <narrative xml:lang="fr">Bahre&#239;n</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Bahrain</narrative>
+                <narrative xml:lang="fr">le Royaume de Bahre&#239;n</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BI</code>
+            <name>
+                <narrative xml:lang="en">Burundi</narrative>
+                <narrative xml:lang="fr">Burundi (le)</narrative>
+                <narrative xml:lang="rn">Burundi</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Burundi</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Burundi</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BJ</code>
+            <name>
+                <narrative xml:lang="en">Benin</narrative>
+                <narrative xml:lang="fr">B&#233;nin (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Benin</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du B&#233;nin</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BL</code>
+            <name>
+                <narrative xml:lang="en">Saint Barth&#233;lemy</narrative>
+                <narrative xml:lang="fr">Saint-Barth&#233;lemy</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BM</code>
+            <name>
+                <narrative xml:lang="en">Bermuda</narrative>
+                <narrative xml:lang="fr">Bermudes (les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BN</code>
+            <name>
+                <narrative xml:lang="en">Brunei Darussalam</narrative>
+                <narrative xml:lang="ms">Negara Brunei Darussalam</narrative>
+                <narrative xml:lang="fr">Brunei (le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BO</code>
+            <name>
+                <narrative xml:lang="en">Bolivia, Plurinational State of</narrative>
+                <narrative xml:lang="es">Bolivia,  Estado Plurinacional de</narrative>
+                <narrative xml:lang="fr">Bolivie, l'&#201;tat plurinational de la</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Plurinational State of Bolivia</narrative>
+                <narrative xml:lang="fr">l'&#201;tat plurinational de Bolivie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BQ</code>
+            <name>
+                <narrative xml:lang="nl">Bonaire, Sint Eustatius en Saba</narrative>
+                <narrative xml:lang="en">Bonaire, Sint Eustatius and Saba</narrative>
+                <narrative xml:lang="fr">Bonaire, Saint-Eustache et Saba</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BR</code>
+            <name>
+                <narrative xml:lang="en">Brazil</narrative>
+                <narrative xml:lang="pt">Brasil (o)</narrative>
+                <narrative xml:lang="fr">Br&#233;sil (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Federative Republic of Brazil</narrative>
+                <narrative xml:lang="fr">la R&#233;publique f&#233;d&#233;rative du Br&#233;sil</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BS</code>
+            <name>
+                <narrative xml:lang="en">Bahamas (the)</narrative>
+                <narrative xml:lang="fr">Bahamas (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Commonwealth of the Bahamas</narrative>
+                <narrative xml:lang="fr">le Commonwealth des Bahamas</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BT</code>
+            <name>
+                <narrative xml:lang="en">Bhutan</narrative>
+                <narrative xml:lang="dz">Druk-Yul</narrative>
+                <narrative xml:lang="fr">Bhoutan (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Bhutan</narrative>
+                <narrative xml:lang="fr">le Royaume du Bhoutan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BV</code>
+            <name>
+                <narrative xml:lang="en">Bouvet Island</narrative>
+                <narrative xml:lang="fr">Bouvet (l'&#206;le)</narrative>
+                <narrative xml:lang="nb">Bouvet&#248;ya</narrative>
+                <narrative xml:lang="nn">Bouvet&#248;ya</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>BW</code>
+            <name>
+                <narrative xml:lang="en">Botswana</narrative>
+                <narrative xml:lang="fr">Botswana (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Botswana</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Botswana</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BY</code>
+            <name>
+                <narrative xml:lang="en">Belarus</narrative>
+                <narrative xml:lang="be">Bielaru&#347;</narrative>
+                <narrative xml:lang="ru">Belarus'</narrative>
+                <narrative xml:lang="fr">B&#233;larus (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Belarus</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du B&#233;larus</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>BZ</code>
+            <name>
+                <narrative xml:lang="en">Belize</narrative>
+                <narrative xml:lang="fr">Belize (le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>CA</code>
+            <name>
+                <narrative xml:lang="en">Canada</narrative>
+                <narrative xml:lang="fr">Canada (le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>CC</code>
+            <name>
+                <narrative xml:lang="en">Cocos (Keeling) Islands (the)</narrative>
+                <narrative xml:lang="fr">Cocos (les&#160;&#206;les)/ Keeling (les&#160;&#206;les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>CD</code>
+            <name>
+                <narrative xml:lang="en">Congo (the Democratic Republic of the)</narrative>
+                <narrative xml:lang="fr">Congo (la R&#233;publique d&#233;mocratique du)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Democratic Republic of the Congo</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d&#233;mocratique du Congo</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CF</code>
+            <name>
+                <narrative xml:lang="en">Central African Republic (the)</narrative>
+                <narrative xml:lang="fr">R&#233;publique centrafricaine (la)</narrative>
+                <narrative xml:lang="sg">K&#246;d&#246;r&#246;s&#234;se t&#238; B&#234;afr&#238;ka</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Central African Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique centrafricaine</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CG</code>
+            <name>
+                <narrative xml:lang="en">Congo</narrative>
+                <narrative xml:lang="fr">Congo (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of the Congo</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Congo</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CH</code>
+            <name>
+                <narrative xml:lang="en">Switzerland</narrative>
+                <narrative xml:lang="de">Schweiz (die)</narrative>
+                <narrative xml:lang="fr">Suisse (la)</narrative>
+                <narrative xml:lang="it">Svizzera (la)</narrative>
+                <narrative xml:lang="rm">Svizra (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Swiss Confederation</narrative>
+                <narrative xml:lang="fr">la Conf&#233;d&#233;ration suisse</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CI</code>
+            <name>
+                <narrative xml:lang="en">C&#244;te d'Ivoire</narrative>
+                <narrative xml:lang="fr">C&#244;te d'Ivoire (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of C&#244;te d'Ivoire</narrative>
+                <narrative xml:lang="fr">la Republic de C&#244;te d'Ivoire</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CK</code>
+            <name>
+                <narrative xml:lang="en">Cook Islands (the)</narrative>
+                <narrative xml:lang="fr">Cook (les &#206;les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>CL</code>
+            <name>
+                <narrative xml:lang="en">Chile</narrative>
+                <narrative xml:lang="fr">Chili (le)</narrative>
+                <narrative xml:lang="es">Chile</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Chile</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Chili</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CM</code>
+            <name>
+                <narrative xml:lang="en">Cameroon</narrative>
+                <narrative xml:lang="fr">Cameroun (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Cameroon</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Cameroun</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CN</code>
+            <name>
+                <narrative xml:lang="en">China</narrative>
+                <narrative xml:lang="fr">Chine (la)</narrative>
+                <narrative xml:lang="zh">Zhongguo</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the People's Republic of China</narrative>
+                <narrative xml:lang="fr">la R&#233;publique populaire de Chine</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CO</code>
+            <name>
+                <narrative xml:lang="en">Colombia</narrative>
+                <narrative xml:lang="fr">Colombie (la)</narrative>
+                <narrative xml:lang="es">Colombia</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Colombia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Colombie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CR</code>
+            <name>
+                <narrative xml:lang="en">Costa Rica</narrative>
+                <narrative xml:lang="es">Costa Rica</narrative>
+                <narrative xml:lang="fr">Costa Rica (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Costa Rica</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Costa Rica</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CU</code>
+            <name>
+                <narrative xml:lang="en">Cuba</narrative>
+                <narrative xml:lang="es">Cuba</narrative>
+                <narrative xml:lang="fr">Cuba</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Cuba</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Cuba</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CV</code>
+            <name>
+                <narrative xml:lang="en">Cabo Verde</narrative>
+                <narrative xml:lang="fr">Cabo Verde</narrative>
+                <narrative xml:lang="pt">Cabo Verde</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Cabo Verde</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Cabo Verde</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CW</code>
+            <name>
+                <narrative xml:lang="nl">Cura&#231;ao</narrative>
+                <narrative xml:lang="fr">Cura&#231;ao</narrative>
+                <narrative xml:lang="en">Cura&#231;ao</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>CX</code>
+            <name>
+                <narrative xml:lang="fr">Christmas (l'&#206;le)</narrative>
+                <narrative xml:lang="en">Christmas Island</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>CY</code>
+            <name>
+                <narrative xml:lang="en">Cyprus</narrative>
+                <narrative xml:lang="el">K&#253;pros</narrative>
+                <narrative xml:lang="tr">K&#305;br&#305;s</narrative>
+                <narrative xml:lang="fr">Chypre</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Cyprus</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Chypre</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>CZ</code>
+            <name>
+                <narrative xml:lang="fr">tch&#232;que (la&#160;R&#233;publique)</narrative>
+                <narrative xml:lang="cs">&#268;esko</narrative>
+                <narrative xml:lang="en">Czech Republic (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique tch&#232;que</narrative>
+                <narrative xml:lang="en">the Czech Republic</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>DE</code>
+            <name>
+                <narrative xml:lang="en">Germany</narrative>
+                <narrative xml:lang="de">Deutschland</narrative>
+                <narrative xml:lang="fr">Allemagne (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Federal Republic of Germany</narrative>
+                <narrative xml:lang="fr">la R&#233;publique f&#233;d&#233;rale d'Allemagne</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>DJ</code>
+            <name>
+                <narrative xml:lang="ar">J&#299;b&#363;t&#299;</narrative>
+                <narrative xml:lang="en">Djibouti</narrative>
+                <narrative xml:lang="fr">Djibouti</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Djibouti</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Djibouti</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>DK</code>
+            <name>
+                <narrative xml:lang="en">Denmark</narrative>
+                <narrative xml:lang="da">Danmark</narrative>
+                <narrative xml:lang="fr">Danemark (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Denmark</narrative>
+                <narrative xml:lang="fr">le Royaume du Danemark</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>DM</code>
+            <name>
+                <narrative xml:lang="en">Dominica</narrative>
+                <narrative xml:lang="fr">Dominique (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Commonwealth of Dominica</narrative>
+                <narrative xml:lang="fr">le Commonwealth de Dominique</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>DO</code>
+            <name>
+                <narrative xml:lang="en">Dominican Republic (the)</narrative>
+                <narrative xml:lang="es">Rep&#250;blica Dominicana (la)</narrative>
+                <narrative xml:lang="fr">dominicaine (la&#160;R&#233;publique)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Dominican Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique dominicaine</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>DZ</code>
+            <name>
+                <narrative xml:lang="en">Algeria</narrative>
+                <narrative xml:lang="fr">Alg&#233;rie (l')</narrative>
+                <narrative xml:lang="ar">Al Jaz&#257;'ir</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the People's Democratic Republic of Algeria</narrative>
+                <narrative xml:lang="fr">la R&#233;publique alg&#233;rienne d&#233;mocratique et populaire</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>EC</code>
+            <name>
+                <narrative xml:lang="en">Ecuador</narrative>
+                <narrative xml:lang="es">Ecuador (el)</narrative>
+                <narrative xml:lang="fr">&#201;quateur (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Ecuador</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'&#201;quateur</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>EE</code>
+            <name>
+                <narrative xml:lang="en">Estonia</narrative>
+                <narrative xml:lang="et">Eesti</narrative>
+                <narrative xml:lang="fr">Estonie (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Estonia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Estonie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>EG</code>
+            <name>
+                <narrative xml:lang="en">Egypt</narrative>
+                <narrative xml:lang="ar">Mi&#351;r</narrative>
+                <narrative xml:lang="fr">&#201;gypte (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Arab Republic of Egypt</narrative>
+                <narrative xml:lang="fr">la R&#233;publique arabe d'&#201;gypte</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
             <code>EH</code>
             <name>
-                <narrative>WESTERN SAHARA</narrative>
+                <narrative xml:lang="en">Western Sahara*</narrative>
+                <narrative xml:lang="fr">Sahara occidental (le)*</narrative>
+                <narrative xml:lang="ar">A&#351; &#350;a&#7721;r&#257;' al Gharb&#299;yah</narrative>
             </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>ER</code>
+            <name>
+                <narrative xml:lang="en">Eritrea</narrative>
+                <narrative xml:lang="ti">Iertra</narrative>
+                <narrative xml:lang="ar">Ir&#299;tr&#299;y&#257;</narrative>
+                <narrative xml:lang="fr">&#201;rythr&#233;e (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the State of Eritrea</narrative>
+                <narrative xml:lang="fr">l'&#201;tat d'&#201;rythr&#233;e</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>ES</code>
+            <name>
+                <narrative xml:lang="en">Spain</narrative>
+                <narrative xml:lang="fr">Espagne (l')</narrative>
+                <narrative xml:lang="es">Espa&#241;a</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Spain</narrative>
+                <narrative xml:lang="fr">le Royaume d'Espagne</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>ET</code>
+            <name>
+                <narrative xml:lang="en">Ethiopia</narrative>
+                <narrative xml:lang="am">&#298;tyop'iya</narrative>
+                <narrative xml:lang="fr">&#201;thiopie (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Federal Democratic Republic of Ethiopia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique f&#233;d&#233;rale d&#233;mocratique d'&#201;thiopie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>FI</code>
+            <name>
+                <narrative xml:lang="en">Finland</narrative>
+                <narrative xml:lang="fi">Suomi</narrative>
+                <narrative xml:lang="fr">Finlande (la)</narrative>
+                <narrative xml:lang="sv">Finland</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Finland</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Finlande</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>FJ</code>
+            <name>
+                <narrative xml:lang="en">Fiji</narrative>
+                <narrative xml:lang="fj">Viti</narrative>
+                <narrative xml:lang="fr">Fidji (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Fiji</narrative>
+                <narrative xml:lang="fr">la R&#233;publique des Fidji</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>FK</code>
+            <name>
+                <narrative xml:lang="en">Falkland Islands (the) [Malvinas]</narrative>
+                <narrative xml:lang="fr">Falkland (les &#206;les)/Malouines (les &#206;les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>FM</code>
+            <name>
+                <narrative xml:lang="fr">Micron&#233;sie, &#201;tats f&#233;d&#233;r&#233;s de</narrative>
+                <narrative xml:lang="en">Micronesia (the Federated States of)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">les &#201;tats f&#233;d&#233;r&#233;s de Micron&#233;sie</narrative>
+                <narrative xml:lang="en">the Federated States of Micronesia</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>FO</code>
+            <name>
+                <narrative xml:lang="en">Faroe Islands (the)</narrative>
+                <narrative xml:lang="da">F&#230;r&#248;erne</narrative>
+                <narrative xml:lang="fo">F&#248;royar</narrative>
+                <narrative xml:lang="fr">F&#233;ro&#233; (les &#206;les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>FR</code>
+            <name>
+                <narrative xml:lang="fr">France (la)</narrative>
+                <narrative xml:lang="en">France</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique fran&#231;aise</narrative>
+                <narrative xml:lang="en">the French Republic</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GA</code>
+            <name>
+                <narrative xml:lang="en">Gabon</narrative>
+                <narrative xml:lang="fr">Gabon (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Gabonese Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique gabonaise</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GB</code>
+            <name>
+                <narrative xml:lang="fr">Royaume-Uni (le)</narrative>
+                <narrative xml:lang="en">United Kingdom (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Royaume-Uni de Grande-Bretagne et d'Irlande du Nord</narrative>
+                <narrative xml:lang="en">the United Kingdom of Great Britain and Northern Ireland</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GD</code>
+            <name>
+                <narrative xml:lang="en">Grenada</narrative>
+                <narrative xml:lang="fr">Grenade (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GE</code>
+            <name>
+                <narrative xml:lang="ka">Sakartvelo</narrative>
+                <narrative xml:lang="en">Georgia</narrative>
+                <narrative xml:lang="fr">G&#233;orgie (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GF</code>
+            <name>
+                <narrative xml:lang="fr">Guyane fran&#231;aise (la&#160;)</narrative>
+                <narrative xml:lang="en">French Guiana</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GG</code>
+            <name>
+                <narrative xml:lang="en">Guernsey</narrative>
+                <narrative xml:lang="fr">Guernesey</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GH</code>
+            <name>
+                <narrative xml:lang="en">Ghana</narrative>
+                <narrative xml:lang="fr">Ghana (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Ghana</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Ghana</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GI</code>
+            <name>
+                <narrative xml:lang="en">Gibraltar</narrative>
+                <narrative xml:lang="fr">Gibraltar</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GL</code>
+            <name>
+                <narrative xml:lang="en">Greenland</narrative>
+                <narrative xml:lang="da">Gr&#248;nland</narrative>
+                <narrative xml:lang="kl">Kalaallit Nunaat</narrative>
+                <narrative xml:lang="fr">Groenland (le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GM</code>
+            <name>
+                <narrative xml:lang="en">Gambia (The)</narrative>
+                <narrative xml:lang="fr">Gambie (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of The Gambia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Gambie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GN</code>
+            <name>
+                <narrative xml:lang="en">Guinea</narrative>
+                <narrative xml:lang="fr">Guin&#233;e (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Guinea</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Guin&#233;e</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GP</code>
+            <name>
+                <narrative xml:lang="fr">Guadeloupe (la)</narrative>
+                <narrative xml:lang="en">Guadeloupe</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GQ</code>
+            <name>
+                <narrative xml:lang="en">Equatorial Guinea</narrative>
+                <narrative xml:lang="es">Guinea Ecuatorial</narrative>
+                <narrative xml:lang="fr">Guin&#233;e &#233;quatoriale (la)</narrative>
+                <narrative xml:lang="pt">Guin&#233; Equatorial (a)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Equatorial Guinea</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Guin&#233;e &#233;quatoriale</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GR</code>
+            <name>
+                <narrative xml:lang="en">Greece</narrative>
+                <narrative xml:lang="el">Ell&#225;s/Ell&#225;da</narrative>
+                <narrative xml:lang="fr">Gr&#232;ce (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Hellenic Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique hell&#233;nique</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GS</code>
+            <name>
+                <narrative xml:lang="fr">G&#233;orgie du Sud-et-les &#206;les Sandwich du Sud (la)</narrative>
+                <narrative xml:lang="en">South Georgia and the South Sandwich Islands</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GT</code>
+            <name>
+                <narrative xml:lang="en">Guatemala</narrative>
+                <narrative xml:lang="es">Guatemala</narrative>
+                <narrative xml:lang="fr">Guatemala (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Guatemala</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Guatemala</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GU</code>
+            <name>
+                <narrative xml:lang="en">Guam</narrative>
+                <narrative xml:lang="fr">Guam</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>GW</code>
+            <name>
+                <narrative xml:lang="en">Guinea-Bissau</narrative>
+                <narrative xml:lang="pt">Guin&#233;-Bissau (a)</narrative>
+                <narrative xml:lang="fr">Guin&#233;e-Bissau (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Guinea-Bissau</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Guin&#233;e-Bissau</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>GY</code>
+            <name>
+                <narrative xml:lang="en">Guyana</narrative>
+                <narrative xml:lang="fr">Guyana (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Guyana</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Guyana</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>HK</code>
+            <name>
+                <narrative xml:lang="en">Hong Kong</narrative>
+                <narrative xml:lang="zh">Xianggang</narrative>
+                <narrative xml:lang="fr">Hong Kong</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Hong Kong Special Administrative Region of China</narrative>
+                <narrative xml:lang="fr">Hong Kong, R&#233;gion administrative sp&#233;ciale de Chine (la)</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>HM</code>
+            <name>
+                <narrative xml:lang="en">Heard Island and McDonald Islands</narrative>
+                <narrative xml:lang="fr">Heard-et-&#206;les MacDonald (l'&#206;le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">ll'&#206;le Heard-et-&#206;les MacDonald</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>HN</code>
+            <name>
+                <narrative xml:lang="en">Honduras</narrative>
+                <narrative xml:lang="es">Honduras</narrative>
+                <narrative xml:lang="fr">Honduras (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Honduras</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Honduras</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>HR</code>
+            <name>
+                <narrative xml:lang="en">Croatia</narrative>
+                <narrative xml:lang="fr">Croatie (la)</narrative>
+                <narrative xml:lang="hr">Hrvatska</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Croatia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Croatie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>HT</code>
+            <name>
+                <narrative xml:lang="en">Haiti</narrative>
+                <narrative xml:lang="fr">Ha&#239;ti</narrative>
+                <narrative xml:lang="ht">Ayiti</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Haiti</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Ha&#239;ti</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>HU</code>
+            <name>
+                <narrative xml:lang="en">Hungary</narrative>
+                <narrative xml:lang="hu">Magyarorsz&#225;g</narrative>
+                <narrative xml:lang="fr">Hongrie (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>ID</code>
+            <name>
+                <narrative xml:lang="en">Indonesia</narrative>
+                <narrative xml:lang="id">Indonesia</narrative>
+                <narrative xml:lang="fr">Indon&#233;sie (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Indonesia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Indon&#233;sie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IE</code>
+            <name>
+                <narrative xml:lang="en">Ireland</narrative>
+                <narrative xml:lang="ga">&#201;ire</narrative>
+                <narrative xml:lang="fr">Irlande (l')</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>IL</code>
+            <name>
+                <narrative xml:lang="en">Israel</narrative>
+                <narrative xml:lang="ar">Isr&#257;'&#299;l</narrative>
+                <narrative xml:lang="he">Yisra'el</narrative>
+                <narrative xml:lang="fr">Isra&#235;l</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the State of Israel</narrative>
+                <narrative xml:lang="fr">l'&#201;tat d'Isra&#235;l</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IM</code>
+            <name>
+                <narrative xml:lang="en">Isle of Man</narrative>
+                <narrative xml:lang="fr">&#206;le de Man</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>IN</code>
+            <name>
+                <narrative xml:lang="hi">Bh&#257;rat</narrative>
+                <narrative xml:lang="fr">Inde (l')</narrative>
+                <narrative xml:lang="en">India</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de l'Inde</narrative>
+                <narrative xml:lang="en">the Republic of India</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IO</code>
+            <name>
+                <narrative xml:lang="fr">Indien (le&#160;Territoire britannique de l'oc&#233;an)</narrative>
+                <narrative xml:lang="en">British Indian Ocean Territory (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Territoire britannique de l'oc&#233;an Indien</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IQ</code>
+            <name>
+                <narrative xml:lang="en">Iraq</narrative>
+                <narrative xml:lang="ar">Al &#8216;Ir&#257;q</narrative>
+                <narrative xml:lang="fr">Iraq (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Iraq</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Iraq</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IR</code>
+            <name>
+                <narrative xml:lang="en">Iran (the Islamic Republic of)</narrative>
+                <narrative xml:lang="fa">Jomh&#363;r&#299;-ye Esl&#257;m&#299;-ye &#298;r&#257;n</narrative>
+                <narrative xml:lang="fr">Iran (R&#233;publique Islamique d')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Islamic Republic of Iran</narrative>
+                <narrative xml:lang="fr">la R&#233;publique islamique d'Iran</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IS</code>
+            <name>
+                <narrative xml:lang="en">Iceland</narrative>
+                <narrative xml:lang="is">&#205;sland</narrative>
+                <narrative xml:lang="fr">Islande (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Iceland</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Islande</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>IT</code>
+            <name>
+                <narrative xml:lang="en">Italy</narrative>
+                <narrative xml:lang="it">Italia (l')</narrative>
+                <narrative xml:lang="fr">Italie (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Italy</narrative>
+                <narrative xml:lang="fr">la R&#233;publique italienne</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>JE</code>
+            <name>
+                <narrative xml:lang="en">Jersey</narrative>
+                <narrative xml:lang="fr">Jersey</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>JM</code>
+            <name>
+                <narrative xml:lang="en">Jamaica</narrative>
+                <narrative xml:lang="fr">Jama&#239;que (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>JO</code>
+            <name>
+                <narrative xml:lang="en">Jordan</narrative>
+                <narrative xml:lang="ar">Al Urdun</narrative>
+                <narrative xml:lang="fr">Jordanie (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Hashemite Kingdom of Jordan</narrative>
+                <narrative xml:lang="fr">le Royaume hach&#233;mite de Jordanie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>JP</code>
+            <name>
+                <narrative xml:lang="en">Japan</narrative>
+                <narrative xml:lang="ja">Nihon/Nippon</narrative>
+                <narrative xml:lang="fr">Japon (le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>KE</code>
+            <name>
+                <narrative xml:lang="en">Kenya</narrative>
+                <narrative xml:lang="sw">Kenya</narrative>
+                <narrative xml:lang="fr">Kenya (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Kenya</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Kenya</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KG</code>
+            <name>
+                <narrative xml:lang="en">Kyrgyzstan</narrative>
+                <narrative xml:lang="ky">Kyrgyzstan</narrative>
+                <narrative xml:lang="ru">Kyrgyzstan</narrative>
+                <narrative xml:lang="fr">Kirghizistan (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kyrgyz Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique kirghize</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KH</code>
+            <name>
+                <narrative xml:lang="en">Cambodia</narrative>
+                <narrative xml:lang="fr">Cambodge (le)</narrative>
+                <narrative xml:lang="km">K&#226;mp&#365;ch&#233;a</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Cambodia</narrative>
+                <narrative xml:lang="fr">le Royaume du Cambodge</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KI</code>
+            <name>
+                <narrative xml:lang="en">Kiribati</narrative>
+                <narrative xml:lang="fr">Kiribati (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Kiribati</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Kiribati</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KM</code>
+            <name>
+                <narrative xml:lang="en">Comoros</narrative>
+                <narrative xml:lang="ar">Al Qamar</narrative>
+                <narrative xml:lang="fr">Comores (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Union of the Comoros</narrative>
+                <narrative xml:lang="fr">l'Union des Comores</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KN</code>
+            <name>
+                <narrative xml:lang="fr">Saint-Kitts-et-Nevis</narrative>
+                <narrative xml:lang="en">Saint Kitts and Nevis</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>KP</code>
+            <name>
+                <narrative xml:lang="en">Korea (the Democratic People's Republic of)</narrative>
+                <narrative xml:lang="ko">Chos&#335;n</narrative>
+                <narrative xml:lang="fr">Cor&#233;e (la&#160;R&#233;publique populaire d&#233;mocratique de&#160;)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Democratic People's Republic of Korea</narrative>
+                <narrative xml:lang="fr">la R&#233;publique populaire d&#233;mocratique de Cor&#233;e</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KR</code>
+            <name>
+                <narrative xml:lang="en">Korea (the Republic of)</narrative>
+                <narrative xml:lang="ko">Hanguk</narrative>
+                <narrative xml:lang="fr">Cor&#233;e (la R&#233;publique de)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Korea</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Cor&#233;e</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KW</code>
+            <name>
+                <narrative xml:lang="en">Kuwait</narrative>
+                <narrative xml:lang="ar">Al Kuwayt</narrative>
+                <narrative xml:lang="fr">Kowe&#239;t (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the State of Kuwait</narrative>
+                <narrative xml:lang="fr">l'&#201;tat du Kowe&#239;t</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>KY</code>
+            <name>
+                <narrative xml:lang="en">Cayman Islands (the)</narrative>
+                <narrative xml:lang="fr">Ca&#239;mans (les&#160;&#206;les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>KZ</code>
+            <name>
+                <narrative xml:lang="kk">Qazaqstan</narrative>
+                <narrative xml:lang="ru">Kazahstan</narrative>
+                <narrative xml:lang="fr">Kazakhstan (le)</narrative>
+                <narrative xml:lang="en">Kazakhstan</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Kazakhstan</narrative>
+                <narrative xml:lang="en">the Republic of Kazakhstan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LA</code>
+            <name>
+                <narrative xml:lang="en">Lao People's Democratic Republic (the)</narrative>
+                <narrative xml:lang="lo">Sathalanalat Paxathipatai Paxax&#244;n Lao</narrative>
+                <narrative xml:lang="fr">Lao, R&#233;publique d&#233;mocratique populaire</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Lao People's Democratic Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d&#233;mocratique populaire lao</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LB</code>
+            <name>
+                <narrative xml:lang="en">Lebanon</narrative>
+                <narrative xml:lang="ar">Lubn&#257;n</narrative>
+                <narrative xml:lang="fr">Liban (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Lebanese Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique libanaise</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LC</code>
+            <name>
+                <narrative xml:lang="fr">Sainte-Lucie</narrative>
+                <narrative xml:lang="en">Saint Lucia</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>LI</code>
+            <name>
+                <narrative xml:lang="en">Liechtenstein</narrative>
+                <narrative xml:lang="de">Liechtenstein</narrative>
+                <narrative xml:lang="fr">Liechtenstein (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Principality of Liechtenstein</narrative>
+                <narrative xml:lang="fr">la Principaut&#233; du Liechtenstein</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LK</code>
+            <name>
+                <narrative xml:lang="en">Sri Lanka</narrative>
+                <narrative xml:lang="fr">Sri Lanka (le)</narrative>
+                <narrative xml:lang="si">Shr&#299; La&#7745;k&#257;</narrative>
+                <narrative xml:lang="ta">Ila&#7749;kai</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Democratic Socialist Republic of Sri Lanka</narrative>
+                <narrative xml:lang="fr">la R&#233;publique socialiste d&#233;mocratique du Sri Lanka</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LR</code>
+            <name>
+                <narrative xml:lang="en">Liberia</narrative>
+                <narrative xml:lang="fr">Lib&#233;ria (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Liberia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Lib&#233;ria</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LS</code>
+            <name>
+                <narrative xml:lang="en">Lesotho</narrative>
+                <narrative xml:lang="st">Lesotho</narrative>
+                <narrative xml:lang="fr">Lesotho (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Lesotho</narrative>
+                <narrative xml:lang="fr">le Royaume du Lesotho</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LT</code>
+            <name>
+                <narrative xml:lang="en">Lithuania</narrative>
+                <narrative xml:lang="lt">Lietuva</narrative>
+                <narrative xml:lang="fr">Lituanie (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Lithuania</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Lituanie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LU</code>
+            <name>
+                <narrative xml:lang="en">Luxembourg</narrative>
+                <narrative xml:lang="de">Luxemburg</narrative>
+                <narrative xml:lang="lb">L&#235;tzebuerg</narrative>
+                <narrative xml:lang="fr">Luxembourg (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Grand Duchy of Luxembourg</narrative>
+                <narrative xml:lang="fr">le Grand-Duch&#233; de Luxembourg</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LV</code>
+            <name>
+                <narrative xml:lang="fr">Lettonie (la)</narrative>
+                <narrative xml:lang="lv">Latvija</narrative>
+                <narrative xml:lang="en">Latvia</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Lettonie</narrative>
+                <narrative xml:lang="en">the Republic of Latvia</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>LY</code>
+            <name>
+                <narrative xml:lang="en">Libya</narrative>
+                <narrative xml:lang="ar">L&#299;biy&#257;</narrative>
+                <narrative xml:lang="fr">Libye</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>MA</code>
+            <name>
+                <narrative xml:lang="en">Morocco</narrative>
+                <narrative xml:lang="ar">Al Maghrib</narrative>
+                <narrative xml:lang="fr">Maroc (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Morocco</narrative>
+                <narrative xml:lang="fr">le Royaume du Maroc</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MC</code>
+            <name>
+                <narrative xml:lang="en">Monaco</narrative>
+                <narrative xml:lang="fr">Monaco</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Principality of Monaco</narrative>
+                <narrative xml:lang="fr">la Principaut&#233; de Monaco</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MD</code>
+            <name>
+                <narrative xml:lang="mo">Republica Moldova</narrative>
+                <narrative xml:lang="fr">Moldova&#160;, R&#233;publique de</narrative>
+                <narrative xml:lang="en">Moldova (the Republic of)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Moldova</narrative>
+                <narrative xml:lang="en">the Republic of Moldova</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>ME</code>
+            <name>
+                <narrative xml:lang="fr">Mont&#233;n&#233;gro (le)</narrative>
+                <narrative xml:lang="en">Montenegro</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">Mont&#233;n&#233;gro (le)</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MF</code>
+            <name>
+                <narrative xml:lang="en">Saint Martin (French part)</narrative>
+                <narrative xml:lang="fr">Saint-Martin (partie fran&#231;aise)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>MG</code>
+            <name>
+                <narrative xml:lang="en">Madagascar</narrative>
+                <narrative xml:lang="mg">Madagasikara</narrative>
+                <narrative xml:lang="fr">Madagascar</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Madagascar</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Madagascar</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MH</code>
+            <name>
+                <narrative xml:lang="mh">Ael&#333;n&#772; in M&#807;aje&#316;</narrative>
+                <narrative xml:lang="fr">Marshall (&#206;les)</narrative>
+                <narrative xml:lang="en">Marshall Islands (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique des &#206;les Marshall</narrative>
+                <narrative xml:lang="en">the Republic of the Marshall Islands</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MK</code>
+            <name>
+                <narrative xml:lang="mk">Porane&#353;na Jugoslovenska Republika Makedonija</narrative>
+                <narrative xml:lang="en">Macedonia (the former Yugoslav Republic of)</narrative>
+                <narrative xml:lang="fr">Mac&#233;doine (l'ex&#8209;R&#233;publique yougoslave de)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the former Yugoslav Republic of Macedonia</narrative>
+                <narrative xml:lang="fr">l'ex-R&#233;publique yougoslave de Mac&#233;doine</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>ML</code>
+            <name>
+                <narrative xml:lang="en">Mali</narrative>
+                <narrative xml:lang="fr">Mali (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Mali</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Mali</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MM</code>
+            <name>
+                <narrative xml:lang="my">Myanma</narrative>
+                <narrative xml:lang="en">Myanmar</narrative>
+                <narrative xml:lang="fr">Myanmar (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of the Union of Myanmar</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de l'Union du Myanmar</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MN</code>
+            <name>
+                <narrative xml:lang="en">Mongolia</narrative>
+                <narrative xml:lang="mn">Mongol</narrative>
+                <narrative xml:lang="fr">Mongolie (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>MO</code>
+            <name>
+                <narrative xml:lang="pt">Macau</narrative>
+                <narrative xml:lang="zh">Aomen</narrative>
+                <narrative xml:lang="en">Macao</narrative>
+                <narrative xml:lang="fr">Macao</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">Macao Special Administrative Region of China</narrative>
+                <narrative xml:lang="fr">Macao, R&#233;gion administrative sp&#233;ciale de Chine</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MP</code>
+            <name>
+                <narrative xml:lang="en">Northern Mariana Islands (the)</narrative>
+                <narrative xml:lang="fr">Mariannes du Nord (les &#206;les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Commonwealth of the Northern Mariana Islands</narrative>
+                <narrative xml:lang="fr">les &#206;les Mariannes du Nord</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MQ</code>
+            <name>
+                <narrative xml:lang="fr">Martinique (la)</narrative>
+                <narrative xml:lang="en">Martinique</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>MR</code>
+            <name>
+                <narrative xml:lang="en">Mauritania</narrative>
+                <narrative xml:lang="ar">M&#363;r&#299;t&#257;niy&#257;</narrative>
+                <narrative xml:lang="fr">Mauritanie (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Islamic Republic of Mauritania</narrative>
+                <narrative xml:lang="fr">la R&#233;publique islamique de Mauritanie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MS</code>
+            <name>
+                <narrative xml:lang="en">Montserrat</narrative>
+                <narrative xml:lang="fr">Montserrat</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>MT</code>
+            <name>
+                <narrative xml:lang="en">Malta</narrative>
+                <narrative xml:lang="mt">Malta</narrative>
+                <narrative xml:lang="fr">Malte</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Malta</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Malte</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MU</code>
+            <name>
+                <narrative xml:lang="fr">Maurice</narrative>
+                <narrative xml:lang="en">Mauritius</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Maurice</narrative>
+                <narrative xml:lang="en">the Republic of Mauritius</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MV</code>
+            <name>
+                <narrative xml:lang="en">Maldives</narrative>
+                <narrative xml:lang="dv">Dhivehi Raajje</narrative>
+                <narrative xml:lang="fr">Maldives (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Maldives</narrative>
+                <narrative xml:lang="fr">la R&#233;publique des Maldives</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MW</code>
+            <name>
+                <narrative xml:lang="en">Malawi</narrative>
+                <narrative xml:lang="ny">Mala&#373;i</narrative>
+                <narrative xml:lang="fr">Malawi (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Malawi</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Malawi</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MX</code>
+            <name>
+                <narrative xml:lang="en">Mexico</narrative>
+                <narrative xml:lang="fr">Mexique (le)</narrative>
+                <narrative xml:lang="es">M&#233;xico</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the United Mexican States</narrative>
+                <narrative xml:lang="fr">les &#201;tats-Unis du Mexique</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>MY</code>
+            <name>
+                <narrative xml:lang="en">Malaysia</narrative>
+                <narrative xml:lang="ms">Malaysia</narrative>
+                <narrative xml:lang="fr">Malaisie (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>MZ</code>
+            <name>
+                <narrative xml:lang="en">Mozambique</narrative>
+                <narrative xml:lang="pt">Mo&#231;ambique</narrative>
+                <narrative xml:lang="fr">Mozambique (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Mozambique</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Mozambique</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NA</code>
+            <name>
+                <narrative xml:lang="en">Namibia</narrative>
+                <narrative xml:lang="fr">Namibie (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Namibia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Namibie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NC</code>
+            <name>
+                <narrative xml:lang="en">New Caledonia</narrative>
+                <narrative xml:lang="fr">Nouvelle-Cal&#233;donie (la)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>NE</code>
+            <name>
+                <narrative xml:lang="en">Niger (the)</narrative>
+                <narrative xml:lang="fr">Niger (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of the Niger</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Niger</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NF</code>
+            <name>
+                <narrative xml:lang="en">Norfolk Island</narrative>
+                <narrative xml:lang="fr">Norfolk (l'&#206;le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>NG</code>
+            <name>
+                <narrative xml:lang="en">Nigeria</narrative>
+                <narrative xml:lang="fr">Nig&#233;ria (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Federal Republic of Nigeria</narrative>
+                <narrative xml:lang="fr">la R&#233;publique f&#233;d&#233;rale du Nig&#233;ria</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NI</code>
+            <name>
+                <narrative xml:lang="en">Nicaragua</narrative>
+                <narrative xml:lang="es">Nicaragua</narrative>
+                <narrative xml:lang="fr">Nicaragua (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Nicaragua</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Nicaragua</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NL</code>
+            <name>
+                <narrative xml:lang="en">Netherlands (the)</narrative>
+                <narrative xml:lang="nl">Nederland</narrative>
+                <narrative xml:lang="fr">Pays-Bas (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of the Netherlands</narrative>
+                <narrative xml:lang="fr">le Royaume des Pays-Bas</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NO</code>
+            <name>
+                <narrative xml:lang="en">Norway</narrative>
+                <narrative xml:lang="nn">Noreg</narrative>
+                <narrative xml:lang="nb">Norge</narrative>
+                <narrative xml:lang="fr">Norv&#232;ge (la)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Norway</narrative>
+                <narrative xml:lang="fr">le Royaume de Norv&#232;ge</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NP</code>
+            <name>
+                <narrative xml:lang="en">Nepal</narrative>
+                <narrative xml:lang="ne">Nep&#257;l</narrative>
+                <narrative xml:lang="fr">N&#233;pal (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Federal Democratic Republic of Nepal</narrative>
+                <narrative xml:lang="fr">la R&#233;publique f&#233;d&#233;rale d&#233;mocratique du N&#233;pal</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NR</code>
+            <name>
+                <narrative xml:lang="en">Nauru</narrative>
+                <narrative xml:lang="na">Naoero</narrative>
+                <narrative xml:lang="fr">Nauru</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Nauru</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Nauru</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>NU</code>
+            <name>
+                <narrative xml:lang="fr">Niue</narrative>
+                <narrative xml:lang="en">Niue</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>NZ</code>
+            <name>
+                <narrative xml:lang="mi">Aotearoa</narrative>
+                <narrative xml:lang="fr">Nouvelle-Z&#233;lande (la)</narrative>
+                <narrative xml:lang="en">New Zealand</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>OM</code>
+            <name>
+                <narrative xml:lang="en">Oman</narrative>
+                <narrative xml:lang="ar">&#8216;Um&#257;n</narrative>
+                <narrative xml:lang="fr">Oman</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Sultanate of Oman</narrative>
+                <narrative xml:lang="fr">le Sultanat d'Oman</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PA</code>
+            <name>
+                <narrative xml:lang="en">Panama</narrative>
+                <narrative xml:lang="fr">Panama (le)</narrative>
+                <narrative xml:lang="es">Panam&#225;</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Panama</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Panama</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PE</code>
+            <name>
+                <narrative xml:lang="en">Peru</narrative>
+                <narrative xml:lang="fr">P&#233;rou (le)</narrative>
+                <narrative xml:lang="ay">Per&#250;</narrative>
+                <narrative xml:lang="es">Per&#250; (el)</narrative>
+                <narrative xml:lang="qu">Per&#250;</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Peru</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du P&#233;rou</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PF</code>
+            <name>
+                <narrative xml:lang="fr">Polyn&#233;sie fran&#231;aise (la)</narrative>
+                <narrative xml:lang="en">French Polynesia</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>PG</code>
+            <name>
+                <narrative xml:lang="en">Papua New Guinea</narrative>
+                <narrative xml:lang="fr">Papouasie-Nouvelle-Guin&#233;e (la)</narrative>
+                <narrative xml:lang="ho">Papuaniugini</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Independent State of Papua New Guinea</narrative>
+                <narrative xml:lang="fr">l'&#201;tat ind&#233;pendant de Papouasie-Nouvelle-Guin&#233;e</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PH</code>
+            <name>
+                <narrative xml:lang="fr">Philippines (les)</narrative>
+                <narrative xml:lang="en">Philippines (the)</narrative>
+                <narrative xml:lang="tl">Pilipinas</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique des Philippines</narrative>
+                <narrative xml:lang="en">the Republic of the Philippines</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PK</code>
+            <name>
+                <narrative xml:lang="en">Pakistan</narrative>
+                <narrative xml:lang="ur">P&#257;kist&#257;n</narrative>
+                <narrative xml:lang="fr">Pakistan (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Islamic Republic of Pakistan</narrative>
+                <narrative xml:lang="fr">la R&#233;publique islamique du Pakistan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PL</code>
+            <name>
+                <narrative xml:lang="en">Poland</narrative>
+                <narrative xml:lang="fr">Pologne (la)</narrative>
+                <narrative xml:lang="pl">Polska</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Poland</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Pologne</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PM</code>
+            <name>
+                <narrative xml:lang="en">Saint Pierre and Miquelon</narrative>
+                <narrative xml:lang="fr">Saint-Pierre-et-Miquelon</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>PN</code>
+            <name>
+                <narrative xml:lang="fr">Pitcairn</narrative>
+                <narrative xml:lang="en">Pitcairn</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>PR</code>
+            <name>
+                <narrative xml:lang="fr">Porto Rico</narrative>
+                <narrative xml:lang="en">Puerto Rico</narrative>
+                <narrative xml:lang="es">Puerto Rico</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>PS</code>
+            <name>
+                <narrative xml:lang="en">Palestine, State of</narrative>
+                <narrative xml:lang="fr">Palestine, &#201;tat de</narrative>
+                <narrative xml:lang="ar">Dawlat Filas&#355;&#299;n</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the State of Palestine</narrative>
+                <narrative xml:lang="fr">l'&#201;tat de Palestine</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PT</code>
+            <name>
+                <narrative xml:lang="en">Portugal</narrative>
+                <narrative xml:lang="fr">Portugal (le)</narrative>
+                <narrative xml:lang="pt">Portugal</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Portuguese Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique portugaise</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PW</code>
+            <name>
+                <narrative xml:lang="en">Palau</narrative>
+                <narrative xml:lang="fr">Palaos (les)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Palau</narrative>
+                <narrative xml:lang="fr">la R&#233;publique des Palaos</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>PY</code>
+            <name>
+                <narrative xml:lang="en">Paraguay</narrative>
+                <narrative xml:lang="fr">Paraguay (le)</narrative>
+                <narrative xml:lang="es">Paraguay (el)</narrative>
+                <narrative xml:lang="gn">Paraguay</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Paraguay</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Paraguay</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>QA</code>
+            <name>
+                <narrative xml:lang="en">Qatar</narrative>
+                <narrative xml:lang="fr">Qatar (le)</narrative>
+                <narrative xml:lang="ar">Qa&#355;ar</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the State of Qatar</narrative>
+                <narrative xml:lang="fr">l'&#201;tat du Qatar</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>RE</code>
+            <name>
+                <narrative xml:lang="fr">R&#233;union (La)</narrative>
+                <narrative xml:lang="en">R&#233;union</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>RO</code>
+            <name>
+                <narrative xml:lang="fr">Roumanie (la)</narrative>
+                <narrative xml:lang="ro">Rom&#226;nia</narrative>
+                <narrative xml:lang="en">Romania</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>RS</code>
+            <name>
+                <narrative xml:lang="sr">Srbija</narrative>
+                <narrative xml:lang="en">Serbia</narrative>
+                <narrative xml:lang="fr">Serbie</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Serbia</narrative>
+                <narrative xml:lang="fr">la R&#233;publique de Serbie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>RU</code>
+            <name>
+                <narrative xml:lang="en">Russian Federation (the)</narrative>
+                <narrative xml:lang="fr">Russie (la F&#233;d&#233;ration de)</narrative>
+                <narrative xml:lang="ru">Rossijskaja Federacija</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Russian Federation</narrative>
+                <narrative xml:lang="fr">la F&#233;d&#233;ration de Russie</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>RW</code>
+            <name>
+                <narrative xml:lang="en">Rwanda</narrative>
+                <narrative xml:lang="fr">Rwanda (le)</narrative>
+                <narrative xml:lang="rw">Rwanda</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Rwanda</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Rwanda</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SA</code>
+            <name>
+                <narrative xml:lang="ar">As Su&#8216;&#363;d&#299;yah</narrative>
+                <narrative xml:lang="en">Saudi Arabia</narrative>
+                <narrative xml:lang="fr">Arabie saoudite (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Kingdom of Saudi Arabia</narrative>
+                <narrative xml:lang="fr">le Royaume d'Arabie saoudite</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SB</code>
+            <name>
+                <narrative xml:lang="fr">Salomon (&#206;les)</narrative>
+                <narrative xml:lang="en">Solomon Islands (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">les &#206;les Salomon</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SC</code>
+            <name>
+                <narrative xml:lang="fr">Seychelles (les)</narrative>
+                <narrative xml:lang="en">Seychelles</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique des Seychelles</narrative>
+                <narrative xml:lang="en">the Republic of Seychelles</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SD</code>
+            <name>
+                <narrative xml:lang="fr">Soudan (le)</narrative>
+                <narrative xml:lang="ar">As S&#363;d&#257;n</narrative>
+                <narrative xml:lang="en">Sudan (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Soudan</narrative>
+                <narrative xml:lang="en">the Republic of the Sudan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SE</code>
+            <name>
+                <narrative xml:lang="fr">Su&#232;de (la)</narrative>
+                <narrative xml:lang="sv">Sverige</narrative>
+                <narrative xml:lang="en">Sweden</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Royaume de Su&#232;de</narrative>
+                <narrative xml:lang="en">the Kingdom of Sweden</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SG</code>
+            <name>
+                <narrative xml:lang="fr">Singapour</narrative>
+                <narrative xml:lang="en">Singapore</narrative>
+                <narrative xml:lang="ms">Singapura</narrative>
+                <narrative xml:lang="ta">Chi&#7749;kapp&#363;r</narrative>
+                <narrative xml:lang="zh">Xinjiapo</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Singapour</narrative>
+                <narrative xml:lang="en">the Republic of Singapore</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SH</code>
+            <name>
+                <narrative xml:lang="fr">Sainte-H&#233;l&#232;ne, Ascension et Tristan da Cunha</narrative>
+                <narrative xml:lang="en">Saint Helena, Ascension and Tristan da Cunha</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>SI</code>
+            <name>
+                <narrative xml:lang="fr">Slov&#233;nie (la)</narrative>
+                <narrative xml:lang="sl">Slovenija</narrative>
+                <narrative xml:lang="en">Slovenia</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Slov&#233;nie</narrative>
+                <narrative xml:lang="en">the Republic of Slovenia</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SJ</code>
+            <name>
+                <narrative xml:lang="fr">Svalbard et l'&#206;le Jan Mayen (le)</narrative>
+                <narrative xml:lang="nb">Svalbard og Jan Mayen</narrative>
+                <narrative xml:lang="nn">Svalbard og Jan Mayen</narrative>
+                <narrative xml:lang="en">Svalbard and Jan Mayen</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>SK</code>
+            <name>
+                <narrative xml:lang="en">Slovakia</narrative>
+                <narrative xml:lang="fr">Slovaquie (la)</narrative>
+                <narrative xml:lang="sk">Slovensko</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Slovak Republic</narrative>
+                <narrative xml:lang="fr">la R&#233;publique slovaque</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SL</code>
+            <name>
+                <narrative xml:lang="fr">Sierra Leone (la)</narrative>
+                <narrative xml:lang="en">Sierra Leone</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Sierra Leone</narrative>
+                <narrative xml:lang="en">the Republic of Sierra Leone</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SM</code>
+            <name>
+                <narrative xml:lang="fr">Saint-Marin</narrative>
+                <narrative xml:lang="it">San Marino</narrative>
+                <narrative xml:lang="en">San Marino</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Saint-Marin</narrative>
+                <narrative xml:lang="en">the Republic of San Marino</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SN</code>
+            <name>
+                <narrative xml:lang="fr">S&#233;n&#233;gal (le)</narrative>
+                <narrative xml:lang="en">Senegal</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du S&#233;n&#233;gal</narrative>
+                <narrative xml:lang="en">the Republic of Senegal</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SO</code>
+            <name>
+                <narrative xml:lang="fr">Somalie (la)</narrative>
+                <narrative xml:lang="ar">A&#351; &#350;&#363;m&#257;l</narrative>
+                <narrative xml:lang="so">Soomaaliya</narrative>
+                <narrative xml:lang="en">Somalia</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique f&#233;d&#233;rale de Somalie</narrative>
+                <narrative xml:lang="en">the Federal Republic of Somalia</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SR</code>
+            <name>
+                <narrative xml:lang="fr">Suriname (le)</narrative>
+                <narrative xml:lang="nl">Suriname</narrative>
+                <narrative xml:lang="en">Suriname</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Suriname</narrative>
+                <narrative xml:lang="en">the Republic of Suriname</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SS</code>
+            <name>
+                <narrative xml:lang="fr">Soudan du Sud (le)</narrative>
+                <narrative xml:lang="en">South Sudan </narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Soudan du Sud</narrative>
+                <narrative xml:lang="en">the Republic of South Sudan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>ST</code>
+            <name>
+                <narrative xml:lang="fr">Sao Tom&#233;-et-Principe</narrative>
+                <narrative xml:lang="pt">S&#227;o Tom&#233; e Pr&#237;ncipe</narrative>
+                <narrative xml:lang="en">Sao Tome and Principe</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique d&#233;mocratique de Sao Tom&#233;-et-Principe</narrative>
+                <narrative xml:lang="en">the Democratic Republic of Sao Tome and Principe</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SV</code>
+            <name>
+                <narrative xml:lang="es">El Salvador</narrative>
+                <narrative xml:lang="fr">Salvador (le)</narrative>
+                <narrative xml:lang="en">El Salvador</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique d'El Salvador</narrative>
+                <narrative xml:lang="en">the Republic of El Salvador</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SX</code>
+            <name>
+                <narrative xml:lang="nl">Sint Maarten</narrative>
+                <narrative xml:lang="en">Sint Maarten (Dutch part)</narrative>
+                <narrative xml:lang="fr">Saint-Martin (partie n&#233;erlandaise)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>SY</code>
+            <name>
+                <narrative xml:lang="fr">R&#233;publique arabe syrienne (la)</narrative>
+                <narrative xml:lang="ar">Al Jumh&#363;r&#299;yah al &#8216;Arab&#299;yah as S&#363;r&#299;yah</narrative>
+                <narrative xml:lang="en">Syrian Arab Republic (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique arabe syrienne</narrative>
+                <narrative xml:lang="en">the Syrian Arab Republic</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>SZ</code>
+            <name>
+                <narrative xml:lang="fr">Swaziland (le)</narrative>
+                <narrative xml:lang="ss">eSwatini</narrative>
+                <narrative xml:lang="en">Swaziland</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Royaume du Swaziland</narrative>
+                <narrative xml:lang="en">the Kingdom of Swaziland</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TC</code>
+            <name>
+                <narrative xml:lang="fr">Turks-et-Ca&#239;cos (les &#206;les)</narrative>
+                <narrative xml:lang="en">Turks and Caicos Islands (the)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>TD</code>
+            <name>
+                <narrative xml:lang="ar">Tsh&#257;d</narrative>
+                <narrative xml:lang="fr">Tchad (le)</narrative>
+                <narrative xml:lang="en">Chad</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Tchad</narrative>
+                <narrative xml:lang="en">the Republic of Chad</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TF</code>
+            <name>
+                <narrative xml:lang="fr">Terres australes fran&#231;aises (les)</narrative>
+                <narrative xml:lang="en">French Southern Territories (the)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>TG</code>
+            <name>
+                <narrative xml:lang="fr">Togo (le)</narrative>
+                <narrative xml:lang="en">Togo</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique togolaise</narrative>
+                <narrative xml:lang="en">the Togolese Republic</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TH</code>
+            <name>
+                <narrative xml:lang="fr">Tha&#239;lande (la)</narrative>
+                <narrative xml:lang="th">Prathet Thai</narrative>
+                <narrative xml:lang="en">Thailand</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Royaume de Tha&#239;lande</narrative>
+                <narrative xml:lang="en">the Kingdom of Thailand</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TJ</code>
+            <name>
+                <narrative xml:lang="tg">Tojikiston</narrative>
+                <narrative xml:lang="en">Tajikistan</narrative>
+                <narrative xml:lang="fr">Tadjikistan (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Tajikistan</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Tadjikistan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TK</code>
+            <name>
+                <narrative xml:lang="fr">Tokelau (les)</narrative>
+                <narrative xml:lang="en">Tokelau</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>TL</code>
+            <name>
+                <narrative xml:lang="fr">Timor-Leste (le)</narrative>
+                <narrative xml:lang="pt">Timor-Leste</narrative>
+                <narrative xml:lang="en">Timor-Leste</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique d&#233;mocratique du Timor-Leste</narrative>
+                <narrative xml:lang="en">the Democratic Republic of Timor-Leste</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TM</code>
+            <name>
+                <narrative xml:lang="tk">T&#252;rkmenistan</narrative>
+                <narrative xml:lang="en">Turkmenistan</narrative>
+                <narrative xml:lang="fr">Turkm&#233;nistan (le)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>TN</code>
+            <name>
+                <narrative xml:lang="fr">Tunisie (la)</narrative>
+                <narrative xml:lang="ar">T&#363;nus</narrative>
+                <narrative xml:lang="en">Tunisia</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique tunisienne</narrative>
+                <narrative xml:lang="en">the Republic of Tunisia</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TO</code>
+            <name>
+                <narrative xml:lang="fr">Tonga (les)</narrative>
+                <narrative xml:lang="en">Tonga</narrative>
+                <narrative xml:lang="to">Tonga</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">le Royaume des Tonga</narrative>
+                <narrative xml:lang="en">the Kingdom of Tonga</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TR</code>
+            <name>
+                <narrative xml:lang="tr">T&#252;rkiye</narrative>
+                <narrative xml:lang="fr">Turquie (la)</narrative>
+                <narrative xml:lang="en">Turkey</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique turque</narrative>
+                <narrative xml:lang="en">the Republic of Turkey</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TT</code>
+            <name>
+                <narrative xml:lang="fr">Trinit&#233;-et-Tobago (la)</narrative>
+                <narrative xml:lang="en">Trinidad and Tobago</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Trinit&#233;-et-Tobago</narrative>
+                <narrative xml:lang="en">the Republic of Trinidad and Tobago</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>TV</code>
+            <name>
+                <narrative xml:lang="en">Tuvalu</narrative>
+                <narrative xml:lang="fr">Tuvalu (les)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>TW</code>
+            <name>
+                <narrative xml:lang="fr">Ta&#239;wan (Province de Chine)</narrative>
+                <narrative xml:lang="zh">Taiwan</narrative>
+                <narrative xml:lang="en">Taiwan (Province of China)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>TZ</code>
+            <name>
+                <narrative xml:lang="fr">Tanzanie, R&#233;publique-Unie de</narrative>
+                <narrative xml:lang="sw">Jamhuri ya Muungano wa Tanzania</narrative>
+                <narrative xml:lang="en">Tanzania, United Republic of</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique-Unie de Tanzanie</narrative>
+                <narrative xml:lang="en">the United Republic of Tanzania</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>UA</code>
+            <name>
+                <narrative xml:lang="fr">Ukraine (l')</narrative>
+                <narrative xml:lang="uk">Ukraina</narrative>
+                <narrative xml:lang="en">Ukraine</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>UG</code>
+            <name>
+                <narrative xml:lang="fr">Ouganda (l')</narrative>
+                <narrative xml:lang="en">Uganda</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique d'Ouganda</narrative>
+                <narrative xml:lang="en">the Republic of Uganda</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>UM</code>
+            <name>
+                <narrative xml:lang="fr">&#206;les mineures &#233;loign&#233;es des &#201;tats-Unis (les)</narrative>
+                <narrative xml:lang="en">United States Minor Outlying Islands (the)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>US</code>
+            <name>
+                <narrative xml:lang="fr">&#201;tats-Unis (les)</narrative>
+                <narrative xml:lang="en">United States (the)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">les &#201;tats-Unis d'Am&#233;rique</narrative>
+                <narrative xml:lang="en">the United States of America</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>UY</code>
+            <name>
+                <narrative xml:lang="fr">Uruguay (l')</narrative>
+                <narrative xml:lang="es">Uruguay (el)</narrative>
+                <narrative xml:lang="en">Uruguay</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique orientale de l'Uruguay</narrative>
+                <narrative xml:lang="en">the Eastern Republic of Uruguay</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>UZ</code>
+            <name>
+                <narrative xml:lang="uz">O&#8216;zbekiston</narrative>
+                <narrative xml:lang="en">Uzbekistan</narrative>
+                <narrative xml:lang="fr">Ouzb&#233;kistan (l')</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Uzbekistan</narrative>
+                <narrative xml:lang="fr">la R&#233;publique d'Ouzb&#233;kistan</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>VA</code>
+            <name>
+                <narrative xml:lang="it">Santa Sede (la)</narrative>
+                <narrative xml:lang="la">Sancta Sedes</narrative>
+                <narrative xml:lang="fr">Saint-Si&#232;ge (le) [&#201;tat de la Cit&#233; du Vatican (l')]</narrative>
+                <narrative xml:lang="en">Holy See (the) [Vatican City State]</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>VC</code>
+            <name>
+                <narrative xml:lang="fr">Saint-Vincent-et-les-Grenadines</narrative>
+                <narrative xml:lang="en">Saint Vincent and the Grenadines</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>VE</code>
+            <name>
+                <narrative xml:lang="fr">Venezuela, R&#233;publique bolivarienne du&#160;</narrative>
+                <narrative xml:lang="es">Venezuela, Rep&#250;blica Bolivariana de</narrative>
+                <narrative xml:lang="en">Venezuela, Bolivarian Republic of&#160;</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique bolivarienne du Venezuela</narrative>
+                <narrative xml:lang="en">the Bolivarian Republic of Venezuela</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>VG</code>
+            <name>
+                <narrative xml:lang="fr">Vierges britanniques (les&#160;&#206;les)</narrative>
+                <narrative xml:lang="en">Virgin Islands (British)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">British Virgin Islands (the)</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>VI</code>
+            <name>
+                <narrative xml:lang="fr">Vierges des &#201;tats-Unis (les &#206;les)</narrative>
+                <narrative xml:lang="en">Virgin Islands (U.S.)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Virgin Islands of the United States</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>VN</code>
+            <name>
+                <narrative xml:lang="vi">Vi&#7879;t Nam</narrative>
+                <narrative xml:lang="en">Viet Nam</narrative>
+                <narrative xml:lang="fr">Viet Nam (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Socialist Republic of Viet Nam</narrative>
+                <narrative xml:lang="fr">la R&#233;publique socialiste du Viet Nam</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>VU</code>
+            <name>
+                <narrative xml:lang="bi">Vanuatu</narrative>
+                <narrative xml:lang="en">Vanuatu</narrative>
+                <narrative xml:lang="fr">Vanuatu (le)</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">the Republic of Vanuatu</narrative>
+                <narrative xml:lang="fr">la R&#233;publique du Vanuatu</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>WF</code>
+            <name>
+                <narrative xml:lang="en">Wallis and Futuna</narrative>
+                <narrative xml:lang="fr">Wallis-et-Futuna </narrative>
+            </name>
+            <description>
+                <narrative xml:lang="en">Wallis and Futuna Islands</narrative>
+                <narrative xml:lang="fr">les &#206;les Wallis-et-Futuna</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>WS</code>
+            <name>
+                <narrative xml:lang="fr">Samoa (les)</narrative>
+                <narrative xml:lang="en">Samoa</narrative>
+                <narrative xml:lang="sm">Samoa</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">l'&#201;tat ind&#233;pendant du Samoa</narrative>
+                <narrative xml:lang="en">the Independent State of Samoa</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
             <code>YE</code>
             <name>
-                <narrative>YEMEN</narrative>
+                <narrative xml:lang="fr">Y&#233;men (le)</narrative>
+                <narrative xml:lang="ar">Al Yaman</narrative>
+                <narrative xml:lang="en">Yemen</narrative>
             </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Y&#233;men</narrative>
+                <narrative xml:lang="en">the  Republic of Yemen</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>YT</code>
+            <name>
+                <narrative xml:lang="fr">Mayotte</narrative>
+                <narrative xml:lang="en">Mayotte</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item>
+            <code>ZA</code>
+            <name>
+                <narrative xml:lang="fr">Afrique du Sud (l')</narrative>
+                <narrative xml:lang="af">Suid-Afrika</narrative>
+                <narrative xml:lang="en">South Africa</narrative>
+                <narrative xml:lang="nr">Sewula Afrika</narrative>
+                <narrative xml:lang="st">Afrika-Borwa</narrative>
+                <narrative xml:lang="ss">Ningizimu Afrika</narrative>
+                <narrative xml:lang="ts">Afrika-Dzonga</narrative>
+                <narrative xml:lang="tn">Afrika-Borwa</narrative>
+                <narrative xml:lang="ve">Afrika Tshipembe</narrative>
+                <narrative xml:lang="xh">Mzantsi Afrika</narrative>
+                <narrative xml:lang="zu">Ningizimu Afrika</narrative>
+            </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique sud-africaine</narrative>
+                <narrative xml:lang="en">the Republic of South Africa</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
             <code>ZM</code>
             <name>
-                <narrative>ZAMBIA</narrative>
+                <narrative xml:lang="fr">Zambie (la)</narrative>
+                <narrative xml:lang="en">Zambia</narrative>
             </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique de Zambie</narrative>
+                <narrative xml:lang="en">the Republic of Zambia</narrative>
+            </description>
         </codelist-item>
         <codelist-item>
             <code>ZW</code>
             <name>
-                <narrative>ZIMBABWE</narrative>
+                <narrative xml:lang="fr">Zimbabwe (le)</narrative>
+                <narrative xml:lang="en">Zimbabwe</narrative>
             </name>
+            <description>
+                <narrative xml:lang="fr">la R&#233;publique du Zimbabwe</narrative>
+                <narrative xml:lang="en">the Republic of Zimbabwe</narrative>
+            </description>
         </codelist-item>
     </codelist-items>
 </codelist>
+

--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -2729,26 +2729,10 @@
             </description>
         </codelist-item>
         <codelist-item withdrawn="1978-07-15">
-            <code>AI</code>
-            <name>
-                <narrative xml:lang="en">French Afars and Issas</narrative>
-                <narrative xml:lang="fr">Afars et Issas</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1978-07-15">
             <code>AIDJ</code>
             <name>
                 <narrative xml:lang="en">French Afars and Issas</narrative>
                 <narrative xml:lang="fr">Afars et Issas</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="2010-12-15">
-            <code>AN</code>
-            <name>
-                <narrative xml:lang="fr">Antilles n&#233;erlandaises (les&#160;) </narrative>
-                <narrative xml:lang="en">Netherlands Antilles</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2761,26 +2745,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1981-05-15">
-            <code>BQ</code>
-            <name>
-                <narrative xml:lang="en">British Antarctic Territory</narrative>
-                <narrative xml:lang="fr">Antarctique, Territoire britannique de l'</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1981-05-15">
             <code>BQAQ</code>
             <name>
                 <narrative xml:lang="en">British Antarctic Territory</narrative>
                 <narrative xml:lang="fr">Antarctique, Territoire britannique de l'</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1989-12-15">
-            <code>BU</code>
-            <name>
-                <narrative xml:lang="en">Burma</narrative>
-                <narrative xml:lang="fr">Birmanie</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2793,26 +2761,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1992-06-15">
-            <code>BY</code>
-            <name>
-                <narrative xml:lang="en">Byelorussian SSR</narrative>
-                <narrative xml:lang="fr">Bi&#233;lorussie, RSS de</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1992-06-15">
             <code>BYAA</code>
             <name>
                 <narrative xml:lang="en">Byelorussian SSR</narrative>
                 <narrative xml:lang="fr">Bi&#233;lorussie, RSS de</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="2006-09-26">
-            <code>CS</code>
-            <name>
-                <narrative xml:lang="en">Serbia and Montenegro</narrative>
-                <narrative xml:lang="fr">Serbie-et-Mont&#233;n&#233;gro</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2825,26 +2777,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1993-06-15">
-            <code>CS</code>
-            <name>
-                <narrative xml:lang="en">Czechoslovakia</narrative>
-                <narrative xml:lang="fr">Tch&#233;coslovaquie</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1993-06-15">
             <code>CSHH</code>
             <name>
                 <narrative xml:lang="en">Czechoslovakia</narrative>
                 <narrative xml:lang="fr">Tch&#233;coslovaquie</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1984-01-15">
-            <code>CT</code>
-            <name>
-                <narrative xml:lang="en">Canton and Enderbury Islands</narrative>
-                <narrative xml:lang="fr">Canton et Enderbury, &#206;les</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2857,26 +2793,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1990-12-04">
-            <code>DD</code>
-            <name>
-                <narrative xml:lang="en">German Democratic Republic</narrative>
-                <narrative xml:lang="fr">Allemande, R&#233;publique d&#233;mocratique</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1990-12-04">
             <code>DDDE</code>
             <name>
                 <narrative xml:lang="en">German Democratic Republic</narrative>
                 <narrative xml:lang="fr">Allemande, R&#233;publique d&#233;mocratique</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1977-08-01">
-            <code>DY</code>
-            <name>
-                <narrative xml:lang="en">Dahomey</narrative>
-                <narrative xml:lang="fr">Dahomey</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2889,26 +2809,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1981-05-15">
-            <code>FQ</code>
-            <name>
-                <narrative xml:lang="en">French Southern and Antarctic Territories</narrative>
-                <narrative xml:lang="fr">Australes et Antarctiques fran&#231;aises, Terres</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1981-05-15">
             <code>FQHH</code>
             <name>
                 <narrative xml:lang="en">French Southern and Antarctic Territories</narrative>
                 <narrative xml:lang="fr">Australes et Antarctiques fran&#231;aises, Terres</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1977-08-01">
-            <code>GE</code>
-            <name>
-                <narrative xml:lang="fr">Gilbert et Ellice, &#206;les</narrative>
-                <narrative xml:lang="en">Gilbert and Ellice Islands</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2921,26 +2825,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1984-11-30">
-            <code>HV</code>
-            <name>
-                <narrative xml:lang="en">Upper Volta</narrative>
-                <narrative xml:lang="fr">Haute-Volta</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1984-11-30">
             <code>HVBF</code>
             <name>
                 <narrative xml:lang="en">Upper Volta</narrative>
                 <narrative xml:lang="fr">Haute-Volta</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1986-07-14">
-            <code>JT</code>
-            <name>
-                <narrative xml:lang="en">Johnston Island</narrative>
-                <narrative xml:lang="fr">Johnston, &#206;le</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2953,26 +2841,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1986-07-14">
-            <code>MI</code>
-            <name>
-                <narrative xml:lang="en">Midway Islands</narrative>
-                <narrative xml:lang="fr">Midway, &#206;les</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1986-07-14">
             <code>MIUM</code>
             <name>
                 <narrative xml:lang="en">Midway Islands</narrative>
                 <narrative xml:lang="fr">Midway, &#206;les</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1980-01-15">
-            <code>NH</code>
-            <name>
-                <narrative xml:lang="en">New Hebrides</narrative>
-                <narrative xml:lang="fr">Nouvelles-H&#233;brides</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2985,26 +2857,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1983-01-15">
-            <code>NQ</code>
-            <name>
-                <narrative xml:lang="en">Dronning Maud Land</narrative>
-                <narrative xml:lang="fr">Terre de la Reine Maud</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1983-01-15">
             <code>NQAQ</code>
             <name>
                 <narrative xml:lang="en">Dronning Maud Land</narrative>
                 <narrative xml:lang="fr">Terre de la Reine Maud</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1993-07-12">
-            <code>NT</code>
-            <name>
-                <narrative xml:lang="en">Neutral Zone</narrative>
-                <narrative xml:lang="fr">Zone neutre</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -3017,26 +2873,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1986-01-15">
-            <code>PC</code>
-            <name>
-                <narrative xml:lang="en">Pacific Islands (Trust Territory)</narrative>
-                <narrative xml:lang="fr">Pacifique, &#206;les du (territoire sous tutelle)</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1986-01-15">
             <code>PCHH</code>
             <name>
                 <narrative xml:lang="en">Pacific Islands (Trust Territory)</narrative>
                 <narrative xml:lang="fr">Pacifique, &#206;les du (territoire sous tutelle)</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1986-07-14">
-            <code>PU</code>
-            <name>
-                <narrative xml:lang="en">United States Miscellaneous Pacific Islands</narrative>
-                <narrative xml:lang="fr">Pacifique, Diverses &#238;les du (&#201;tats-Unis)</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -3049,26 +2889,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1981-05-15">
-            <code>PZ</code>
-            <name>
-                <narrative xml:lang="en">Panama Canal Zone</narrative>
-                <narrative xml:lang="fr">Panama, Zone du Canal de</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1981-05-15">
             <code>PZPA</code>
             <name>
                 <narrative xml:lang="en">Panama Canal Zone</narrative>
                 <narrative xml:lang="fr">Panama, Zone du Canal de</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1980-01-15">
-            <code>RH</code>
-            <name>
-                <narrative xml:lang="en">Southern Rhodesia</narrative>
-                <narrative xml:lang="fr">Rhod&#233;sie du Sud</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -3081,26 +2905,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1977-08-01">
-            <code>SK</code>
-            <name>
-                <narrative xml:lang="en">Sikkim</narrative>
-                <narrative xml:lang="fr">Sikkim</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1977-08-01">
             <code>SKIN</code>
             <name>
                 <narrative xml:lang="en">Sikkim</narrative>
                 <narrative xml:lang="fr">Sikkim</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="2002-05-20">
-            <code>TP</code>
-            <name>
-                <narrative xml:lang="en">East Timor</narrative>
-                <narrative xml:lang="fr">Timor oriental</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -3113,26 +2921,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1977-08-01">
-            <code>VD</code>
-            <name>
-                <narrative xml:lang="en">Viet-Nam, Democratic Republic of</narrative>
-                <narrative xml:lang="fr">Viet-Nam, R&#233;publique d&#233;mocratique du</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1977-08-01">
             <code>VDVN</code>
             <name>
                 <narrative xml:lang="en">Viet-Nam, Democratic Republic of</narrative>
                 <narrative xml:lang="fr">Viet-Nam, R&#233;publique d&#233;mocratique du</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1986-07-14">
-            <code>WK</code>
-            <name>
-                <narrative xml:lang="fr">Wake, &#206;le de</narrative>
-                <narrative xml:lang="en">Wake Island</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -3145,14 +2937,6 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="1990-08-14">
-            <code>YD</code>
-            <name>
-                <narrative xml:lang="fr">Y&#233;men d&#233;mocratique</narrative>
-                <narrative xml:lang="en">Yemen, Democratic</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1990-08-14">
             <code>YDYE</code>
             <name>
                 <narrative xml:lang="fr">Y&#233;men d&#233;mocratique</narrative>
@@ -3161,26 +2945,10 @@
             <description/>
         </codelist-item>
         <codelist-item withdrawn="2003-07-23">
-            <code>YU</code>
-            <name>
-                <narrative xml:lang="fr">Yougoslavie</narrative>
-                <narrative xml:lang="en">Yugoslavia</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="2003-07-23">
             <code>YUCS</code>
             <name>
                 <narrative xml:lang="fr">Yougoslavie</narrative>
                 <narrative xml:lang="en">Yugoslavia</narrative>
-            </name>
-            <description/>
-        </codelist-item>
-        <codelist-item withdrawn="1997-07-14">
-            <code>ZR</code>
-            <name>
-                <narrative xml:lang="en">Zaire</narrative>
-                <narrative xml:lang="fr">Za&#239;re</narrative>
             </name>
             <description/>
         </codelist-item>

--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -2744,6 +2744,22 @@
             </name>
             <description/>
         </codelist-item>
+        <codelist-item withdrawn="2010-12-15">
+            <code>AN</code>
+            <name>
+                <narrative xml:lang="fr">Antilles n&#233;erlandaises (les&#160;) </narrative>
+                <narrative xml:lang="en">Netherlands Antilles</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="2010-12-15">
+            <code>ANHH</code>
+            <name>
+                <narrative xml:lang="fr">Antilles n&#233;erlandaises (les&#160;) </narrative>
+                <narrative xml:lang="en">Netherlands Antilles</narrative>
+            </name>
+            <description/>
+        </codelist-item>
         <codelist-item withdrawn="1981-05-15">
             <code>BQ</code>
             <name>
@@ -2760,6 +2776,22 @@
             </name>
             <description/>
         </codelist-item>
+        <codelist-item withdrawn="1989-12-15">
+            <code>BU</code>
+            <name>
+                <narrative xml:lang="en">Burma</narrative>
+                <narrative xml:lang="fr">Birmanie</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12-15">
+            <code>BUMM</code>
+            <name>
+                <narrative xml:lang="en">Burma</narrative>
+                <narrative xml:lang="fr">Birmanie</narrative>
+            </name>
+            <description/>
+        </codelist-item>
         <codelist-item withdrawn="1992-06-15">
             <code>BY</code>
             <name>
@@ -2773,6 +2805,22 @@
             <name>
                 <narrative xml:lang="en">Byelorussian SSR</narrative>
                 <narrative xml:lang="fr">Bi&#233;lorussie, RSS de</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="2006-09-26">
+            <code>CS</code>
+            <name>
+                <narrative xml:lang="en">Serbia and Montenegro</narrative>
+                <narrative xml:lang="fr">Serbie-et-Mont&#233;n&#233;gro</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="2006-09-26">
+            <code>CSXX</code>
+            <name>
+                <narrative xml:lang="en">Serbia and Montenegro</narrative>
+                <narrative xml:lang="fr">Serbie-et-Mont&#233;n&#233;gro</narrative>
             </name>
             <description/>
         </codelist-item>
@@ -2952,6 +3000,22 @@
             </name>
             <description/>
         </codelist-item>
+        <codelist-item withdrawn="1993-07-12">
+            <code>NT</code>
+            <name>
+                <narrative xml:lang="en">Neutral Zone</narrative>
+                <narrative xml:lang="fr">Zone neutre</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1993-07-12">
+            <code>NTHH</code>
+            <name>
+                <narrative xml:lang="en">Neutral Zone</narrative>
+                <narrative xml:lang="fr">Zone neutre</narrative>
+            </name>
+            <description/>
+        </codelist-item>
         <codelist-item withdrawn="1986-01-15">
             <code>PC</code>
             <name>
@@ -3032,6 +3096,22 @@
             </name>
             <description/>
         </codelist-item>
+        <codelist-item withdrawn="2002-05-20">
+            <code>TP</code>
+            <name>
+                <narrative xml:lang="en">East Timor</narrative>
+                <narrative xml:lang="fr">Timor oriental</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="2002-05-20">
+            <code>TPTL</code>
+            <name>
+                <narrative xml:lang="en">East Timor</narrative>
+                <narrative xml:lang="fr">Timor oriental</narrative>
+            </name>
+            <description/>
+        </codelist-item>
         <codelist-item withdrawn="1977-08-01">
             <code>VD</code>
             <name>
@@ -3077,6 +3157,38 @@
             <name>
                 <narrative xml:lang="fr">Y&#233;men d&#233;mocratique</narrative>
                 <narrative xml:lang="en">Yemen, Democratic</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="2003-07-23">
+            <code>YU</code>
+            <name>
+                <narrative xml:lang="fr">Yougoslavie</narrative>
+                <narrative xml:lang="en">Yugoslavia</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="2003-07-23">
+            <code>YUCS</code>
+            <name>
+                <narrative xml:lang="fr">Yougoslavie</narrative>
+                <narrative xml:lang="en">Yugoslavia</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1997-07-14">
+            <code>ZR</code>
+            <name>
+                <narrative xml:lang="en">Zaire</narrative>
+                <narrative xml:lang="fr">Za&#239;re</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1997-07-14">
+            <code>ZRCD</code>
+            <name>
+                <narrative xml:lang="en">Zaire</narrative>
+                <narrative xml:lang="fr">Za&#239;re</narrative>
             </name>
             <description/>
         </codelist-item>

--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -2728,6 +2728,358 @@
                 <narrative xml:lang="en">the Republic of Zimbabwe</narrative>
             </description>
         </codelist-item>
+        <codelist-item withdrawn="1978-07-15">
+            <code>AI</code>
+            <name>
+                <narrative xml:lang="en">French Afars and Issas</narrative>
+                <narrative xml:lang="fr">Afars et Issas</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1978-07-15">
+            <code>AIDJ</code>
+            <name>
+                <narrative xml:lang="en">French Afars and Issas</narrative>
+                <narrative xml:lang="fr">Afars et Issas</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1981-05-15">
+            <code>BQ</code>
+            <name>
+                <narrative xml:lang="en">British Antarctic Territory</narrative>
+                <narrative xml:lang="fr">Antarctique, Territoire britannique de l'</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1981-05-15">
+            <code>BQAQ</code>
+            <name>
+                <narrative xml:lang="en">British Antarctic Territory</narrative>
+                <narrative xml:lang="fr">Antarctique, Territoire britannique de l'</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1992-06-15">
+            <code>BY</code>
+            <name>
+                <narrative xml:lang="en">Byelorussian SSR</narrative>
+                <narrative xml:lang="fr">Bi&#233;lorussie, RSS de</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1992-06-15">
+            <code>BYAA</code>
+            <name>
+                <narrative xml:lang="en">Byelorussian SSR</narrative>
+                <narrative xml:lang="fr">Bi&#233;lorussie, RSS de</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1993-06-15">
+            <code>CS</code>
+            <name>
+                <narrative xml:lang="en">Czechoslovakia</narrative>
+                <narrative xml:lang="fr">Tch&#233;coslovaquie</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1993-06-15">
+            <code>CSHH</code>
+            <name>
+                <narrative xml:lang="en">Czechoslovakia</narrative>
+                <narrative xml:lang="fr">Tch&#233;coslovaquie</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1984-01-15">
+            <code>CT</code>
+            <name>
+                <narrative xml:lang="en">Canton and Enderbury Islands</narrative>
+                <narrative xml:lang="fr">Canton et Enderbury, &#206;les</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1984-01-15">
+            <code>CTKI</code>
+            <name>
+                <narrative xml:lang="en">Canton and Enderbury Islands</narrative>
+                <narrative xml:lang="fr">Canton et Enderbury, &#206;les</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1990-12-04">
+            <code>DD</code>
+            <name>
+                <narrative xml:lang="en">German Democratic Republic</narrative>
+                <narrative xml:lang="fr">Allemande, R&#233;publique d&#233;mocratique</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1990-12-04">
+            <code>DDDE</code>
+            <name>
+                <narrative xml:lang="en">German Democratic Republic</narrative>
+                <narrative xml:lang="fr">Allemande, R&#233;publique d&#233;mocratique</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>DY</code>
+            <name>
+                <narrative xml:lang="en">Dahomey</narrative>
+                <narrative xml:lang="fr">Dahomey</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>DYBJ</code>
+            <name>
+                <narrative xml:lang="en">Dahomey</narrative>
+                <narrative xml:lang="fr">Dahomey</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1981-05-15">
+            <code>FQ</code>
+            <name>
+                <narrative xml:lang="en">French Southern and Antarctic Territories</narrative>
+                <narrative xml:lang="fr">Australes et Antarctiques fran&#231;aises, Terres</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1981-05-15">
+            <code>FQHH</code>
+            <name>
+                <narrative xml:lang="en">French Southern and Antarctic Territories</narrative>
+                <narrative xml:lang="fr">Australes et Antarctiques fran&#231;aises, Terres</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>GE</code>
+            <name>
+                <narrative xml:lang="fr">Gilbert et Ellice, &#206;les</narrative>
+                <narrative xml:lang="en">Gilbert and Ellice Islands</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>GEHH</code>
+            <name>
+                <narrative xml:lang="fr">Gilbert et Ellice, &#206;les</narrative>
+                <narrative xml:lang="en">Gilbert and Ellice Islands</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1984-11-30">
+            <code>HV</code>
+            <name>
+                <narrative xml:lang="en">Upper Volta</narrative>
+                <narrative xml:lang="fr">Haute-Volta</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1984-11-30">
+            <code>HVBF</code>
+            <name>
+                <narrative xml:lang="en">Upper Volta</narrative>
+                <narrative xml:lang="fr">Haute-Volta</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>JT</code>
+            <name>
+                <narrative xml:lang="en">Johnston Island</narrative>
+                <narrative xml:lang="fr">Johnston, &#206;le</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>JTUM</code>
+            <name>
+                <narrative xml:lang="en">Johnston Island</narrative>
+                <narrative xml:lang="fr">Johnston, &#206;le</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>MI</code>
+            <name>
+                <narrative xml:lang="en">Midway Islands</narrative>
+                <narrative xml:lang="fr">Midway, &#206;les</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>MIUM</code>
+            <name>
+                <narrative xml:lang="en">Midway Islands</narrative>
+                <narrative xml:lang="fr">Midway, &#206;les</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1980-01-15">
+            <code>NH</code>
+            <name>
+                <narrative xml:lang="en">New Hebrides</narrative>
+                <narrative xml:lang="fr">Nouvelles-H&#233;brides</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1980-01-15">
+            <code>NHVU</code>
+            <name>
+                <narrative xml:lang="en">New Hebrides</narrative>
+                <narrative xml:lang="fr">Nouvelles-H&#233;brides</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1983-01-15">
+            <code>NQ</code>
+            <name>
+                <narrative xml:lang="en">Dronning Maud Land</narrative>
+                <narrative xml:lang="fr">Terre de la Reine Maud</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1983-01-15">
+            <code>NQAQ</code>
+            <name>
+                <narrative xml:lang="en">Dronning Maud Land</narrative>
+                <narrative xml:lang="fr">Terre de la Reine Maud</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-01-15">
+            <code>PC</code>
+            <name>
+                <narrative xml:lang="en">Pacific Islands (Trust Territory)</narrative>
+                <narrative xml:lang="fr">Pacifique, &#206;les du (territoire sous tutelle)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-01-15">
+            <code>PCHH</code>
+            <name>
+                <narrative xml:lang="en">Pacific Islands (Trust Territory)</narrative>
+                <narrative xml:lang="fr">Pacifique, &#206;les du (territoire sous tutelle)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>PU</code>
+            <name>
+                <narrative xml:lang="en">United States Miscellaneous Pacific Islands</narrative>
+                <narrative xml:lang="fr">Pacifique, Diverses &#238;les du (&#201;tats-Unis)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>PUUM</code>
+            <name>
+                <narrative xml:lang="en">United States Miscellaneous Pacific Islands</narrative>
+                <narrative xml:lang="fr">Pacifique, Diverses &#238;les du (&#201;tats-Unis)</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1981-05-15">
+            <code>PZ</code>
+            <name>
+                <narrative xml:lang="en">Panama Canal Zone</narrative>
+                <narrative xml:lang="fr">Panama, Zone du Canal de</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1981-05-15">
+            <code>PZPA</code>
+            <name>
+                <narrative xml:lang="en">Panama Canal Zone</narrative>
+                <narrative xml:lang="fr">Panama, Zone du Canal de</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1980-01-15">
+            <code>RH</code>
+            <name>
+                <narrative xml:lang="en">Southern Rhodesia</narrative>
+                <narrative xml:lang="fr">Rhod&#233;sie du Sud</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1980-01-15">
+            <code>RHZW</code>
+            <name>
+                <narrative xml:lang="en">Southern Rhodesia</narrative>
+                <narrative xml:lang="fr">Rhod&#233;sie du Sud</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>SK</code>
+            <name>
+                <narrative xml:lang="en">Sikkim</narrative>
+                <narrative xml:lang="fr">Sikkim</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>SKIN</code>
+            <name>
+                <narrative xml:lang="en">Sikkim</narrative>
+                <narrative xml:lang="fr">Sikkim</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>VD</code>
+            <name>
+                <narrative xml:lang="en">Viet-Nam, Democratic Republic of</narrative>
+                <narrative xml:lang="fr">Viet-Nam, R&#233;publique d&#233;mocratique du</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1977-08-01">
+            <code>VDVN</code>
+            <name>
+                <narrative xml:lang="en">Viet-Nam, Democratic Republic of</narrative>
+                <narrative xml:lang="fr">Viet-Nam, R&#233;publique d&#233;mocratique du</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>WK</code>
+            <name>
+                <narrative xml:lang="fr">Wake, &#206;le de</narrative>
+                <narrative xml:lang="en">Wake Island</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1986-07-14">
+            <code>WKUM</code>
+            <name>
+                <narrative xml:lang="fr">Wake, &#206;le de</narrative>
+                <narrative xml:lang="en">Wake Island</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1990-08-14">
+            <code>YD</code>
+            <name>
+                <narrative xml:lang="fr">Y&#233;men d&#233;mocratique</narrative>
+                <narrative xml:lang="en">Yemen, Democratic</narrative>
+            </name>
+            <description/>
+        </codelist-item>
+        <codelist-item withdrawn="1990-08-14">
+            <code>YDYE</code>
+            <name>
+                <narrative xml:lang="fr">Y&#233;men d&#233;mocratique</narrative>
+                <narrative xml:lang="en">Yemen, Democratic</narrative>
+            </name>
+            <description/>
+        </codelist-item>
     </codelist-items>
 </codelist>
 

--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -7,6 +7,12 @@
     </metadata>
     <codelist-items>
         <codelist-item>
+            <code>XK</code>
+            <name>
+                <narrative xml:lang="en">Kosovo</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
             <code>AD</code>
             <name>
                 <narrative xml:lang="ca">Andorra</narrative>

--- a/xml/Currency.xml
+++ b/xml/Currency.xml
@@ -246,7 +246,7 @@
         <codelist-item>
             <code>CVE</code>
             <name>
-                <narrative>Cape Verde Escudo</narrative>
+                <narrative>Cabo Verde Escudo</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -529,12 +529,6 @@
             <code>LSL</code>
             <name>
                 <narrative>Loti</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
-            <code>LTL</code>
-            <name>
-                <narrative>Lithuanian Litas</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -1079,6 +1073,738 @@
         </codelist-item>
         <codelist-item>
             <code>ZWL</code>
+            <name>
+                <narrative>Zimbabwe Dollar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2003-07">
+            <code>ADP</code>
+            <name>
+                <narrative>Andorran Peseta</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2003-01">
+            <code>AFA</code>
+            <name>
+                <narrative>Afghani</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>ALK</code>
+            <name>
+                <narrative>Old Lek</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1991-03">
+            <code>AOK</code>
+            <name>
+                <narrative>Kwanza</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2000-02">
+            <code>AON</code>
+            <name>
+                <narrative>New Kwanza</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2000-02">
+            <code>AOR</code>
+            <name>
+                <narrative>Kwanza Reajustado</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1992-01">
+            <code>ARA</code>
+            <name>
+                <narrative>Austral</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1985-07">
+            <code>ARP</code>
+            <name>
+                <narrative>Peso Argentino</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>ARY</code>
+            <name>
+                <narrative>Peso</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>ATS</code>
+            <name>
+                <narrative>Schilling</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2005-10">
+            <code>AYM</code>
+            <name>
+                <narrative>Azerbaijan Manat</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2005-12">
+            <code>AZM</code>
+            <name>
+                <narrative>Azerbaijanian Manat</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1997-07">
+            <code>BAD</code>
+            <name>
+                <narrative>Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-03">
+            <code>BEC</code>
+            <name>
+                <narrative>Convertible Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>BEF</code>
+            <name>
+                <narrative>Belgian Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-03">
+            <code>BEL</code>
+            <name>
+                <narrative>Financial Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>BGJ</code>
+            <name>
+                <narrative>Lev A/52</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>BGK</code>
+            <name>
+                <narrative>Lev A/62</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2003-11">
+            <code>BGL</code>
+            <name>
+                <narrative>Lev</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1987-02">
+            <code>BOP</code>
+            <name>
+                <narrative>Peso boliviano</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1986-03">
+            <code>BRB</code>
+            <name>
+                <narrative>Cruzeiro</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-02">
+            <code>BRC</code>
+            <name>
+                <narrative>Cruzado</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1993-03">
+            <code>BRE</code>
+            <name>
+                <narrative>Cruzeiro</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-03">
+            <code>BRN</code>
+            <name>
+                <narrative>New Cruzado</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1994-07">
+            <code>BRR</code>
+            <name>
+                <narrative>Cruzeiro Real</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-02">
+            <code>BUK</code>
+            <name>
+                <narrative>N.A.</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2001-01">
+            <code>BYB</code>
+            <name>
+                <narrative>Belarussian Ruble</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2004-11">
+            <code>CHC</code>
+            <name>
+                <narrative>WIR Franc (for electronic)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>CNX</code>
+            <name>
+                <narrative>Peoples Bank Dollar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2006-10">
+            <code>CSD</code>
+            <name>
+                <narrative>Serbian Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>CSJ</code>
+            <name>
+                <narrative>Krona A/53</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1993-03">
+            <code>CSK</code>
+            <name>
+                <narrative>Koruna</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2008-01">
+            <code>CYP</code>
+            <name>
+                <narrative>Cyprus Pound</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-07 to 1990-09">
+            <code>DDM</code>
+            <name>
+                <narrative>Mark der DDR</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>DEM</code>
+            <name>
+                <narrative>Deutsche Mark</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2000-09">
+            <code>ECS</code>
+            <name>
+                <narrative>Sucre</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2000-09">
+            <code>ECV</code>
+            <name>
+                <narrative>Unidad de Valor Constante (UVC)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2011-01">
+            <code>EEK</code>
+            <name>
+                <narrative>Kroon</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>EQE</code>
+            <name>
+                <narrative>Ekwele</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1978 to 1981">
+            <code>ESA</code>
+            <name>
+                <narrative>Spanish Peseta</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1994-12">
+            <code>ESB</code>
+            <name>
+                <narrative>"A" Account (convertible Peseta Account)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>ESP</code>
+            <name>
+                <narrative>Spanish Peseta</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>FIM</code>
+            <name>
+                <narrative>Markka</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>FRF</code>
+            <name>
+                <narrative>French Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1995-10">
+            <code>GEK</code>
+            <name>
+                <narrative>Georgian Coupon</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2008-01">
+            <code>GHC</code>
+            <name>
+                <narrative>Cedi</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2007-06">
+            <code>GHP</code>
+            <name>
+                <narrative>Ghana Cedi</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>GNE</code>
+            <name>
+                <narrative>Syli</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1986-02">
+            <code>GNS</code>
+            <name>
+                <narrative>Syli</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1986-06">
+            <code>GQE</code>
+            <name>
+                <narrative>Ekwele</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>GRD</code>
+            <name>
+                <narrative>Drachma</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1978 to 1981">
+            <code>GWE</code>
+            <name>
+                <narrative>Guinea Escudo</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1997-05">
+            <code>GWP</code>
+            <name>
+                <narrative>Guinea-Bissau Peso</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1995-01">
+            <code>HRD</code>
+            <name>
+                <narrative>Croatian Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>IEP</code>
+            <name>
+                <narrative>Irish Pound</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1978 to 1981">
+            <code>ILP</code>
+            <name>
+                <narrative>Pound</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>ILR</code>
+            <name>
+                <narrative>Old Shekel</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>ISJ</code>
+            <name>
+                <narrative>Old Krona</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>ITL</code>
+            <name>
+                <narrative>Italian Lira</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>LAJ</code>
+            <name>
+                <narrative>Kip Pot Pol</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1985-05">
+            <code>LSM</code>
+            <name>
+                <narrative>Maloti</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2014-12">
+            <code>LTL</code>
+            <name>
+                <narrative>Lithuanian Litas</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1993-07">
+            <code>LTT</code>
+            <name>
+                <narrative>Talonas</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-03">
+            <code>LUC</code>
+            <name>
+                <narrative>Luxembourg Convertible Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>LUF</code>
+            <name>
+                <narrative>Luxembourg Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-03">
+            <code>LUL</code>
+            <name>
+                <narrative>Luxembourg Financial Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2014-01">
+            <code>LVL</code>
+            <name>
+                <narrative>Latvian Lats</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1994-12">
+            <code>LVR</code>
+            <name>
+                <narrative>Latvian Ruble</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>MAF</code>
+            <name>
+                <narrative>Mali Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2004-12">
+            <code>MGF</code>
+            <name>
+                <narrative>Malagasy Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1984-11">
+            <code>MLF</code>
+            <name>
+                <narrative>Mali Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2008-01">
+            <code>MTL</code>
+            <name>
+                <narrative>Maltese Lira</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1983-06">
+            <code>MTP</code>
+            <name>
+                <narrative>Maltese Pound</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>MVQ</code>
+            <name>
+                <narrative>Maldive Rupee</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1993-01">
+            <code>MXP</code>
+            <name>
+                <narrative>Mexican Peso</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1978 to 1981">
+            <code>MZE</code>
+            <name>
+                <narrative>Mozambique Escudo</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2006-06">
+            <code>MZM</code>
+            <name>
+                <narrative>Mozambique Metical</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-10">
+            <code>NIC</code>
+            <name>
+                <narrative>Cordoba</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>NLG</code>
+            <name>
+                <narrative>Netherlands Guilder</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>PEH</code>
+            <name>
+                <narrative>Sol</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1991-07">
+            <code>PEI</code>
+            <name>
+                <narrative>Inti</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1986-02">
+            <code>PES</code>
+            <name>
+                <narrative>Sol</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1997-01">
+            <code>PLZ</code>
+            <name>
+                <narrative>Zloty</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-03">
+            <code>PTE</code>
+            <name>
+                <narrative>Portuguese Escudo</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1978 to 1981">
+            <code>RHD</code>
+            <name>
+                <narrative>Rhodesian Dollar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>ROK</code>
+            <name>
+                <narrative>Leu A/52</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2005-06">
+            <code>ROL</code>
+            <name>
+                <narrative>Old Leu</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1994-08">
+            <code>RUR</code>
+            <name>
+                <narrative>Russian Ruble</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2007-07">
+            <code>SDD</code>
+            <name>
+                <narrative>Sudanese Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1998-06">
+            <code>SDP</code>
+            <name>
+                <narrative>Sudanese Pound</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2007-01">
+            <code>SIT</code>
+            <name>
+                <narrative>Tolar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2009-01">
+            <code>SKK</code>
+            <name>
+                <narrative>Slovak Koruna</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2003-12">
+            <code>SRG</code>
+            <name>
+                <narrative>Surinam Guilder</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-12">
+            <code>SUR</code>
+            <name>
+                <narrative>Rouble</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2001-04">
+            <code>TJR</code>
+            <name>
+                <narrative>Tajik Ruble</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2009-01">
+            <code>TMM</code>
+            <name>
+                <narrative>Turkmenistan Manat</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2002-11">
+            <code>TPE</code>
+            <name>
+                <narrative>Timor Escudo</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2005-12">
+            <code>TRL</code>
+            <name>
+                <narrative>Old Turkish Lira</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1996-09">
+            <code>UAK</code>
+            <name>
+                <narrative>Karbovanet</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1987-05">
+            <code>UGS</code>
+            <name>
+                <narrative>Uganda Shilling</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989 to 1990">
+            <code>UGW</code>
+            <name>
+                <narrative>Old Shilling</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2014-03">
+            <code>USS</code>
+            <name>
+                <narrative>US Dollar (Same day)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>UYN</code>
+            <name>
+                <narrative>Old Uruguay Peso</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1993-03">
+            <code>UYP</code>
+            <name>
+                <narrative>Uruguayan Peso</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2008-01">
+            <code>VEB</code>
+            <name>
+                <narrative>Bolivar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-1990">
+            <code>VNC</code>
+            <name>
+                <narrative>Old Dong</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1999-01">
+            <code>XEU</code>
+            <name>
+                <narrative>European Currency Unit (E.C.U)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2006-10">
+            <code>XFO</code>
+            <name>
+                <narrative>Gold-Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2013-11">
+            <code>XFU</code>
+            <name>
+                <narrative>UIC-Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1999-11">
+            <code>XRE</code>
+            <name>
+                <narrative>RINET Funds Code</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1991-09">
+            <code>YDD</code>
+            <name>
+                <narrative>Yemeni Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1990-01">
+            <code>YUD</code>
+            <name>
+                <narrative>New Yugoslavian Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2003-07">
+            <code>YUM</code>
+            <name>
+                <narrative>New Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1995-11">
+            <code>YUN</code>
+            <name>
+                <narrative>Yugoslavian Dinar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1995-03">
+            <code>ZAL</code>
+            <name>
+                <narrative>Financial Rand</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2012-12">
+            <code>ZMK</code>
+            <name>
+                <narrative>Zambian Kwacha</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1999-06">
+            <code>ZRN</code>
+            <name>
+                <narrative>New Zaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1994-02">
+            <code>ZRZ</code>
+            <name>
+                <narrative>Zaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="1989-12">
+            <code>ZWC</code>
+            <name>
+                <narrative>Rhodesian Dollar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2006-08">
+            <code>ZWD</code>
+            <name>
+                <narrative>Zimbabwe Dollar (old)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2006-09">
+            <code>ZWN</code>
+            <name>
+                <narrative>Zimbabwe Dollar (new)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item withdrawn="2009-06">
+            <code>ZWR</code>
             <name>
                 <narrative>Zimbabwe Dollar</narrative>
             </name>

--- a/xml/Currency.xml
+++ b/xml/Currency.xml
@@ -1,7 +1,7 @@
 <codelist name="Currency" xml:lang="en" complete="1">
     <metadata>
         <name>
-            <narrative>Currency</narrative>
+            <narrative>&gt;Currency</narrative>
         </name>
         <description>
             <narrative>ISO 4217 Currency used for all transactions and budgets</narrative>
@@ -36,7 +36,7 @@
         <codelist-item>
             <code>ANG</code>
             <name>
-                <narrative>Netherlands Antillian Guilder</narrative>
+                <narrative>Netherlands Antillean Guilder</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -60,7 +60,7 @@
         <codelist-item>
             <code>AWG</code>
             <name>
-                <narrative>Aruban Guilder</narrative>
+                <narrative>Aruban Florin</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -72,7 +72,7 @@
         <codelist-item>
             <code>BAM</code>
             <name>
-                <narrative>Convertible Marks</narrative>
+                <narrative>Convertible Mark</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -178,15 +178,27 @@
             </name>
         </codelist-item>
         <codelist-item>
+            <code>CHE</code>
+            <name>
+                <narrative>WIR Euro</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
             <code>CHF</code>
             <name>
                 <narrative>Swiss Franc</narrative>
             </name>
         </codelist-item>
         <codelist-item>
+            <code>CHW</code>
+            <name>
+                <narrative>WIR Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
             <code>CLF</code>
             <name>
-                <narrative>Unidades de fomento</narrative>
+                <narrative>Unidad de Fomento</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -268,12 +280,6 @@
             </name>
         </codelist-item>
         <codelist-item>
-            <code>EEK</code>
-            <name>
-                <narrative>Kroon</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
             <code>EGP</code>
             <name>
                 <narrative>Egyptian Pound</narrative>
@@ -324,7 +330,7 @@
         <codelist-item>
             <code>GHS</code>
             <name>
-                <narrative>Cedi</narrative>
+                <narrative>Ghana Cedi</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -532,12 +538,6 @@
             </name>
         </codelist-item>
         <codelist-item>
-            <code>LVL</code>
-            <name>
-                <narrative>Latvian Lats</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
             <code>LYD</code>
             <name>
                 <narrative>Libyan Dinar</narrative>
@@ -606,7 +606,7 @@
         <codelist-item>
             <code>MWK</code>
             <name>
-                <narrative>Malawi Kwacha</narrative>
+                <narrative>Kwacha</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -630,7 +630,7 @@
         <codelist-item>
             <code>MZN</code>
             <name>
-                <narrative>Metical</narrative>
+                <narrative>Mozambique Metical</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -726,7 +726,7 @@
         <codelist-item>
             <code>RON</code>
             <name>
-                <narrative>New Leu</narrative>
+                <narrative>New Romanian Leu</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -802,15 +802,15 @@
             </name>
         </codelist-item>
         <codelist-item>
-            <code>SSP</code>
-            <name>
-                <narrative>South Sudanese Pound</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
             <code>SRD</code>
             <name>
                 <narrative>Surinam Dollar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>SSP</code>
+            <name>
+                <narrative>South Sudanese Pound</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -852,7 +852,7 @@
         <codelist-item>
             <code>TMT</code>
             <name>
-                <narrative>Manat</narrative>
+                <narrative>Turkmenistan New Manat</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -864,7 +864,7 @@
         <codelist-item>
             <code>TOP</code>
             <name>
-                <narrative>Paanga</narrative>
+                <narrative>Pa&#8217;anga</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -916,15 +916,9 @@
             </name>
         </codelist-item>
         <codelist-item>
-            <code>USS</code>
-            <name>
-                <narrative>US Dollar (Same day)</narrative>
-            </name>
-        </codelist-item>
-        <codelist-item>
             <code>UYI</code>
             <name>
-                <narrative>Uruguay Peso en Unidades Indexadas</narrative>
+                <narrative>Uruguay Peso en Unidades Indexadas (URUIURUI)</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -970,9 +964,51 @@
             </name>
         </codelist-item>
         <codelist-item>
+            <code>XAG</code>
+            <name>
+                <narrative>Silver</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XAU</code>
+            <name>
+                <narrative>Gold</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XBA</code>
+            <name>
+                <narrative>Bond Markets Unit European Composite Unit (EURCO)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XBB</code>
+            <name>
+                <narrative>Bond Markets Unit European Monetary Unit (E.M.U.-6)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XBC</code>
+            <name>
+                <narrative>Bond Markets Unit European Unit of Account 9 (E.U.A.-9)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XBD</code>
+            <name>
+                <narrative>Bond Markets Unit European Unit of Account 17 (E.U.A.-17)</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
             <code>XCD</code>
             <name>
                 <narrative>East Caribbean Dollar</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XDR</code>
+            <name>
+                <narrative>SDR (Special Drawing Right)</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -982,9 +1018,45 @@
             </name>
         </codelist-item>
         <codelist-item>
+            <code>XPD</code>
+            <name>
+                <narrative>Palladium</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
             <code>XPF</code>
             <name>
                 <narrative>CFP Franc</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XPT</code>
+            <name>
+                <narrative>Platinum</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XSU</code>
+            <name>
+                <narrative>Sucre</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XTS</code>
+            <name>
+                <narrative>Codes specifically reserved for testing purposes</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XUA</code>
+            <name>
+                <narrative>ADB Unit of Account</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>XXX</code>
+            <name>
+                <narrative>The codes assigned for transactions where no currency is involved</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -1000,7 +1072,7 @@
             </name>
         </codelist-item>
         <codelist-item>
-            <code>ZMK</code>
+            <code>ZMW</code>
             <name>
                 <narrative>Zambian Kwacha</narrative>
             </name>
@@ -1013,3 +1085,4 @@
         </codelist-item>
     </codelist-items>
 </codelist>
+

--- a/xml/Currency.xml
+++ b/xml/Currency.xml
@@ -1,7 +1,7 @@
 <codelist name="Currency" xml:lang="en" complete="1">
     <metadata>
         <name>
-            <narrative>&gt;Currency</narrative>
+            <narrative>Currency</narrative>
         </name>
         <description>
             <narrative>ISO 4217 Currency used for all transactions and budgets</narrative>

--- a/xml/FileFormat.xml
+++ b/xml/FileFormat.xml
@@ -1074,7 +1074,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/smil - OBSOLETED in favor of application/smil+xml</code>
+            <code>application/smil</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1370,7 +1370,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.arastra.swi - OBSOLETED in favor of application/vnd.aristanetworks.swi</code>
+            <code>application/vnd.arastra.swi</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2042,7 +2042,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.geocube+xml - OBSOLETED by request</code>
+            <code>application/vnd.geocube+xml</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2078,7 +2078,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.gmx - DEPRECATED</code>
+            <code>application/vnd.gmx</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2290,7 +2290,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.informix-visionary - OBSOLETED in favor of application/vnd.visionary</code>
+            <code>application/vnd.informix-visionary</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2930,7 +2930,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.nokia.n-gage.symbian.install - OBSOLETE; no replacement given</code>
+            <code>application/vnd.nokia.n-gage.symbian.install</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -4434,7 +4434,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/xhtml-voice+xml - OBSOLETE; no replacement given</code>
+            <code>application/xhtml-voice+xml</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -5022,7 +5022,7 @@
             <category>audio</category>
         </codelist-item>
         <codelist-item>
-            <code>audio/vnd.qcelp - DEPRECATED in favor of audio/qcelp</code>
+            <code>audio/vnd.qcelp</code>
             <category>audio</category>
         </codelist-item>
         <codelist-item>
@@ -5286,7 +5286,7 @@
             <category>message</category>
         </codelist-item>
         <codelist-item>
-            <code>message/news - OBSOLETED by RFC5537</code>
+            <code>message/news</code>
             <category>message</category>
         </codelist-item>
         <codelist-item>
@@ -5314,7 +5314,7 @@
             <category>message</category>
         </codelist-item>
         <codelist-item>
-            <code>message/vnd.si.simp - OBSOLETED by request</code>
+            <code>message/vnd.si.simp</code>
             <category>message</category>
         </codelist-item>
         <codelist-item>
@@ -5486,7 +5486,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/directory - DEPRECATED by RFC6350</code>
+            <code>text/directory</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5494,7 +5494,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/ecmascript - OBSOLETED in favor of application/ecmascript</code>
+            <code>text/ecmascript</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5522,7 +5522,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/javascript - OBSOLETED in favor of application/javascript</code>
+            <code>text/javascript</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5530,7 +5530,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/markdown (TEMPORARY - registered 2014-11-11, expires 2015-11-11)</code>
+            <code>text/markdown</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5706,7 +5706,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/vnd.si.uricatalogue - OBSOLETED by request</code>
+            <code>text/vnd.si.uricatalogue</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>

--- a/xml/FileFormat.xml
+++ b/xml/FileFormat.xml
@@ -14,7 +14,15 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/3gpdash-qoe-report+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/3gpp-ims+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/A2L</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -66,11 +74,23 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/AML</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/andrew-inset</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
             <code>application/applefile</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/ATF</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/ATFX</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -91,6 +111,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/atomsvc+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/ATXML</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -138,6 +162,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/CDFX+XML</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/cdmi-capability</code>
             <category>application</category>
         </codelist-item>
@@ -158,6 +186,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/CEA</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/cea-2018+xml</code>
             <category>application</category>
         </codelist-item>
@@ -175,6 +207,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/cnrp+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/coap-group+json</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -222,6 +258,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/DCD</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/dec-dx</code>
             <category>application</category>
         </codelist-item>
@@ -231,6 +271,14 @@
         </codelist-item>
         <codelist-item>
             <code>application/dicom</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/DII</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/DIT</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -283,6 +331,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/epp+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/epub+zip</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -418,6 +470,14 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/jose</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/jose+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/jrd+json</code>
             <category>application</category>
         </codelist-item>
@@ -427,6 +487,22 @@
         </codelist-item>
         <codelist-item>
             <code>application/json-patch+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/json-seq</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/jwk+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/jwk-set+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/jwt</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -455,6 +531,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/lostsync+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/LXF</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -554,11 +634,19 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/merge-patch+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/metalink4+xml</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
             <code>application/mets+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/MF4</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -822,6 +910,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/rdap+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/reginfo+xml</code>
             <category>application</category>
         </codelist-item>
@@ -895,6 +987,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/sbml+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/scaip+xml</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -978,7 +1074,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/smil</code>
+            <code>application/smil - OBSOLETED in favor of application/smil+xml</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1250,6 +1346,18 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.apache.thrift.binary</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.apache.thrift.compact</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.apache.thrift.json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.api+json</code>
             <category>application</category>
         </codelist-item>
@@ -1262,11 +1370,15 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.arastra.swi</code>
+            <code>application/vnd.arastra.swi - OBSOLETED in favor of application/vnd.aristanetworks.swi</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
             <code>application/vnd.aristanetworks.swi</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.artsquare</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1370,6 +1482,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.coffeescript</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.collection.doc+json</code>
             <category>application</category>
         </codelist-item>
@@ -1470,6 +1586,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.debian.binary-package</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.dece.data</code>
             <category>application</category>
         </codelist-item>
@@ -1515,6 +1635,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.dolby.mobile.2</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.doremir.scorecloud-binary-document</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1622,6 +1746,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.dzr</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.easykaraoke.cdgdownload</code>
             <category>application</category>
         </codelist-item>
@@ -1659,6 +1787,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.enliven</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.enphase.envoy</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1906,7 +2038,11 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.geocube+xml</code>
+            <code>application/vnd.geo+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.geocube+xml - OBSOLETED by request</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1942,7 +2078,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.gmx</code>
+            <code>application/vnd.gmx - DEPRECATED</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -1951,6 +2087,14 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.google-earth.kmz</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.gov.sk.e-form+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.gov.sk.e-form+zip</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2098,6 +2242,42 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.ims.imsccv1p1</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.imsccv1p2</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.imsccv1p3</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.lis.v2.result+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.lti.v2.toolconsumerprofile+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.lti.v2.toolproxy.id+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.lti.v2.toolproxy+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.lti.v2.toolsettings+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ims.lti.v2.toolsettings.simple+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.informedcontrol.rms+xml</code>
             <category>application</category>
         </codelist-item>
@@ -2110,7 +2290,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.informix-visionary</code>
+            <code>application/vnd.informix-visionary - OBSOLETED in favor of application/vnd.visionary</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2366,6 +2546,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.maxmind.maxmind-db</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.mcd</code>
             <category>application</category>
         </codelist-item>
@@ -2395,6 +2579,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.micrografx.igx</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.miele+json</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2494,7 +2682,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.mseq</code>
+            <code>application/vnd.ms-3mfdocument</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2618,6 +2806,14 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.msa-disk-image</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.mseq</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.msign</code>
             <category>application</category>
         </codelist-item>
@@ -2734,7 +2930,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/vnd.nokia.n-gage.symbian.install</code>
+            <code>application/vnd.nokia.n-gage.symbian.install - OBSOLETE; no replacement given</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -2771,6 +2967,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.ntt-local.file-transfer</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.ntt-local.ogw_remote-access</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -3362,6 +3562,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.oracle.resource+json</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.orange.indata</code>
             <category>application</category>
         </codelist-item>
@@ -3391,6 +3595,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.palm</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.panoply</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -3818,6 +4026,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.tmd.mediaflex.api+xml</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.tmobile-livetv</code>
             <category>application</category>
         </codelist-item>
@@ -3911,6 +4123,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/vnd.uplanet.signal</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/vnd.valve.source.material</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -4114,6 +4330,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/vnd.yaoweme</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/vnd.yellowriver-custom-menu</code>
             <category>application</category>
         </codelist-item>
@@ -4166,6 +4386,10 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
+            <code>application/x-www-form-urlencoded</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
             <code>application/x400-bp</code>
             <category>application</category>
         </codelist-item>
@@ -4210,7 +4434,7 @@
             <category>application</category>
         </codelist-item>
         <codelist-item>
-            <code>application/xhtml-voice+xml</code>
+            <code>application/xhtml-voice+xml - OBSOLETE; no replacement given</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -4227,6 +4451,10 @@
         </codelist-item>
         <codelist-item>
             <code>application/xml-external-parsed-entity</code>
+            <category>application</category>
+        </codelist-item>
+        <codelist-item>
+            <code>application/xml-patch+xml</code>
             <category>application</category>
         </codelist-item>
         <codelist-item>
@@ -4290,7 +4518,11 @@
             <category>audio</category>
         </codelist-item>
         <codelist-item>
-            <code>audio/amr-wb</code>
+            <code>audio/amr-wb+</code>
+            <category>audio</category>
+        </codelist-item>
+        <codelist-item>
+            <code>audio/aptx</code>
             <category>audio</category>
         </codelist-item>
         <codelist-item>
@@ -4434,11 +4666,11 @@
             <category>audio</category>
         </codelist-item>
         <codelist-item>
-            <code>audio/G722</code>
+            <code>audio/G7221</code>
             <category>audio</category>
         </codelist-item>
         <codelist-item>
-            <code>audio/G7221</code>
+            <code>audio/G722</code>
             <category>audio</category>
         </codelist-item>
         <codelist-item>
@@ -4790,7 +5022,7 @@
             <category>audio</category>
         </codelist-item>
         <codelist-item>
-            <code>audio/vnd.qcelp</code>
+            <code>audio/vnd.qcelp - DEPRECATED in favor of audio/qcelp</code>
             <category>audio</category>
         </codelist-item>
         <codelist-item>
@@ -4990,6 +5222,10 @@
             <category>image</category>
         </codelist-item>
         <codelist-item>
+            <code>image/vnd.tencent.tap</code>
+            <category>image</category>
+        </codelist-item>
+        <codelist-item>
             <code>image/vnd.valve.source.texture</code>
             <category>image</category>
         </codelist-item>
@@ -5050,7 +5286,7 @@
             <category>message</category>
         </codelist-item>
         <codelist-item>
-            <code>message/news</code>
+            <code>message/news - OBSOLETED by RFC5537</code>
             <category>message</category>
         </codelist-item>
         <codelist-item>
@@ -5078,7 +5314,7 @@
             <category>message</category>
         </codelist-item>
         <codelist-item>
-            <code>message/vnd.si.simp</code>
+            <code>message/vnd.si.simp - OBSOLETED by request</code>
             <category>message</category>
         </codelist-item>
         <codelist-item>
@@ -5130,11 +5366,19 @@
             <category>model</category>
         </codelist-item>
         <codelist-item>
+            <code>model/vnd.opengex</code>
+            <category>model</category>
+        </codelist-item>
+        <codelist-item>
             <code>model/vnd.parasolid.transmit.binary</code>
             <category>model</category>
         </codelist-item>
         <codelist-item>
             <code>model/vnd.parasolid.transmit.text</code>
+            <category>model</category>
+        </codelist-item>
+        <codelist-item>
+            <code>model/vnd.valve.source.compiled-map</code>
             <category>model</category>
         </codelist-item>
         <codelist-item>
@@ -5214,7 +5458,15 @@
             <category>multipart</category>
         </codelist-item>
         <codelist-item>
+            <code>multipart/x-mixed-replace</code>
+            <category>multipart</category>
+        </codelist-item>
+        <codelist-item>
             <code>text/1d-interleaved-parityfec</code>
+            <category>text</category>
+        </codelist-item>
+        <codelist-item>
+            <code>text/cache-manifest</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5230,7 +5482,11 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/directory</code>
+            <code>text/csv-schema</code>
+            <category>text</category>
+        </codelist-item>
+        <codelist-item>
+            <code>text/directory - DEPRECATED by RFC6350</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5238,7 +5494,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/ecmascript</code>
+            <code>text/ecmascript - OBSOLETED in favor of application/ecmascript</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5266,11 +5522,15 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/javascript</code>
+            <code>text/javascript - OBSOLETED in favor of application/javascript</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
             <code>text/jcr-cnd</code>
+            <category>text</category>
+        </codelist-item>
+        <codelist-item>
+            <code>text/markdown (TEMPORARY - registered 2014-11-11, expires 2015-11-11)</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5446,7 +5706,7 @@
             <category>text</category>
         </codelist-item>
         <codelist-item>
-            <code>text/vnd.si.uricatalogue</code>
+            <code>text/vnd.si.uricatalogue - OBSOLETED by request</code>
             <category>text</category>
         </codelist-item>
         <codelist-item>
@@ -5562,7 +5822,7 @@
             <category>video</category>
         </codelist-item>
         <codelist-item>
-            <code>video/MJ2</code>
+            <code>video/mj2</code>
             <category>video</category>
         </codelist-item>
         <codelist-item>
@@ -5787,3 +6047,4 @@
         </codelist-item>
     </codelist-items>
 </codelist>
+


### PR DESCRIPTION
The work done here means that the Country, Currency and FileFormat codelists can now be pulled from source programmatically. 

Where IATI derives codelists from external sources we are aiming to pull those codes automatically and directly from their source. However, when those external sources delete or remove values we need to consider how we handle that. (We also need to consider the cases where IATI has agreed to add additional values not in the source e.g. XK=Kosovo on the Country codelist)

We are using the term 'withdrawn' to deal with codes that have been removed from the current source lists. We may also refer to these as historic codes.

We need to make these withdrawn, or historic, values available to data users that wish to report older data. Adding withdrawn codes is important, as it ensures that codes currently in use (and in historical data) are valid against the codelist, even though they may have been subsequently withdrawn.

In the case of the ISO Country and ISO currency sources, they have clearly defined ways of dealing with withdrawn values. Both source lists maintain their own list of withdrawn values, which we plan to now import. **As a result, this pull request adds  a large number of new (withdrawn) codes to these lists.** Consequently, this pull request increases the country codelist from 251 to 308 codes in total; and the Currency codelist from 167 to 300 codes in total.

 When we add a withdrawn value to the IATI codelists we flag it by adding a `withdrawn` attribute on the `codelist-item` element in the XML. (This has been changed in the codelist schema - see below).

As a result of adding withdrawn codes, this pull request doesn't remove any codes from the Country and Currency lists (but some existing codes may be listed as withdrawn if that is true in the ISO source lists). 
#### Impact for codelist users

Once this change is accepted anyone parsing the XML codelists will, by default, see all the entries in their results - e.g. a drop down selection list will contain all entries. To exclude withdrawn entries you will need to specifically request 'not withdrawn' values.

As the codelist API currently stands, consumers of the JSON and CSV, CLv1 XML, CLv2 XML versions of codelists will not yet see the withdrawn attribute and therefore be unable to tell which are current values. However, we plan to address this before the change goes live: https://github.com/IATI/IATI-Codelists/issues/79
#### Altering the codelist XML Schema

The withdrawn attribute should also be added to the xsd in the main codelists repository, see https://github.com/IATI/IATI-Codelists/pull/78. The withdrawn attribute contains whatever information the source has about when the code withdrawn, so the format is not specified in the schema.
#### Handling IATI specific codes

Any IATI specific codes should are maintained by adding them to the codelist template file. e.g.
XK - https://github.com/IATI/IATI-Codelists-NonEmbedded/blob/9-historical-codes/templates/Country.xml#L10
#### Country codelist note

This has had the withdrawn two letter codes added (which are only guaranteed to not be reused for 50 years), and the new 4 letter codes that these countries are assigned when withdrawn (see https://en.wikipedia.org/wiki/ISO_3166-3 for more information).
#### Renames on the IANA Media Types list (used for FileFormat)

`audio/amr-wb` -> `audio/AMR-WB`
`video/MJ2` - > `video/mj2`

These are partly because IANA does not treat their codes as case sensitive. In order to maintain faithfullness to the source list, and because no-one is using these codes, I suggest that in this case we make these renames on the FileFormat list without maintaining the old codes as withdrawn.
#### Relevant GitHub issues

This pull request resolves the following GitHub issues:
- [Pull more external codelists from their source programmatically](https://github.com/IATI/IATI-Codelists-NonEmbedded/issues/8)
- [Look into including historical data in non-embedded codelists](https://github.com/IATI/IATI-Codelists-NonEmbedded/issues/9)
#### Remaining Tasks
- [ ] Implement the change to the codelist API - https://github.com/IATI/IATI-Codelists/issues/79
- [ ] Update the travis test after the change to the codelist schema has been merged
- [ ] Update the README in this repository to describe how external codelists are fetched
