### PR TITLE
Make FileFormat template IATI 2.x compatible

### DIFF
--- a/templates/FileFormat.xml
+++ b/templates/FileFormat.xml
@@ -1,8 +1,12 @@
 <codelist name="FileFormat" xml:lang="en" complete="1">
   <metadata>
-    <name>File Format</name>
-      <description>File format of published documents.</description>
-      <url>http://www.iana.org/assignments/media-types</url>
+    <name>
+      <narrative>File Format</narrative>
+    </name>
+    <description>
+      <narrative>File format of published documents.</narrative>
+    </description>
+    <url>http://www.iana.org/assignments/media-types</url>
   </metadata>
   <codelist-items/>
 </codelist>


### PR DESCRIPTION
Minor change that just adds in missing `<narrative>` tags to the template that [convert.py](https://github.com/IATI/IATI-Codelists-NonEmbedded/blob/master/convert.py) uses.