### PR TITLE
Update CRSChannelCode codelist

### DIFF
--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -2162,7 +2162,7 @@
                 <narrative xml:lang="fr">Agence internationale pour les energies renouvelables</narrative>
             </name>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-12-07">
+        <codelist-item status="withdrawn" activation-date="2015-12-07" withdrawal-date="2017-05-09">
             <code>50000</code>
             <name>
                 <narrative>Other</narrative>

--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -20,11 +20,67 @@
                 <narrative xml:lang="fr">Gouvernement du donneur</narrative>
             </name>
         </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>11001</code>
+            <name>
+                <narrative>Central Government</narrative>
+                <narrative xml:lang="fr">Gouvernment central</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>11002</code>
+            <name>
+                <narrative>Local Government</narrative>
+                <narrative xml:lang="fr">Gouvernment local</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>11003</code>
+            <name>
+                <narrative>Public corporations</narrative>
+                <narrative xml:lang="fr">Entreprise publique</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>11004</code>
+            <name>
+                <narrative>Other public entities in donor country</narrative>
+                <narrative xml:lang="fr">Autres entité publique dans le pays donneur</narrative>
+            </name>
+        </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>12000</code>
             <name>
                 <narrative>Recipient Government</narrative>
                 <narrative xml:lang="fr">Gouvernement du bénéficiaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>12001</code>
+            <name>
+                <narrative>Central Government</narrative>
+                <narrative xml:lang="fr">Gouvernment central</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>12002</code>
+            <name>
+                <narrative>Local Government</narrative>
+                <narrative xml:lang="fr">Gouvernment local</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>12003</code>
+            <name>
+                <narrative>Public corporations</narrative>
+                <narrative xml:lang="fr">Entreprise publique</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>12004</code>
+            <name>
+                <narrative>Other public entities in recipient country</narrative>
+                <narrative xml:lang="fr">Autres entité publique dans le pays bénéficiaire</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -101,7 +157,7 @@
             <code>21503</code>
             <name>
                 <narrative>Family Health International 360</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -199,14 +255,14 @@
             <code>21504</code>
             <name>
                 <narrative>International Relief and Development</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>21506</code>
             <name>
                 <narrative>International Rescue Committee</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -234,14 +290,14 @@
             <code>21501</code>
             <name>
                 <narrative>OXFAM International</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>21507</code>
             <name>
                 <narrative>Pact World</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -262,7 +318,7 @@
             <code>21505</code>
             <name>
                 <narrative>Save the Children</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -290,7 +346,7 @@
             <code>21502</code>
             <name>
                 <narrative>World Vision</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -409,14 +465,14 @@
             <code>22501</code>
             <name>
                 <narrative>OXFAM - provider country office</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>22502</code>
             <name>
                 <narrative>Save the Children - donor country office</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -884,8 +940,8 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>41310</code>
             <name>
-                <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, UNAMID, UNIFIL, UNIFSA, UNMIK, UNMIL, UNMIS (terminated July 2011), UNMISS, UNMIT (terminated December 2012), UNOCI]. Report contributions mission by mission in CRS++.</narrative>
-                <narrative xml:lang="fr">Département des opérations de maintien de la paix des Nations unies [seulement MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, MINUAD, FINUL, FISNUA, MINUK, MINUL, MINUS (terminée en juillet 2011), UNMISS, MINUT (terminée en décembre 2012), ONUCI]. Notifier les contributions mission par mission au format SNPC++.</narrative>
+                <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, UNAMID, UNIFIL, UNIFSA, UNMIK, UNMIL, UNMISS, UNOCI]. Report contributions mission by mission in CRS++.</narrative>
+                <narrative xml:lang="fr">Département des opérations de maintien de la paix des Nations unies [seulement MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, MINUAD, FINUL, FISNUA, MINUK, MINUL, UNMISS, ONUCI]. Notifier les contributions mission par mission au format SNPC++.</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1032,7 +1088,7 @@
             <code>41501</code>
             <name>
                 <narrative>United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1215,6 +1271,13 @@
             <name>
                 <narrative>International Monetary Fund - Subsidization of Emergency Post Conflict Assistance/Emergency Assistance for Natural Disasters for PRGT-eligible members</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international – Aide d’urgence après un conflit (EPCA) et aide d’urgence à la suite de catastrophes naturelles (ENDA) pour les membres pouvant bénéficier de la FRPC</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>43006</code>
+            <name>
+                <narrative>Catastrophe Containment and Relief Trust</narrative>
+                <narrative xml:lang="fr">Fonds fiduciaire d’assistance et de riposte aux catastrophes</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1662,7 +1725,7 @@
             <code>47504</code>
             <name>
                 <narrative>Forest Carbon Partnership Facility</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1690,7 +1753,7 @@
             <code>47503</code>
             <name>
                 <narrative>Global Agriculture and Food Security Program</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1725,7 +1788,7 @@
             <code>47502</code>
             <name>
                 <narrative>Global Fund for Disaster Risk Reduction</narrative>
