### PR TITLE
Mark ‘Netherland Antilles’ as withdrawn

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -963,7 +963,7 @@
                 <narrative>NETHERLANDS (THE)</narrative>
             </name>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="withdrawn">
             <code>AN</code>
             <name>
                 <narrative>NETHERLAND ANTILLES</narrative>


### PR DESCRIPTION
This code is no longer part of the [ISO 3166-1 list](https://www.iso.org/iso-3166-country-codes.html), so marking as withdrawn.