-                <narrative xml:lang="fr">0</narrative>
+                <narrative xml:lang="fr"></narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -2085,6 +2148,20 @@
                 <narrative xml:lang="fr">Organisation Mondiale des Douanes Fonds de coopération douanière</narrative>
             </name>
         </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>47143</code>
+            <name>
+                <narrative>Global Community Engagement and Resilience Fund</narrative>
+                <narrative xml:lang="fr">Fonds mondial pour l’engagement de la communauté et la résilience</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2016-07-06">
+            <code>47144</code>
+            <name>
+                <narrative>International Renewable Energy Agency</narrative>
+                <narrative xml:lang="fr">Agence internationale pour les energies renouvelables</narrative>
+            </name>
+        </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>50000</code>
             <name>
@@ -2297,6 +2374,104 @@
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>52000</code>
+            <name>
+                <narrative>Other</narrative>
+                <narrative xml:lang="fr">Autre</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>60000</code>
+            <name>
+                <narrative>Private sector institution</narrative>
+                <narrative xml:lang="fr">Institutions du Secteur Privé</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>61000</code>
+            <name>
+                <narrative>Private sector in provider country</narrative>
+                <narrative xml:lang="fr">Secteur privé du pays donneur</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>61001</code>
+            <name>
+                <narrative>Private bank in provider country</narrative>
+                <narrative xml:lang="fr">Banque privée dans le pays donneur</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>61002</code>
+            <name>
+                <narrative>Private exporter in provider country</narrative>
+                <narrative xml:lang="fr">Exportateur privé dans le pays donneur</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>61003</code>
+            <name>
+                <narrative>Private investor in provider country</narrative>
+                <narrative xml:lang="fr">Investisseur privé dans le pays donneur</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>61004</code>
+            <name>
+                <narrative>Other non-bank entity in provider country</narrative>
+                <narrative xml:lang="fr">Autre entité non-bancaire dans le pays donneur</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>62000</code>
+            <name>
+                <narrative>Private sector in recipient country</narrative>
+                <narrative xml:lang="fr">Secteur privé du pays bénéficiaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>62001</code>
+            <name>
+                <narrative>Private bank in recipient country</narrative>
+                <narrative xml:lang="fr">Banque privée dans le pays bénéficiaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>62002</code>
+            <name>
+                <narrative>Joint-venture in recipient country</narrative>
+                <narrative xml:lang="fr">Co-entreprise dans le pays bénéficiaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>62003</code>
+            <name>
+                <narrative>Other non-bank in recipient country</narrative>
+                <narrative xml:lang="fr">Autre entité non-bancaire dans le pays bénéficiaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>63000</code>
+            <name>
+                <narrative>Private sector in third country</narrative>
+                <narrative xml:lang="fr">Secteur privé d'un pays tiers</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>63001</code>
+            <name>
+                <narrative>Private bank in third country</narrative>
+                <narrative xml:lang="fr">Banque privée d'un pays tiers</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>63002</code>
+            <name>
+                <narrative>Private non-bank in third country</narrative>
+                <narrative xml:lang="fr">Secteur privé non-bancaire dans le pays bénéficiaire</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-03-31">
+            <code>90000</code>
             <name>
                 <narrative>Other</narrative>
                 <narrative xml:lang="fr">Autre</narrative>


### PR DESCRIPTION
Codes added:

 * `11001` Central Government
 * `11002` Local Government
 * `11003` Public corporations
 * `11004` Other public entities in donor country
 * `12001` Central Government
 * `12002` Local Government
 * `12003` Public corporations
 * `12004` Other public entities in recipient country
 * `43006` Catastrophe Containment and Relief Trust
 * `47143` Global Community Engagement and Resilience Fund
 * `47144` International Renewable Energy Agency
 * `60000` Private sector institution
 * `61000` Private sector in provider country
 * `61001` Private bank in provider country
 * `61002` Private exporter in provider country
 * `61003` Private investor in provider country
 * `61004` Other non-bank entity in provider country
 * `62000` Private sector in recipient country
 * `62001` Private bank in recipient country
 * `62002` Joint-venture in recipient country
 * `62003` Other non-bank in recipient country
 * `63000` Private sector in third country
 * `63001` Private bank in third country
 * `63002` Private non-bank in third country
 * `90000` Other

Code withdrawn:

 * `50000` Other (withdrawn on 2017-05-09)

Note that `11001`-`11003` refer to the donor government, whereas `12001`-`12003` refer to the recipient government. This isn’t clear from the titles, so should probably be amended.

I’ve added some `activation-date`s and a `withdrawn-date` here, but these are somewhat arbitrary.