### PR TITLE
August 2017 DAC CRS codelist updates

### DIFF
--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -9,8 +9,8 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>10000</code>
             <name>
-                <narrative>Public Sector Institutions</narrative>
-                <narrative xml:lang="fr">Institutions du Secteur Public</narrative>
+                <narrative>PUBLIC SECTOR INSTITUTIONS</narrative>
+                <narrative xml:lang="fr">INSTITUTIONS DU SECTEUR PUBLIC</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -93,15 +93,15 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>20000</code>
             <name>
-                <narrative>Non-governmental Organisations (NGOs) And Civil Society</narrative>
-                <narrative xml:lang="fr">Organisations Non Gouvernementales (ONG) et Société Civile</narrative>
+                <narrative>NON-GOVERNMENTAL ORGANISATIONS (NGOs) AND CIVIL SOCIETY</narrative>
+                <narrative xml:lang="fr">ORGANISATIONS NON GOUVERNEMENTALES (ONG) et SOCIÉTÉ CIVILE</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>21000</code>
             <name>
-                <narrative>International NGO</narrative>
-                <narrative xml:lang="fr">ONG Internationale</narrative>
+                <narrative>INTERNATIONAL NGO</narrative>
+                <narrative xml:lang="fr">ONG INTERNATIONALE</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -123,6 +123,13 @@
             <name>
                 <narrative>Association of Geoscientists for International Development</narrative>
                 <narrative xml:lang="fr">Association de géoscientifiques pour le développement international</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-08-08">
+            <code>21063</code>
+            <name>
+                <narrative>Conservation International</narrative>
+                <narrative xml:lang="fr"/>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -247,7 +254,7 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>21061</code>
             <name>
-                <narrative>International Rehabilitation Council for Torture</narrative>
+                <narrative>International Rehabilitation Council for Torture Victims</narrative>
                 <narrative xml:lang="fr">Conseil international de réhabilitation pour les victimes de torture</narrative>
             </name>
         </codelist-item>
@@ -276,7 +283,7 @@
             <code>21053</code>
             <name>
                 <narrative>IPAS-Protecting Women’s Health, Advancing Women’s Reproductive Rights</narrative>
-                <narrative xml:lang="fr">IPAS-Protecting Women’s Health, Advancing Women’s Reproductive Rights</narrative>
+                <narrative xml:lang="fr">IPAS-Protecting Womens Health, Advancing Womens Reproductive Rights</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -450,8 +457,8 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>21027</code>
             <name>
-                <narrative>International Trust Fund for Demining and Mine Victims Assistance</narrative>
-                <narrative xml:lang="fr">Fonds international d’affectation spéciale pour le déminage et l’assistance aux victimes des mines</narrative>
+                <narrative>ITF Enhancing Human Security</narrative>
+                <narrative xml:lang="fr">ITF Améliorer la sécurité humaine</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -545,6 +552,13 @@
                 <narrative xml:lang="fr">Conseil latino-américain des sciences sociales</narrative>
             </name>
         </codelist-item>
+        <codelist-item status="active" activation-date="2017-08-08">
+            <code>23501</code>
+            <name>
+                <narrative>National Red Cross and Red Crescent Societies</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+        </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>21030</code>
             <name>
@@ -562,8 +576,8 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>30000</code>
             <name>
-                <narrative>Public-Private Partnerships (PPPs) And Networks</narrative>
-                <narrative xml:lang="fr">Partenariats public-privé et Réseaux</narrative>
+                <narrative>PUBLIC-PRIVATE PARTNERSHIPS (PPPs) and NETWORKS</narrative>
+                <narrative xml:lang="fr">PARTENARIATS PUBLIC-PRIVÉ ET RÉSEAUX</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -619,7 +633,7 @@
             <code>30015</code>
             <name>
                 <narrative>Global Energy Efficiency and Renewable Energy Fund</narrative>
-                <narrative xml:lang="fr">Fonds mondial pour la promotion de l’'efficacité énergétique et des énergies renouvelables</narrative>
+                <narrative xml:lang="fr">Fonds mondial pour la promotion de l'efficacité énergétique et des énergies renouvelables</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -675,7 +689,7 @@
             <code>21056</code>
             <name>
                 <narrative>Renewable Energy and Energy Efficiency Partnership</narrative>
-                <narrative xml:lang="fr">Partenariat pour les énergies renouvelables et l’'efficience énergétique</narrative>
+                <narrative xml:lang="fr">Partenariat pour les énergies renouvelables et l'efficience énergétique</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -765,8 +779,8 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>40000</code>
             <name>
-                <narrative>Multilateral Organisations</narrative>
-                <narrative xml:lang="fr">Organisations Multilatérales</narrative>
+                <narrative>MULTILATERAL ORGANISATIONS</narrative>
+                <narrative xml:lang="fr">ORGANISATIONS MULTILATÉRALES</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -940,7 +954,7 @@
         <codelist-item status="active" activation-date="2015-12-07">
             <code>41310</code>
             <name>
-                <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, UNAMID, UNIFIL, UNIFSA, UNMIK, UNMIL, UNMISS, UNOCI]. Report contributions mission by mission in CRS++.</narrative>
+                <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, UNAMID, UNIFIL, UNISFA, UNMIK, UNMIL, UNMISS, UNOCI]. Report contributions mission by mission in CRS++.</narrative>
                 <narrative xml:lang="fr">Département des opérations de maintien de la paix des Nations unies [seulement MINURSO, MINUSCA, MINUSMA, MINUSTAH, MONUSCO, MINUAD, FINUL, FISNUA, MINUK, MINUL, UNMISS, ONUCI]. Notifier les contributions mission par mission au format SNPC++.</narrative>
             </name>
         </codelist-item>
@@ -1168,6 +1182,13 @@
                 <narrative xml:lang="fr">Union postale universelle</narrative>
             </name>
         </codelist-item>
+        <codelist-item status="active" activation-date="2017-08-08">
+            <code>41503</code>
+            <name>
+                <narrative>UN-led Country-based Pooled Funds</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+        </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>41140</code>
             <name>
@@ -1201,6 +1222,13 @@
             <name>
                 <narrative>World Meteorological Organisation</narrative>
                 <narrative xml:lang="fr">Organisation météorologique mondiale</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2017-08-08">
+            <code>41319</code>
+            <name>
+                <narrative>World Tourism Organization</narrative>
+                <narrative xml:lang="fr"/>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1413,6 +1441,13 @@
                 <narrative xml:lang="fr">Fonds asiatique de développement</narrative>
             </name>
         </codelist-item>
+        <codelist-item status="active" activation-date="2017-08-08">
+            <code>46026</code>
+            <name>
+                <narrative>Asian Infrastructure Investment Bank</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+        </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>46006</code>
             <name>
@@ -1616,11 +1651,18 @@
                 <narrative xml:lang="fr">Centre épidémiologique des Caraïbes</narrative>
             </name>
         </codelist-item>
+        <codelist-item status="active" activation-date="2017-08-08">
+            <code>47145</code>
+            <name>
+                <narrative>Center of Excellence in Finance</narrative>
+                <narrative xml:lang="fr"/>
+            </name>
+        </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
             <code>47112</code>
             <name>
                 <narrative>Central European Initiative - Special Fund for Climate and Environmental Protection</narrative>
-                <narrative xml:lang="fr">Initiative de l’Europe centrale - – Fonds Spécial pour la protection climatique et environnementale</narrative>
+                <narrative xml:lang="fr">Initiative de l’Europe centrale -  Fonds Spécial pour la protection climatique et environnementale</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">
@@ -1816,7 +1858,7 @@
             <code>47116</code>
             <name>
                 <narrative>Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries</narrative>
-                <narrative xml:lang="fr">Cadre intégré pour l’'assistance technique liée au commerce en faveur des pays les moins avancés</narrative>
+                <narrative xml:lang="fr">Cadre intégré pour l'assistance technique liée au commerce en faveur des pays les moins avancés</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-12-07">

--- a/xml/CollaborationType.xml
+++ b/xml/CollaborationType.xml
@@ -62,7 +62,7 @@
         <codelist-item>
             <code>7</code>
             <name>
-                <narrative>Bilateral, ex-post reporting on NGOs' activities funded through core contributions</narrative>
+                <narrative>Bilateral, ex-post reporting on NGOs’ activities funded through core contributions</narrative>
                 <narrative xml:lang="fr">Contributions bilatérales, notification ex post des activités des ONG financées par des contributions des donneurs au budget général de l'ONG.</narrative>
             </name>
             <description>

--- a/xml/Region.xml
+++ b/xml/Region.xml
@@ -9,7 +9,7 @@
         <codelist-item>
             <code>88</code>
             <name>
-                <narrative>States Ex-Yugoslavia, unspecified</narrative>
+                <narrative>States Ex-Yugoslavia unspecified</narrative>
                 <narrative xml:lang="fr">Etats ex-Yougoslavie non spécifié</narrative>
             </name>
         </codelist-item>
@@ -51,7 +51,7 @@
         <codelist-item>
             <code>389</code>
             <name>
-                <narrative>North and Central America, regional</narrative>
+                <narrative>North &amp; Central America, regional</narrative>
                 <narrative xml:lang="fr">Amérique N. &amp; C., régional</narrative>
             </name>
         </codelist-item>
@@ -93,7 +93,7 @@
         <codelist-item>
             <code>689</code>
             <name>
-                <narrative>South and Central Asia, regional</narrative>
+                <narrative>South &amp; Central Asia, regional</narrative>
                 <narrative xml:lang="fr">Asie du Sud &amp; C., régional</narrative>
             </name>
         </codelist-item>

--- a/xml/Sector.xml
+++ b/xml/Sector.xml
@@ -1,3354 +1,3354 @@
 <codelist name="Sector" xml:lang="en" category-codelist="SectorCategory" complete="1">
-	<metadata>
-		<name>
-			<narrative>DAC 5 Digit Sector</narrative>
-		</name>
-		<url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
-	</metadata>
-	<codelist-items>
-		<codelist-item>
-			<code>11110</code>
-			<name>
-				<narrative>Education policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de l’éducation et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Education sector policy, planning and programmes; aid to education ministries, administration and management systems; institution capacity building and advice; school management and governance; curriculum and materials development; unspecified education activities.</narrative>
-				<narrative xml:lang="fr">Politique de l’éducation, planification et programmes ; aide aux ministères de l’éducation, à l’administration et au développement de systèmes de gestion, renforcement des capacités institutionnelles et conseils ; gestion et direction des écoles, développement des programmes d’études et des matériels pédagogiques ; activités d’éducation non spécifiées.</narrative>
-			</description>
-			<category>111</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11120</code>
-			<name>
-				<narrative>Education facilities and training</narrative>
-				<narrative xml:lang="fr">Équipements scolaires et formation</narrative>
-			</name>
-			<description>
-				<narrative>Educational buildings, equipment, materials; subsidiary services to education (boarding facilities, staff housing); language training; colloquia, seminars, lectures, etc.</narrative>
-				<narrative xml:lang="fr">Bâtiments scolaires, équipement, fournitures ; services pour l’éducation (équipement pour les pensionnaires, logement pour le personnel) ; cours de langues ; colloques, séminaires, conférences, etc.</narrative>
-			</description>
-			<category>111</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11130</code>
-			<name>
-				<narrative>Teacher training</narrative>
-				<narrative xml:lang="fr">Formation des enseignants</narrative>
-			</name>
-			<description>
-				<narrative>Teacher education (where the level of education is unspecified); in-service and pre-service training; materials development.</narrative>
-				<narrative xml:lang="fr">Éducation des enseignants (quand le niveau d’éducation n’est pas spécifié) ; formation et formation continue ; développement des matériels pédagogiques.</narrative>
-			</description>
-			<category>111</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11182</code>
-			<name>
-				<narrative>Educational research</narrative>
-				<narrative xml:lang="fr">Recherche en éducation</narrative>
-			</name>
-			<description>
-				<narrative>Research and studies on education effectiveness, relevance and quality; systematic evaluation and monitoring.</narrative>
-				<narrative xml:lang="fr">Recherche et études sur l’efficacité, la pertinence et la qualité de l’éducation ; évaluation et suivi systématiques.</narrative>
-			</description>
-			<category>111</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11220</code>
-			<name>
-				<narrative>Primary education</narrative>
-				<narrative xml:lang="fr">Enseignement primaire</narrative>
-			</name>
-			<description>
-				<narrative>Formal and non-formal primary education for children; all elementary and first cycle systematic instruction; provision of learning materials.</narrative>
-				<narrative xml:lang="fr">Enseignement primaire formel et non formel pour les enfants ; enseignement élémentaire général ; fournitures scolaires.</narrative>
-			</description>
-			<category>112</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11230</code>
-			<name>
-				<narrative>Basic life skills for youth and adults</narrative>
-				<narrative xml:lang="fr">Éducation pour une meilleure qualité de vie pour les jeunes et les adultes</narrative>
-			</name>
-			<description>
-				<narrative>Formal and non-formal education for basic life skills for young people and adults (adults education); literacy and numeracy training.</narrative>
-				<narrative xml:lang="fr">Éducation formelle et non formelle pour une meilleure qualité de vie pour les jeunes et les adultes (éducation des adultes) ; alphabétisation et apprentissage du calcul.</narrative>
-			</description>
-			<category>112</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11231</code>
-			<name>
-				<narrative>Basic life skills for youth</narrative>
-				<narrative xml:lang="fr">Éducation pour une meilleure qualité de vie pour les jeunes</narrative>
-			</name>
-			<description>
-				<narrative>Formal and non-formal education for basic life skills for young people.</narrative>
-				<narrative xml:lang="fr">Éducation formelle et non formelle pour une meilleure qualité de vie pour les jeunes.</narrative>
-			</description>
-			<category>112</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11232</code>
-			<name>
-				<narrative>Primary education equivalent for adults</narrative>
-				<narrative xml:lang="fr">Education primaire des adultes</narrative>
-			</name>
-			<description>
-				<narrative>Formal primary education for adults.</narrative>
-				<narrative xml:lang="fr">Éducation primaire formelle pour adultes.</narrative>
-			</description>
-			<category>112</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11240</code>
-			<name>
-				<narrative>Early childhood education</narrative>
-				<narrative xml:lang="fr">Éducation de la petite enfance</narrative>
-			</name>
-			<description>
-				<narrative>Formal and non-formal pre-school education.</narrative>
-				<narrative xml:lang="fr">Éducation préscolaire formelle et non formelle.</narrative>
-			</description>
-			<category>112</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11320</code>
-			<name>
-				<narrative>Secondary education</narrative>
-				<narrative xml:lang="fr">Enseignement secondaire</narrative>
-			</name>
-			<description>
-				<narrative>Second cycle systematic instruction at both junior and senior levels.</narrative>
-				<narrative xml:lang="fr">Éducation secondaire généralisée pour les premiers et derniers cycles.</narrative>
-			</description>
-			<category>113</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11321</code>
-			<name>
-				<narrative>Lower secondary education</narrative>
-				<narrative xml:lang="fr">Premier cycle de l'enseignement secondaire</narrative>
-			</name>
-			<description>
-				<narrative>Second cycle systematic instruction at junior level.</narrative>
-				<narrative xml:lang="fr">Éducation secondaire généralisée pour le premier cycle.</narrative>
-			</description>
-			<category>113</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11322</code>
-			<name>
-				<narrative>Upper secondary education</narrative>
-				<narrative xml:lang="fr">Deuxième cycle de l'enseignement secondaire</narrative>
-			</name>
-			<description>
-				<narrative>Second cycle systematic instruction at senior level.</narrative>
-				<narrative xml:lang="fr">Éducation secondaire généralisée pour le dernier cycle.</narrative>
-			</description>
-			<category>113</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11330</code>
-			<name>
-				<narrative>Vocational training</narrative>
-				<narrative xml:lang="fr">Formation professionnelle</narrative>
-			</name>
-			<description>
-				<narrative>Elementary vocational training and secondary level technical education; on-the job training; apprenticeships; including informal vocational training.</narrative>
-				<narrative xml:lang="fr">Formation professionnelle élémentaire et enseignement technique au niveau secondaire ; formation sur le tas ; apprentissage.</narrative>
-			</description>
-			<category>113</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11420</code>
-			<name>
-				<narrative>Higher education</narrative>
-				<narrative xml:lang="fr">Enseignement supérieur</narrative>
-			</name>
-			<description>
-				<narrative>Degree and diploma programmes at universities, colleges and polytechnics; scholarships.</narrative>
-				<narrative xml:lang="fr">Diplômes universitaires, de l’enseignement supérieur, de technologie ; bourses d’études.</narrative>
-			</description>
-			<category>114</category>
-		</codelist-item>
-		<codelist-item>
-			<code>11430</code>
-			<name>
-				<narrative>Advanced technical and managerial training</narrative>
-				<narrative xml:lang="fr">Formation technique supérieure de gestion</narrative>
-			</name>
-			<description>
-				<narrative>Professional-level vocational training programmes and in-service training.</narrative>
-				<narrative xml:lang="fr">Formation professionnelle supérieure et formation sur le tas.</narrative>
-			</description>
-			<category>114</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12110</code>
-			<name>
-				<narrative>Health policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de la santé et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Health sector policy, planning and programmes; aid to health ministries, public health administration; institution capacity building and advice; medical insurance programmes; unspecified health activities.</narrative>
-				<narrative xml:lang="fr">Politique de la santé, planification et programmes ; aide aux ministères de la santé ; administration de la santé publique ; renforcement des capacités institutionnelles et conseils ; programmes d’assurance-maladie ; activités de santé non spécifiés.</narrative>
-			</description>
-			<category>121</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12181</code>
-			<name>
-				<narrative>Medical education/training</narrative>
-				<narrative xml:lang="fr">Éducation et formation médicales</narrative>
-			</name>
-			<description>
-				<narrative>Medical education and training for tertiary level services.</narrative>
-				<narrative xml:lang="fr">Enseignement médical et formation pour les services au niveau tertiaire.</narrative>
-			</description>
-			<category>121</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12182</code>
-			<name>
-				<narrative>Medical research</narrative>
-				<narrative xml:lang="fr">Recherche médicale</narrative>
-			</name>
-			<description>
-				<narrative>General medical research (excluding basic health research).</narrative>
-				<narrative xml:lang="fr">Recherche médicale (à l’exclusion de la recherche sur la santé de base).</narrative>
-			</description>
-			<category>121</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12191</code>
-			<name>
-				<narrative>Medical services</narrative>
-				<narrative xml:lang="fr">Services médicaux</narrative>
-			</name>
-			<description>
-				<narrative>Laboratories, specialised clinics and hospitals (including equipment and supplies); ambulances; dental services; mental health care; medical rehabilitation; control of non-infectious diseases; drug and substance abuse control [excluding narcotics traffic control (16063)].</narrative>
-				<narrative xml:lang="fr">Laboratoires, centres de santé et hôpitaux spécialisés (y compris l’équipement et les fournitures) ; ambulances ; services dentaires ; santé mentale ; rééducation médicale ; lutte contre les maladies à l’exclusion des maladies infectieuses ; lutte contre la toxicomanie [à l’exclusion du trafic de drogues (16063)].</narrative>
-			</description>
-			<category>121</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12220</code>
-			<name>
-				<narrative>Basic health care</narrative>
-				<narrative xml:lang="fr">Soins et services de santé de base</narrative>
-			</name>
-			<description>
-				<narrative>Basic and primary health care programmes; paramedical and nursing care programmes; supply of drugs, medicines and vaccines related to basic health care.</narrative>
-				<narrative xml:lang="fr">Programmes de soins sanitaires primaires et de base ; programmes de soins paramédicaux et infirmiers ; approvisionnement en médicaments et en vaccins relatifs aux soins et services de santé de base.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12230</code>
-			<name>
-				<narrative>Basic health infrastructure</narrative>
-				<narrative xml:lang="fr">Infrastructure pour la santé de base</narrative>
-			</name>
-			<description>
-				<narrative>District-level hospitals, clinics and dispensaries and related medical equipment; excluding specialised hospitals and clinics (12191).</narrative>
-				<narrative xml:lang="fr">Hôpitaux régionaux, centres de santé, dispensaires et équipements médicaux ; à l’exclusion des hôpitaux et centres de santé spécialisés (12191).</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12240</code>
-			<name>
-				<narrative>Basic nutrition</narrative>
-				<narrative xml:lang="fr">Nutrition de base</narrative>
-			</name>
-			<description>
-				<narrative>Direct feeding programmes (maternal feeding, breastfeeding and weaning foods, child feeding, school feeding); determination of micro-nutrient deficiencies; provision of vitamin A, iodine, iron etc.; monitoring of nutritional status; nutrition and food hygiene education; household food security.</narrative>
-				<narrative xml:lang="fr">Programmes pour l’alimentation (alimentation maternelle, allaitement et alimentation du sevrage, alimentation de l’enfant, alimentation à l’école) ; identification des déficiences nutritives ; fourniture de vitamine A, d’iode, de fer, etc. ; surveillance de l’état nutritionnel ; enseignement de la nutrition et de l’hygiène alimentaire ; alimentation domestique.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12250</code>
-			<name>
-				<narrative>Infectious disease control</narrative>
-				<narrative xml:lang="fr">Lutte contre les maladies infectieuses</narrative>
-			</name>
-			<description>
-				<narrative>Immunisation; prevention and control of infectious and parasite diseases, except malaria (12262), tuberculosis (12263), HIV/AIDS and other STDs (13040). It includes diarrheal diseases, vector-borne diseases (e.g. river blindness and guinea worm), viral diseases, mycosis, helminthiasis, zoonosis, diseases by other bacteria and viruses, pediculosis, etc.</narrative>
-				<narrative xml:lang="fr">Vaccination ; prévention et lutte contre les maladies infectieuses parasitaires à l’exception du paludisme (12262), de la tuberculose (12263), du VIH/sida et autres MST (13040). Ceci inclus les diarrhées chroniques, les maladies transmises par un vecteur (par exemple onchocercose, bilharziose), les maladies virales, les mycoses, l’helminthiasis, les zoonoses et les maladies provoquées par d’autres bactéries et virus, pédiculose, etc.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12261</code>
-			<name>
-				<narrative>Health education</narrative>
-				<narrative xml:lang="fr">Éducation sanitaire</narrative>
-			</name>
-			<description>
-				<narrative>Information, education and training of the population for improving health knowledge and practices; public health and awareness campaigns; promotion of improved personal hygiene practices, including use of sanitation facilities and handwashing with soap.</narrative>
-				<narrative xml:lang="fr">Information, éducation et formation de la population pour l’amélioration des connaissances et des pratiques liées à la santé ; campagnes pour la santé publique et programmes de sensibilisation ; promotion de meilleures pratiques d’hygiène personnelle, notamment de l’utilisation d’équipements sanitaires et du savonnage des mains.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12262</code>
-			<name>
-				<narrative>Malaria control</narrative>
-				<narrative xml:lang="fr">Lutte contre le paludisme</narrative>
-			</name>
-			<description>
-				<narrative>Prevention and control of malaria.</narrative>
-				<narrative xml:lang="fr">Prévention et lutte contre le paludisme.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12263</code>
-			<name>
-				<narrative>Tuberculosis control</narrative>
-				<narrative xml:lang="fr">Lutte contre la tuberculose</narrative>
-			</name>
-			<description>
-				<narrative>Immunisation, prevention and control of tuberculosis.</narrative>
-				<narrative xml:lang="fr">Vaccination, prévention et lutte contre la tuberculose.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>12281</code>
-			<name>
-				<narrative>Health personnel development</narrative>
-				<narrative xml:lang="fr">Formation de personnel de santé</narrative>
-			</name>
-			<description>
-				<narrative>Training of health staff for basic health care services.</narrative>
-				<narrative xml:lang="fr">Formation du personnel de santé pour les services et les soins sanitaires de base.</narrative>
-			</description>
-			<category>122</category>
-		</codelist-item>
-		<codelist-item>
-			<code>13010</code>
-			<name>
-				<narrative>Population policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique/programmes en matière de population et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Population/development policies; census work, vital registration; migration data; demographic research/analysis; reproductive health research; unspecified population activities.</narrative>
-				<narrative xml:lang="fr">Politique en matière de population et de développement ; recensement, enregistrement des naissances/décès ; données sur la migration ; recherche et analyse démographiques ; recherche en santé et fertilité ; activités de population non spécifiées.</narrative>
-			</description>
-			<category>130</category>
-		</codelist-item>
-		<codelist-item>
-			<code>13020</code>
-			<name>
-				<narrative>Reproductive health care</narrative>
-				<narrative xml:lang="fr">Soins en matière de fertilité</narrative>
-			</name>
-			<description>
-				<narrative>Promotion of reproductive health; prenatal and postnatal care including delivery; prevention and treatment of infertility; prevention and management of consequences of abortion; safe motherhood activities.</narrative>
-				<narrative xml:lang="fr">Santé et fertilité ; soins prénatals et périnatals, y compris l’accouchement ; prévention et traitement de la stérilité ; prévention et suites de l’avortement ; activités pour une maternité sans risque.</narrative>
-			</description>
-			<category>130</category>
-		</codelist-item>
-		<codelist-item>
-			<code>13030</code>
-			<name>
-				<narrative>Family planning</narrative>
-				<narrative xml:lang="fr">Planification familiale</narrative>
-			</name>
-			<description>
-				<narrative>Family planning services including counselling; information, education and communication (IEC) activities; delivery of contraceptives; capacity building and training.</narrative>
-				<narrative xml:lang="fr">Conseils en planification familiale ; activités d’information, d’éducation et de communication (IEC) ; distribution de produits contraceptifs ; accroissement des moyens et aptitudes, formation.</narrative>
-			</description>
-			<category>130</category>
-		</codelist-item>
-		<codelist-item>
-			<code>13040</code>
-			<name>
-				<narrative>STD control including HIV/AIDS</narrative>
-				<narrative xml:lang="fr">Lutte contre les MST et VIH/sida</narrative>
-			</name>
-			<description>
-				<narrative>All activities related to sexually transmitted diseases and HIV/AIDS control e.g. information, education and communication; testing; prevention; treatment, care.</narrative>
-				<narrative xml:lang="fr">Toutes activités liées au contrôle des maladies sexuellement transmissibles et du VIH/sida ; activités d’information, éducation et communication ; dépistage ; prévention ; traitement, soins.</narrative>
-			</description>
-			<category>130</category>
-		</codelist-item>
-		<codelist-item>
-			<code>13081</code>
-			<name>
-				<narrative>Personnel development for population and reproductive health</narrative>
-				<narrative xml:lang="fr">Formation de personnel en matière de population et de santé et fertilité</narrative>
-			</name>
-			<description>
-				<narrative>Education and training of health staff for population and reproductive health care services.</narrative>
-				<narrative xml:lang="fr">Éducation et formation du personnel de santé pour les services de population ainsi que les soins en matière de santé et fertilité.</narrative>
-			</description>
-			<category>130</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14010</code>
-			<name>
-				<narrative>Water sector policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique et gestion administrative du secteur de l’eau</narrative>
-			</name>
-			<description>
-				<narrative>Water sector policy and governance, including legislation, regulation, planning and management as well as transboundary management of water; institutional capacity development; activities supporting the Integrated Water Resource Management approach (IWRM: see box below).</narrative>
-				<narrative xml:lang="fr">Politique et gouvernance du secteur de l’eau, y compris législation, réglementation, planification et gestion ainsi que gestion transfrontalière de l’eau; renforcement des capacités institutionnelles ; activités favorisant une approche intégrée de la gestion des ressources en eau (GIRE : voir encadré ci-dessous).</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14015</code>
-			<name>
-				<narrative>Water resources conservation (including data collection)</narrative>
-				<narrative xml:lang="fr">Préservation des ressources en eau (y compris collecte de données)</narrative>
-			</name>
-			<description>
-				<narrative>Collection and usage of quantitative and qualitative data on water resources; creation and sharing of water knowledge; conservation and rehabilitation of inland surface waters (rivers, lakes etc.), ground water and coastal waters; prevention of water contamination.</narrative>
-				<narrative xml:lang="fr">Collecte et utilisation de données quantitatives et qualitatives sur les ressources en eau ; création et mise en commun de connaissances sur l’eau ; préservation et remise en état des eaux intérieures de surface (rivières, lacs, etc.), des nappes souterraines et des eaux côtières ; prévention de la contamination des eaux.</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14020</code>
-			<name>
-				<narrative>Water supply and sanitation - large systems</narrative>
-				<narrative xml:lang="fr">Approvisionnement en eau et assainissement – systèmes à grande échelle</narrative>
-			</name>
-			<description>
-				<narrative>Programmes where components according to 14021 and 14022 cannot be identified. When components are known, they should individually be reported under their respective purpose codes: water supply (14021), sanitation (14022), and hygiene (12261).</narrative>
-				<narrative xml:lang="fr">Programmes dont les composantes relatives aux codes 14021 et 14022 ne peuvent être identifiées séparément. Lorsque les composantes sont connues, elles devraient être individuellement notifiées sous leurs codes respectifs : approvisionnement en eau [14021], assainissement [14022] et hygiène [12261].</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14021</code>
-			<name>
-				<narrative>Water supply - large systems</narrative>
-				<narrative xml:lang="fr">Approvisionnement en eau – systèmes à grande échelle</narrative>
-			</name>
-			<description>
-				<narrative>Potable water treatment plants; intake works; storage; water supply pumping stations; large scale transmission / conveyance and distribution systems.</narrative>
-				<narrative xml:lang="fr">Usines de traitement d’eau potable ; ouvrages d’adduction ; stockage ; stations de pompage pour l’approvisionnement en eau ; réseaux d’adduction et de distribution à grande échelle.</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14022</code>
-			<name>
-				<narrative>Sanitation - large systems</narrative>
-				<narrative xml:lang="fr">Assainissement – systèmes à grande échelle</narrative>
-			</name>
-			<description>
-				<narrative>Large scale sewerage including trunk sewers and sewage pumping stations; domestic and industrial waste water treatment plants.</narrative>
-				<narrative xml:lang="fr">Réseaux d’assainissement à grande échelle y compris égouts et stations de pompage des eaux d’égouts ; usines de traitement des eaux usées domestiques et industrielles.</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14030</code>
-			<name>
-				<narrative>Basic drinking water supply and basic sanitation</narrative>
-				<narrative xml:lang="fr">Approvisionnement en eau potable et assainissement - dispositifs de base</narrative>
-			</name>
-			<description>
-				<narrative>Programmes where components according to 14031 and 14032 cannot be identified. When components are known, they should individually be reported under their respective purpose codes: water supply (14031), sanitation (14032), and hygiene (12261).</narrative>
-				<narrative xml:lang="fr">Programmes dont les composantes relatives aux codes 14031 et 14032 ne peuvent être identifiées séparément. Lorsque les composantes sont connues, elles devraient être individuellement notifiées sous leurs codes respectifs : approvisionnement en eau [14031], assainissement [14032] et hygiène [12261].</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14031</code>
-			<name>
-				<narrative>Basic drinking water supply</narrative>
-				<narrative xml:lang="fr">Approvisionnement en eau potable – dispositifs de base</narrative>
-			</name>
-			<description>
-				<narrative>Rural water supply schemes using handpumps, spring catchments, gravity-fed systems, rainwater collection and fog harvesting, storage tanks, small distribution systems typically with shared connections/points of use. Urban schemes using handpumps and local neighbourhood networks including those with shared connections.</narrative>
-				<narrative xml:lang="fr">Dispositifs ruraux d’approvisionnement en eau reposant sur des pompes manuelles, des captages de sources, des systèmes par gravité, la collecte des eaux de pluie et de brouillard, des citernes, des systèmes simplifiés de distribution avec points d’eau collectifs/branchements partagés. Dispositifs urbains utilisant des pompes manuelles et mini-réseaux, y compris ceux avec branchements partagés et bornes-fontaines.</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14032</code>
-			<name>
-				<narrative>Basic sanitation</narrative>
-				<narrative xml:lang="fr">Assainissement – dispositifs de base</narrative>
-			</name>
-			<description>
-				<narrative>Latrines, on-site disposal and alternative sanitation systems, including the promotion of household and community investments in the construction of these facilities. (Use code 12261 for activities promoting improved personal hygiene practices.)</narrative>
-				<narrative xml:lang="fr">Latrines, dispositifs d’assainissement autonomes et systèmes alternatifs, y compris la promotion d’investissements de la part des ménages et des communautés locales dans la construction d’équipements de ce type. (Utiliser le code 12261 pour les activités de promotion des règles d’hygiène personnelle.)</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14040</code>
-			<name>
-				<narrative>River basins’ development</narrative>
-				<narrative xml:lang="fr">Aménagement de bassins fluviaux</narrative>
-			</name>
-			<description>
-				<narrative>Infrastructure-focused integrated river basin projects and related institutional activities; river flow control; dams and reservoirs [excluding dams primarily for irrigation (31140) and hydropower (23065) and activities related to river transport (21040)].</narrative>
-				<narrative xml:lang="fr">Projets de bassins fluviaux centrés sur les infrastructures et activités institutionnelles connexes ; régulation des cours d’eau ; barrages et réservoirs [à l’exclusion des barrages hydroélectriques (23065) et barrages pour l’irrigation (31140) et activités liées au transport fluvial (21040)].</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14050</code>
-			<name>
-				<narrative>Waste management / disposal</narrative>
-				<narrative xml:lang="fr">Traitement des déchets</narrative>
-			</name>
-			<description>
-				<narrative>Municipal and industrial solid waste management, including hazardous and toxic waste; collection, disposal and treatment; landfill areas; composting and reuse.</narrative>
-				<narrative xml:lang="fr">Au niveau municipal et industriel, y compris les déchets dangereux et toxiques ; enlèvement et traitement ; zones d’enfouissement des déchets ; compost et recyclage.</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>14081</code>
-			<name>
-				<narrative>Education and training in water supply and sanitation</narrative>
-				<narrative xml:lang="fr">Éducation et formation en matière d’approvisionnement en eau et d’assainissement</narrative>
-			</name>
-			<description>
-				<narrative>Education and training for sector professionals and service providers.</narrative>
-				<narrative xml:lang="fr">Activités d’éducation et de formation destinées aux professionnels et fournisseurs de services de ce secteur.</narrative>
-			</description>
-			<category>140</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15110</code>
-			<name>
-				<narrative>Public sector policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politiques publiques et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Institution-building assistance to strengthen core public sector management systems and capacities. This includes macro-economic and other policy management, co-ordination, planning and reform; human resource management; organisational development; civil service reform; e-government; development planning, monitoring and evaluation; support to ministries involved in aid co-ordination; other ministries and government departments when sector cannot be specified. (Use specific sector codes for development of systems and capacities in sector ministries.)</narrative>
-				<narrative xml:lang="fr">Aide au renforcement des institutions visant à consolider les capacités et systèmes principaux de gestion du secteur public. Ceci recouvre la gestion macroéconomique et la gestion d’autres politiques, la coordination, la planification et la réforme ; la gestion des ressources humaines ; le développement organisationnel ; la réforme de la fonction publique ; l’administration électronique ; la planification, le suivi et l’évaluation du développement ; le soutien aux ministères participant à la coordination de l’aide ; d’autres ministères et services gouvernementaux lorsque le secteur ne peut pas être précisé. (Utiliser des codes sectoriels spécifiques pour le renforcement des systèmes et des capacités dans les ministères sectoriels.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15111</code>
-			<name>
-				<narrative>Public Finance Management (PFM)</narrative>
-				<narrative xml:lang="fr">Gestion des finances publiques</narrative>
-			</name>
-			<description>
-				<narrative>Fiscal policy and planning; support to ministries of finance; strengthening financial and managerial accountability; public expenditure management; improving financial management systems; budget drafting; inter-governmental fiscal relations, public audit, public debt. (Use code 15114 for domestic revenue mobilisation and code 33120 for customs).</narrative>
-				<narrative xml:lang="fr">Politique et planification budgétaires ; soutien aux ministères des finances ; renforcement de la responsabilité financière et administrative ; gestion des dépenses publiques ; amélioration des systèmes de gestion financière ; préparation du budget ; relations budgétaires intergouvernementales, audit public, dette publique. (Utiliser les codes 15114 pour la mobilisation des ressources intérieures et 33120 pour les douanes.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15112</code>
-			<name>
-				<narrative>Decentralisation and support to subnational government</narrative>
-				<narrative xml:lang="fr">Décentralisation et soutien aux administrations infranationales</narrative>
-			</name>
-			<description>
-				<narrative>Decentralisation processes (including political, administrative and fiscal dimensions); intergovernmental relations and federalism; strengthening departments of regional and local government, regional and local authorities and their national associations. (Use specific sector codes for decentralisation of sector management and services.)</narrative>
-				<narrative xml:lang="fr">Processus de décentralisation (y compris aspects politiques, administratifs et budgétaires) ; relations intergouvernementales et fédéralisme ; renforcement des services des administrations régionales et locales, des autorités régionales et locales et de leurs associations nationales. (Utiliser des codes sectoriels spécifiques pour la décentralisation de la gestion et des services sectoriels.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15113</code>
-			<name>
-				<narrative>Anti-corruption organisations and institutions</narrative>
-				<narrative xml:lang="fr">Organisations et institutions pour la lutte contre la corruption</narrative>
-			</name>
-			<description>
-				<narrative>Specialised organisations, institutions and frameworks for the prevention of and combat against corruption, bribery, money- laundering and other aspects of organised crime, with or without law enforcement powers, e.g. anti-corruption commissions and monitoring bodies, special investigation services, institutions and initiatives of integrity and ethics oversight, specialised NGOs, other civil society and citizens’ organisations directly concerned with corruption.</narrative>
-				<narrative xml:lang="fr">Organisations, institutions et cadres spécialisés dans la prévention et la lutte contre la corruption active et passive, le blanchiment d’argent et d’autres aspects du crime organisé, dotés ou non de pouvoirs pour faire respecter la loi, comme les commissions chargées de la lutte contre la corruption et les organismes de suivi, les services spéciaux d’enquête, les institutions et les initiatives de contrôle de l’intégrité et de l’éthique, les ONG spécialisées, d’autres organisations de citoyens et de la société civile s’occupant directement de lutter contre la corruption.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15114</code>
-			<name>
-				<narrative>Domestic Revenue Mobilisation</narrative>
-				<narrative xml:lang="fr">Mobilisation des ressources intérieures</narrative>
-			</name>
-			<description>
-				<narrative>Support to domestic revenue mobilisation/tax policy, analysis and administration as well as non-tax public revenue, which includes work with ministries of finance, line ministries, revenue authorities or other local, regional or national public bodies. (Use code 16010 for social security and other social protection.)</narrative>
-				<narrative xml:lang="fr">Soutien à la mobilisation des ressources intérieures/politique fiscale, analyse et administration ainsi que les recettes non-fiscales, incluant le travail avec les ministères des finances, les ministères de tutelle, les autorités fiscales ou autres institutions publiques locales, régionales ou nationales (Utiliser le code 16010 pour la sécurité sociale et autres plans sociaux.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15116</code>
-			<name>
-				<narrative>Tax collection</narrative>
-				<narrative xml:lang="fr">Recouvrement de l'impôt</narrative>
-			</name>
-			<description>
-				<narrative>Operation of the inland revenue authority.</narrative>
-				<narrative xml:lang="fr">Fonctionnement de l'autorité nationale de recouvrement des impôts.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15117</code>
-			<name>
-				<narrative>Budget planning</narrative>
-				<narrative xml:lang="fr">Planification budgétaire</narrative>
-			</name>
-			<description>
-				<narrative>Operation of the budget office and planning as part of the budget process.</narrative>
-				<narrative xml:lang="fr">Fonctionnement des services de préparation du budget.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15118</code>
-			<name>
-				<narrative>National audit</narrative>
-				<narrative xml:lang="fr">Contrôle interne national</narrative>
-			</name>
-			<description>
-				<narrative>Operation of the accounting and audit services.</narrative>
-				<narrative xml:lang="fr">Administration et fonctionnement des services de vérification.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15119</code>
-			<name>
-				<narrative>Debt and aid management</narrative>
-				<narrative xml:lang="fr">Gestion de l'aide et de la dette publique</narrative>
-			</name>
-			<description>
-				<narrative>Management of public debt and foreign aid received (in the partner country). For reporting on debt reorganisation, use codes 600xx.</narrative>
-				<narrative xml:lang="fr">Gestion de la dette publique et de l'aide étrangère reçue (par le pays partenaire). Pour rapporter des ré-échelonnements de dette, utiliser les codes 600xx.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>15120</code>
-			<name>
-				<narrative>Public sector financial management</narrative>
-			</name>
-			<description>
-				<narrative>Strengthening financial and managerial accountability; public expenditure management; improving financial management systems; tax assessment procedures; budget drafting; field auditing; measures against waste, fraud and corruption.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15121</code>
-			<name>
-				<narrative>Foreign affairs</narrative>
-				<narrative xml:lang="fr">Affaires étrangères</narrative>
-			</name>
-			<description>
-				<narrative>Administration of external affairs and services.</narrative>
-				<narrative xml:lang="fr">Administration des affaires étrangères et services associés.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15122</code>
-			<name>
-				<narrative>Diplomatic missions</narrative>
-				<narrative xml:lang="fr">Missions diplomatiques</narrative>
-			</name>
-			<description>
-				<narrative>Operation of diplomatic and consular missions stationed abroad or at offices of international organisations.</narrative>
-				<narrative xml:lang="fr">Fonctionnement des missions diplomatiques ou consulaires à l'étranger ou auprès d'organisations internationales.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15123</code>
-			<name>
-				<narrative>Administration of developing countries' foreign aid</narrative>
-				<narrative xml:lang="fr">Gestion de l'aide étrangère des pays en développement</narrative>
-			</name>
-			<description>
-				<narrative>Support to administration of developing countries' foreign aid (including triangular and south-south cooperation).</narrative>
-				<narrative xml:lang="fr">Soutien à la gestion de l'aide étrangère offerte par les pays en développement (y compris la cooperation triangulaire et sud-sud).</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15124</code>
-			<name>
-				<narrative>General personnel services</narrative>
-				<narrative xml:lang="fr">Services généraux de personnel</narrative>
-			</name>
-			<description>
-				<narrative>Administration and operation of the civil service including policies, procedures and regulations.</narrative>
-				<narrative xml:lang="fr">Administration et fonctionnement de services généraux de personnel, y compris les politiques, réglements et procédures.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15125</code>
-			<name>
-				<narrative>Central procurement</narrative>
-				<narrative xml:lang="fr">Services centralisés d'approvisionnement et d'achat</narrative>
-			</name>
-			<description>
-				<narrative>Administration and operation of centralised supply and purchasing services.</narrative>
-				<narrative xml:lang="fr">Administration et fonction des services centralisés d'approvisionnement et d'achat.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15126</code>
-			<name>
-				<narrative>Other general public services</narrative>
-				<narrative xml:lang="fr">Autres services généraux</narrative>
-			</name>
-			<description>
-				<narrative>Maintenance and storage of government records and archives, operation of government-owned or occupied buildings, central motor vehicle pools, government-operated printing offices, centralised computer and data processing services, etc.</narrative>
-				<narrative xml:lang="fr">Tenue et stockage de dossiers et archives des administrations publiques, exploitation d'immeubles dont des administrations publiques sont propriétaires ou occupants, parcs centraux de véhicules, imprimeries exploitées par des administrations publiques, services centraux de calcul et d'informatique, etc.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15127</code>
-			<name>
-				<narrative>National monitoring and evaluation</narrative>
-				<narrative xml:lang="fr">Suivi et evaluation au niveau national</narrative>
-			</name>
-			<description>
-				<narrative>Operation or support of institutions providing national monitoring and evaluation.</narrative>
-				<narrative xml:lang="fr">Administration ou fonctionnement des services s'occupant de suivi et d'évaluation au niveau national.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15128</code>
-			<name>
-				<narrative>Local government finance</narrative>
-				<narrative xml:lang="fr">Financement des gouvernements locaux</narrative>
-			</name>
-			<description>
-				<narrative>Financial transfers to local government; support to institutions managing such transfers. (Use specific sector codes for sector-related transfers.)</narrative>
-				<narrative xml:lang="fr">Transferts financiers aux gouvernements locaux; soutien aux institutions administrant ces transferts. (Pour des transferts concernant des secteurs particuliers, utiliser les codes sectoriels appropriés.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15129</code>
-			<name>
-				<narrative>Other central transfers to institutions</narrative>
-				<narrative xml:lang="fr">Autres transferts du centre à des institutions</narrative>
-			</name>
-			<description>
-				<narrative>Transfers to non sector-specific autonomous bodies or state-owned enterprises outside of local government finance; support to institutions managing such transfers. (Use specific sector codes for sector-related transfers.)</narrative>
-				<narrative xml:lang="fr">Transferts aux organisations autonomes ou entreprises d'États non inclus dans le financement des gouvernements locaux; soutien aux institutions administrant ces transferts.(Pour des transferts concernant des secteurs particuliers, utiliser les codes sectoriels appropriés.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15130</code>
-			<name>
-				<narrative>Legal and judicial development</narrative>
-				<narrative xml:lang="fr">Développement des services légaux et judiciaires</narrative>
-			</name>
-			<description>
-				<narrative>Support to institutions, systems and procedures of the justice sector, both formal and informal; support to ministries of justice, the interior and home affairs; judges and courts; legal drafting services; bar and lawyers associations; professional legal education; maintenance of law and order and public safety; border management; law enforcement agencies, police, prisons and their supervision; ombudsmen; alternative dispute resolution, arbitration and mediation; legal aid and counsel; traditional, indigenous and paralegal practices that fall outside the formal legal system. Measures that support the improvement of legal frameworks, constitutions, laws and regulations; legislative and constitutional drafting and review; legal reform; integration of formal and informal systems of law. Public legal education; dissemination of information on entitlements and remedies for injustice; awareness campaigns. (Use codes 152xx for activities that are primarily aimed at supporting security system reform or undertaken in connection with post-conflict and peace building activities.)</narrative>
-				<narrative xml:lang="fr">Soutien aux institutions, systèmes et procédures du secteur de la justice, aussi bien officiels que non officiels ; soutien aux ministères de la justice et de l’intérieur ; juges et tribunaux ; services de rédaction des actes juridiques ; associations d’avocats et de juristes ; formation juridique professionnelle ; maintien de l’ordre et de la sécurité publique ; gestion des frontières ; organismes chargés de faire respecter la loi, police, prisons et leur supervision ; médiateurs ; mécanismes alternatifs de règlement des conflits, d’arbitrage et de médiation ; aide et conseil juridiques ; pratiques traditionnelles, indigènes et paralégales ne faisant pas partie du système juridique officiel. Mesures à l’appui de l’amélioration des cadres juridiques, constitutions, lois et réglementations ; rédaction et révision de textes législatifs et constitutionnels ; réforme juridique ; intégration des systèmes légaux officiels et non officiels. Éducation juridique ; diffusion d’informations sur les droits et les voies de recours en cas d’injustice ; campagnes de sensibilisation. (Utiliser les codes 152xx pour les activités ayant principalement pour objet de soutenir la réforme des systèmes de sécurité ou entreprises en liaison avec des activités de maintien de la paix à l’issue d’un conflit.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15131</code>
-			<name>
-				<narrative>Justice, law and order policy, planning and administration</narrative>
-				<narrative xml:lang="fr">Développement et administration des politiques de justice et de maintien de l'ordre</narrative>
-			</name>
-			<description>
-				<narrative>Judicial law and order sectors; policy development within ministries of justice or equivalents.</narrative>
-				<narrative xml:lang="fr">Justice et maintien de l'ordre; développement des politiques dans les ministères de la justice ou leur équivalent.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15132</code>
-			<name>
-				<narrative>Police</narrative>
-				<narrative xml:lang="fr">Police</narrative>
-			</name>
-			<description>
-				<narrative>Police affairs and services.</narrative>
-				<narrative xml:lang="fr">Administration des affaires et services de police.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15133</code>
-			<name>
-				<narrative>Fire and rescue services</narrative>
-				<narrative xml:lang="fr">Incendies et services de sauvetage</narrative>
-			</name>
-			<description>
-				<narrative>Fire-prevention and fire-fighting affairs and services.</narrative>
-				<narrative xml:lang="fr">Administration des affaires et services de protection et de lutte contre l'incendie.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15134</code>
-			<name>
-				<narrative>Judicial affairs</narrative>
-				<narrative xml:lang="fr">Système judiciaire</narrative>
-			</name>
-			<description>
-				<narrative>Civil and criminal law courts and the judicial system, including enforcement of fines and legal settlements imposed by the courts and operation of parole and probation systems.</narrative>
-				<narrative xml:lang="fr">Administration, fonctionnement ou soutien des tribunaux civils et pénals et du système judiciaire, y compris mise à exécution des amendes et des obligations imposées par les tribunaux, et suivi des programmes de mise en liberté conditionnelle et de mise à l'épreuve.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15135</code>
-			<name>
-				<narrative>Ombudsman</narrative>
-				<narrative xml:lang="fr">Ombudsman</narrative>
-			</name>
-			<description>
-				<narrative>Independent service representing the interests of the public by investigating and addressing complaints of unfair treatment or maladministration.</narrative>
-				<narrative xml:lang="fr">Officier indépendant représentant les intérêts du public en faisant enquête et en remédiant aux plaintes de traitement inéquitable ou de mauvaise gestion.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15136</code>
-			<name>
-				<narrative>Immigration</narrative>
-				<narrative xml:lang="fr">Immigration</narrative>
-			</name>
-			<description>
-				<narrative>Immigration affairs and services, including alien registration, issuing work and travel documents to immigrants.</narrative>
-				<narrative xml:lang="fr">Administration des affaires et services d'immigration, y compris l'enregistrement des étrangers et la délivrance de documents de travail et de voyage aux immigrants.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15137</code>
-			<name>
-				<narrative>Prisons</narrative>
-				<narrative xml:lang="fr">Prisons</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>15140</code>
-			<name>
-				<narrative>Government administration</narrative>
-			</name>
-			<description>
-				<narrative>Systems of government including parliament, local government, decentralisation; civil service and civil service reform. Including general services by government (or commissioned by government) not elsewhere specified e.g. police, fire protection; cartography, meteorology, legal metrology, aerial surveys and remote sensing; administrative buildings.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15142</code>
-			<name>
-				<narrative>Macroeconomic policy</narrative>
-				<narrative xml:lang="fr">Politique macroéconomique</narrative>
-			</name>
-			<description>
-				<narrative>Macroeconomic policy development and implementation.</narrative>
-				<narrative xml:lang="fr">Développement et mise en œuvre de la politique macroéconomique.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15143</code>
-			<name>
-				<narrative>Meteorological services</narrative>
-				<narrative xml:lang="fr">Services météorologiques</narrative>
-			</name>
-			<description>
-				<narrative>Operation or support of institutions dealing with weather forecasting.</narrative>
-				<narrative xml:lang="fr">Administration ou fonctionnement des institutions s'occupant de météorologie.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15144</code>
-			<name>
-				<narrative>National standards development</narrative>
-				<narrative xml:lang="fr">Élaboration des normes nationales</narrative>
-			</name>
-			<description>
-				<narrative>Operation or support of institutions dealing with national standards development. (Use code 16062 for statistical capacity-building.)</narrative>
-				<narrative xml:lang="fr">Administration ou fonctionnement des institutions s'occupant des normes nationales. (Utiliser le code 16062 pour le renforcement des capacités statistiques)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15150</code>
-			<name>
-				<narrative>Democratic participation and civil society</narrative>
-				<narrative xml:lang="fr">Participation démocratique et société civile</narrative>
-			</name>
-			<description>
-				<narrative>Support to the exercise of democracy and diverse forms of participation of citizens beyond elections (15151); direct democracy instruments such as referenda and citizens’ initiatives; support to organisations to represent and advocate for their members, to monitor, engage and hold governments to account, and to help citizens learn to act in the public sphere; curricula and teaching for civic education at various levels. (This purpose code is restricted to activities targeting governance issues. When assistance to civil society is for non-governance purposes use other appropriate purpose codes.)</narrative>
-				<narrative xml:lang="fr">Soutien à l’exercice de la démocratie et à diverses formes de participation des citoyens, excepté les élections (15151) ; instruments de démocratie directe comme les référendums et les initiatives de citoyens ; soutien aux organisations pour représenter et défendre leurs membres, assurer un suivi, participer et demander des comptes aux gouvernements, et pour aider les citoyens à apprendre à agir dans la sphère publique ; programmes d’études et enseignement de l’éducation civique à différents niveaux. (Ce code-objet est limité aux activités ciblées sur des questions de gouvernance. Lorsque l’aide à la société civile ne concerne pas la gouvernance, utiliser d’autres codes-objet appropriés.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15151</code>
-			<name>
-				<narrative>Elections</narrative>
-				<narrative xml:lang="fr">Élections</narrative>
-			</name>
-			<description>
-				<narrative>Electoral management bodies and processes, election observation, voters' education. (Use code 15230 when in the context of an international peacekeeping operation).</narrative>
-				<narrative xml:lang="fr">Organes et processus de gestion électorale, observation des processus électoraux, éducation civique des électeurs. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d’une opération internationale de maintien de la paix.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15152</code>
-			<name>
-				<narrative>Legislatures and political parties</narrative>
-				<narrative xml:lang="fr">Assemblées législatives et partis politiques</narrative>
-			</name>
-			<description>
-				<narrative>Assistance to strengthen key functions of legislatures/ parliaments including subnational assemblies and councils (representation; oversight; legislation), such as improving the capacity of legislative bodies, improving legislatures’ committees and administrative procedures,; research and information management systems; providing training programmes for legislators and support personnel. Assistance to political parties and strengthening of party systems.</narrative>
-				<narrative xml:lang="fr">Aide au renforcement des fonctions clés des assemblées législatives/parlements, y compris des assemblées et conseils infranationaux (représentation ; surveillance ; législation), par exemple amélioration des capacités des organes législatifs, amélioration du fonctionnement des commissions et des procédures administratives des assemblées législatives ; systèmes de gestion de la recherche et de l’information ; mise en place de programmes de formation à l’intention des législateurs et du personnel de soutien. Aide aux partis politiques et renforcement des systèmes de partis.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15153</code>
-			<name>
-				<narrative>Media and free flow of information</narrative>
-				<narrative xml:lang="fr">Médias et liberté de l’information</narrative>
-			</name>
-			<description>
-				<narrative>Activities that support free and uncensored flow of information on public issues; activities that increase the editorial and technical skills and the integrity of the print and broadcast media, e.g. training of journalists. (Use codes 22010-22040 for provision of equipment and capital assistance to media.)</narrative>
-				<narrative xml:lang="fr">Activités qui favorisent une diffusion libre et non censurée de l’information sur les questions publiques ; activités visant à améliorer les compétences rédactionnelles et techniques, et l’intégrité des médias – presse écrite, radio et télévision – par exemple, formation des journalistes. (Utiliser les codes 22010-22040 pour la fourniture d’équipements et d’une aide financière aux médias.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15154</code>
-			<name>
-				<narrative>Executive office</narrative>
-				<narrative xml:lang="fr">Exécutif</narrative>
-			</name>
-			<description>
-				<narrative>Administration, operation or support of executive office. Includes office of the chief executive at all levels of government (monarch, governor-general, president, prime minister, governor, mayor, etc.).</narrative>
-				<narrative xml:lang="fr">Administration, fonctionnement des organes exécutifs, y compris le cabinet du chef de l'exécutif à tous les niveaux de gouvernement (monarque, gouverneur général, président, premier ministre, gouverneur, maire, etc.).</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15155</code>
-			<name>
-				<narrative>Tax policy and administration support</narrative>
-				<narrative xml:lang="fr">Politique et administration fiscales</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15156</code>
-			<name>
-				<narrative>Other non-tax revenue mobilisation</narrative>
-				<narrative xml:lang="fr">Mobilisation des ressources intérieures autre que les recettes non-fiscales</narrative>
-			</name>
-			<description>
-				<narrative>Non-tax public revenue, which includes line ministries, revenue authorities or other local, regional or national public bodies.</narrative>
-				<narrative xml:lang="fr">Recettes non-fiscales incluant les ministères de tutelle, les autorités fiscales ou autres institutions publiques locales, régionales ou nationales.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15160</code>
-			<name>
-				<narrative>Human rights</narrative>
-				<narrative xml:lang="fr">Droits de la personne</narrative>
-			</name>
-			<description>
-				<narrative>Measures to support specialised official human rights institutions and mechanisms at universal, regional, national and local levels in their statutory roles to promote and protect civil and political, economic, social and cultural rights as defined in international conventions and covenants; translation of international human rights commitments into national legislation; reporting and follow-up; human rights dialogue. Human rights defenders and human rights NGOs; human rights advocacy, activism, mobilisation; awareness raising and public human rights education. Human rights programming targeting specific groups, e.g. children, persons with disabilities, migrants, ethnic, religious, linguistic and sexual minorities, indigenous people and those suffering from caste discrimination, victims of trafficking, victims of torture. (Use code 15230 when in the context of a peacekeeping operation.) (As from 2017 reporting on 2016 flows, use code 15180 for ending violence against women and girls.)</narrative>
-				<narrative xml:lang="fr">Mesures visant à soutenir les institutions et mécanismes spécialisés dans les droits de la personne opérant aux niveaux mondial, régional, national ou local, dans leur mission officielle de promotion et de protection des droits civils et politiques, économiques, sociaux et culturels tels qu’ils sont définis dans les conventions et pactes internationaux ; transposition dans la législation nationale des engagements internationaux concernant les droits de la personne ; notification et suivi ; dialogue sur les droits de la personne. Défenseurs des droits de la personne et ONG œuvrant dans ce domaine ; promotion des droits de la personne, défense active, mobilisation ; activités de sensibilisation et éducation des citoyens aux droits de la personne. Élaboration de programmes concernant les droits de la personne, ciblés sur des groupes particuliers, comme les enfants, les individus en situation de handicap, les migrants, les minorités ethniques, religieuses, linguistiques et sexuelles, les populations autochtones et celles qui sont victimes de discrimination de caste, les victimes de la traite d’êtres humains, les victimes de la torture. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d’une opération internationale de maintien de la paix.) (A partir de 2017 pour la notification des apports en 2016, utiliser le code 15180 pour les activités visant l’élimination de la violence à l’égard des femmes et des filles.)</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>15161</code>
-			<name>
-				<narrative>Elections</narrative>
-			</name>
-			<description>
-				<narrative>Electoral assistance and monitoring, voters' education [other than in connection with UN peace building (15230)].</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>15162</code>
-			<name>
-				<narrative>Human rights</narrative>
-			</name>
-			<description>
-				<narrative>Monitoring of human rights performance; support for national and regional human rights bodies; protection of ethnic, religious and cultural minorities [other than in connection with un peace building (15230)].</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>15163</code>
-			<name>
-				<narrative>Free flow of information</narrative>
-			</name>
-			<description>
-				<narrative>Uncensored flow of information on public issues, including activities that increase the professionalism, skills and integrity of the print and broadcast media (e.g. training of journalists).</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>15164</code>
-			<name>
-				<narrative>Women's equality organisations and institutions</narrative>
-			</name>
-			<description>
-				<narrative>Support for institutions and organisations (governmental and non-governmental) working for gender equality and women's empowerment.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15170</code>
-			<name>
-				<narrative>Women’s equality organisations and institutions</narrative>
-				<narrative xml:lang="fr">Organisations et institutions pour la lutte contre la corruption</narrative>
-			</name>
-			<description>
-				<narrative>Support for institutions and organisations (governmental and non-governmental) working for gender equality and women’s empowerment.</narrative>
-				<narrative xml:lang="fr">Soutien aux institutions et organisations (gouvernementales et non gouvernementales) qui œuvrent pour l’égalité homme-femme et l’autonomisation des femmes.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15180</code>
-			<name>
-				<narrative>Ending violence against women and girls</narrative>
-				<narrative xml:lang="fr">Élimination de la violence à l’égard des femmes et des filles</narrative>
-			</name>
-			<description>
-				<narrative>Support to programmes designed to prevent and eliminate all forms of violence against women and girls/gender-based violence. This encompasses a broad range of forms of physical, sexual and psychological violence including but not limited to: intimate partner violence (domestic violence); sexual violence; female genital mutilation/cutting (FGM/C); child, early and forced marriage; acid throwing; honour killings; and trafficking of women and girls. Prevention activities may include efforts to empower women and girls; change attitudes, norms and behaviour; adopt and enact legal reforms; and strengthen implementation of laws and policies on ending violence against women and girls, including through strengthening institutional capacity. Interventions to respond to violence against women and girls/gender-based violence may include expanding access to services including legal assistance, psychosocial counselling and health care; training personnel to respond more effectively to the needs of survivors; and ensuring investigation, prosecution and punishment of perpetrators of violence.</narrative>
-				<narrative xml:lang="fr">Soutien à des programmes visant à prévenir et éliminer toutes les formes de violence à l’égard des femmes et des filles/violence basée sur le genre. Cette définition recouvre des formes diverses de violence physique, sexuelle et psychologique et s'entend comme englobant, sans y être limitée : la violence infligée par un partenaire intime (violence domestique) ; la violence sexuelle ; les mutilations génitales féminines/excision (MGF/E); les mariages d’enfants, précoces et forcés ; les attaques à l’acide ; les crimes d’honneur ; et la traite des femmes et des filles. Les activités de prévention peuvent notamment inclure les efforts visant soutenir l’autonomisation des femmes et des filles ; le changement des attitudes, normes et comportements ; l’adoption et la mise en oeuvre de réformes légales ; et le renforcement de l’application des lois et des politiques visant à mettre fin à la violence à l’égard des femmes et des filles, y compris à travers le renforcement des capacités institutionnelles. Les interventions visant à répondre à la violence à l’égard des femmes et des filles/violence basée sur le genre peuvent notamment inclure l’élargissement de l’accès aux services y compris à l’assistance juridique, l’accompagnement psychologique et les soins médicaux ; la formation du personnel en vue de répondre plus efficacement aux besoins des survivantes ; et les actions visant à garantir l’ouverture d’enquêtes, la poursuite en justice et la condamnation des auteurs de violence.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15185</code>
-			<name>
-				<narrative>Local government administration</narrative>
-				<narrative xml:lang="fr">Administration publique locale</narrative>
-			</name>
-			<description>
-				<narrative>Decentralisation processes (including political, administrative and fiscal dimensions); intergovernmental relations and federalism; strengthening local authorities.</narrative>
-				<narrative xml:lang="fr">Processus de décentralisation (y compris aspects politiques, administratifs et budgétaires) ; relations intergouvernementales et fédéralisme ; renforcement des autorités locales.</narrative>
-			</description>
-			<category>151</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15210</code>
-			<name>
-				<narrative>Security system management and reform</narrative>
-				<narrative xml:lang="fr">Gestion et réforme des systèmes de sécurité</narrative>
-			</name>
-			<description>
-				<narrative>Technical co-operation provided to parliament, government ministries, law enforcement agencies and the judiciary to assist review and reform of the security system to improve democratic governance and civilian control; technical co-operation provided to government to improve civilian oversight and democratic control of budgeting, management, accountability and auditing of security expenditure, including military budgets, as part of a public expenditure management programme; assistance to civil society to enhance its competence and capacity to scrutinise the security system so that it is managed in accordance with democratic norms and principles of accountability, transparency and good governance. [Other than in the context of an international peacekeeping operation (15230).]</narrative>
-				<narrative xml:lang="fr">Coopération technique en faveur des parlements, des ministères publics, des services chargés de faire respecter la loi et des instances judiciaires pour aider à examiner et à réformer les systèmes de sécurité afin d’améliorer la gouvernance démocratique et le contrôle par les civils ; coopération technique en faveur des gouvernements à l’appui du renforcement de la supervision civile et du contrôle démocratique sur la budgétisation, la gestion, la transparence et l’audit des dépenses de sécurité, y compris les dépenses militaires, dans le cadre d’un programme d’amélioration de la gestion des dépenses publiques ; assistance apportée à la société civile en vue de renforcer ses compétences en matière de sécurité et sa capacité de veiller à ce que le système de sécurité soit géré conformément aux normes démocratiques et aux principes de responsabilité, de transparence et de bonne gouvernance. [Autre que dans le cadre d’une opération internationale de maintien de la paix (15230)].</narrative>
-			</description>
-			<category>152</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15220</code>
-			<name>
-				<narrative>Civilian peace-building, conflict prevention and resolution</narrative>
-				<narrative xml:lang="fr">Dispositifs civils de construction de la paix, et de prévention et de règlement des conflits</narrative>
-			</name>
-			<description>
-				<narrative>Support for civilian activities related to peace building, conflict prevention and resolution, including capacity building, monitoring, dialogue and information exchange. Bilateral participation in international civilian peace missions such as those conducted by the UN Department of Political Affairs (UNDPA) or the European Union (European Security and Defence Policy), and contributions to civilian peace funds or commissions (e.g. Peacebuilding Commission, Peacebuilding thematic window of the MDG achievement fund etc.). The contributions can take the form of financing or provision of equipment or civilian or military personnel (e.g. for training civilians). (Use code 15230 for bilateral participation in international peacekeeping operations).</narrative>
-				<narrative xml:lang="fr">Aide à des activités civiles de construction de la paix, et de prévention et de règlement des conflits, y compris renforcement des capacités, suivi, dialogue et échange d’informations. Participation bilatérale à des missions civiles internationales en faveur de la paix comme celles qui sont conduites par le Département des affaires politiques des Nations unies (UNDPA) ou l’Union européenne (Politique européenne de sécurité et de défense), et contributions à des fonds ou commissions civils pour la paix (par exemple, Commission de consolidation de la paix, guichet thématique « Construction de la paix » du Fonds pour la réalisation des OMD, etc.). Les contributions peuvent être apportées sous la forme d’un financement ou à travers la fourniture de matériel ou de personnel civil ou militaire (par exemple, pour la formation des civils). (Utiliser le code 15230 pour la participation bilatérale à des opérations internationales de maintien de la paix.)</narrative>
-			</description>
-			<category>152</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15230</code>
-			<name>
-				<narrative>Participation in international peacekeeping operations</narrative>
-				<narrative xml:lang="fr">Participation à des opérations internationales de maintien de la paix</narrative>
-			</name>
-			<description>
-				<narrative>Bilateral participation in peacekeeping operations mandated or authorised by the United Nations (UN) through Security Council resolutions, and conducted by international organisations, e.g. UN, NATO, the European Union (Security and Defence Policy security-related operations), or regional groupings of developing countries. Direct contributions to the UN Department for Peacekeeping Operations (UNDPKO) budget are excluded from bilateral ODA (they are reportable in part as multilateral ODA, see Annex 9). The activities that can be reported as bilateral ODA under this code are limited to: human rights and election monitoring; reintegration of demobilised soldiers; rehabilitation of basic national infrastructure; monitoring or retraining of civil administrators and police forces; security sector reform and other rule of law-related activities; training in customs and border control procedures; advice or training in fiscal or macroeconomic stabilisation policy; repatriation and demobilisation of armed factions, and disposal of their weapons; explosive mine removal. The enforcement aspects of international peacekeeping operations are not reportable as ODA. ODA-eligible bilateral participation in peacekeeping operations can take the form of financing or provision of equipment or military or civilian personnel (e.g. police officers). The reportable cost is calculated as the excess over what the personnel and equipment would have cost to maintain had they not been assigned to take part in a peace operation. Costs for military contingents participating in UNDPKO peacekeeping operations are not reportable as ODA. International peacekeeping operations may include humanitarian-type activities (contributions to the form of equipment or personnel), as described in codes 7xxxx. These should be included under code 15230 if they are an integrated part of the activities above, otherwise they should be reported as humanitarian aid.NB: When using this code, indicate the name of the operation in the short description of the activity reported.</narrative>
-				<narrative xml:lang="fr">Participation bilatérale à des opérations de maintien de la paix mandatées ou autorisées par les Nations unies (NU) à travers des résolutions du Conseil de sécurité, et conduites par des organisations internationales, par exemple les Nations unies, l’OTAN, l’Union européenne (opérations liées à la sécurité dans le cadre de la Politique européenne de sécurité et de défense) ou des groupements régionaux de pays en développement. Les contributions directes au budget du Département des opérations de maintien de la paix des NU (UNDPKO) ne sont pas à notifier comme opérations bilatérales (elles comptent en partie comme APD multilatérale, voir l’annexe 9). Les activités qui peuvent être notifiées au titre de l’APD bilatérale sous ce code sont uniquement les suivantes : droits de l’homme et supervision des élections ; réinsertion des soldats démobilisés ; remise en état des infrastructures de base du pays ; supervision ou recyclage des administrateurs civils et des forces de police ; réforme des systèmes de sécurité et autres activités liées à l’État de droit ; formation aux procédures douanières et de contrôle aux frontières ; conseil ou formation concernant les politiques budgétaires ou macroéconomiques de stabilisation ; rapatriement et démobilisation des factions armées et destruction de leurs armes ; déminage. Les activités d’imposition de la paix entreprises dans le cadre des opérations internationales de maintien de la paix ne sont comptabilisables dans l’APD. Les contributions bilatérales comptabilisables dans l’APD au titre des opérations de maintien de la paix peuvent être apportées sous la forme d’un financement ou à travers la fourniture de matériel ou de personnel militaire ou civil (par exemple, fonctionnaires de police). Le coût à notifier est donné par le surcoût encouru pour l’entretien du personnel et du matériel du fait qu’ils ont pris part à une opération de maintien de la paix. Les coûts relatifs aux contingents militaires participant à des opérations de maintien de la paix de l’UNDPKO ne sont pas comptabilisables en APD. Les opérations internationales de maintien de la paix peuvent comprendre des activités de type humanitaire (contributions apportées sous la forme de matériel ou de personnel), comme celles qui sont décrites sous les codes 7xxxx. Elles doivent être incluses sous le code 15230 si elles font partie intégrante des activités ci-dessus, sinon elles doivent être notifiées sous l’aide humanitaire. NB : Lors de l’utilisation de ce code, indiquer le nom de l’opération dans la description succincte de l’activité notifiée.</narrative>
-			</description>
-			<category>152</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15240</code>
-			<name>
-				<narrative>Reintegration and SALW control</narrative>
-				<narrative xml:lang="fr">Réintégration et contrôle des armes légères et de petit calibre</narrative>
-			</name>
-			<description>
-				<narrative>Reintegration of demobilised military personnel into the economy; conversion of production facilities from military to civilian outputs; technical co-operation to control, prevent and/or reduce the proliferation of small arms and light weapons (SALW) – see para. 80 of the Directives for definition of SALW activities covered. [Other than in the context of an international peacekeeping operation (15230) or child soldiers (15261)].</narrative>
-				<narrative xml:lang="fr">Réinsertion du personnel militaire démobilisé dans la vie économique et civile ; conversion des usines d’armes en usines de produits à usage civil ; coopération technique destinée à contrôler, prévenir et/ou réduire la prolifération d’armes légères et de petit calibre – voir le paragraphe 80 des Directives pour la définition des activités couvertes. [Autre que dans le cadre d’une opération internationale de maintien de la paix (15230) ou enfants soldats (15261)].</narrative>
-			</description>
-			<category>152</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15250</code>
-			<name>
-				<narrative>Removal of land mines and explosive remnants of war</narrative>
-				<narrative xml:lang="fr">Enlèvement des mines terrestres et restes explosifs de guerre</narrative>
-			</name>
-			<description>
-				<narrative>All activities related to land mines and explosive remnants of war which have benefits to developing countries as their main objective, including removal of land mines and explosive remnants of war, and stockpile destruction for developmental purposes [other than in the context of an international peacekeeping operation (15230)]; risk education and awareness raising; rehabilitation, reintegration and assistance to victims, and research and development on demining and clearance. Only activities for civilian purposes are ODA-eligible.</narrative>
-				<narrative xml:lang="fr">Toutes les activités liées aux mines terrestres et aux restes explosifs de guerre dont le but essentiel est de bénéficier aux pays en développement, y compris l’enlèvement des mines terrestres et des restes explosifs de guerre et la destruction des stocks à des fins de développement [autre qu’en rapport compris l’enlèvement des mines terrestres et des restes explosifs de guerre et la destruction des stocks à des fins de développement [autre qu’en rapport avec la participation à des opérations internationales de maintien de la paix (15230)] ; sensibilisation au risque ; réhabilitation, réinsertion et assistance aux victimes, et les activités de recherche et développement sur le déminage. Seules les activités menées à fins civiles sont éligibles à l’APD.</narrative>
-			</description>
-			<category>152</category>
-		</codelist-item>
-		<codelist-item>
-			<code>15261</code>
-			<name>
-				<narrative>Child soldiers (Prevention and demobilisation)</narrative>
-				<narrative xml:lang="fr">Enfants soldats (Prévention et démobilisation)</narrative>
-			</name>
-			<description>
-				<narrative>Technical co-operation provided to government – and assistance to civil society organisations – to support and apply legislation designed to prevent the recruitment of child soldiers, and to demobilise, disarm, reintegrate, repatriate and resettle (DDR) child soldiers.</narrative>
-				<narrative xml:lang="fr">Coopération technique en faveur des gouvernements – et assistance aux organisations de la société civile – à l’appui de l’adoption et de l’application de lois destinées à empêcher le recrutement d’enfants en tant que soldats ; appui à la démobilisation, au désarmement, à la réinsertion, au rapatriement et à la réintégration (DDR) des enfants soldats.</narrative>
-			</description>
-			<category>152</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16010</code>
-			<name>
-				<narrative>Social/ welfare services</narrative>
-				<narrative xml:lang="fr">Services sociaux</narrative>
-			</name>
-			<description>
-				<narrative>Social legislation and administration; institution capacity building and advice; social security and other social schemes; special programmes for the elderly, orphans, the disabled, street children; social dimensions of structural adjustment; unspecified social infrastructure and services, including consumer protection.</narrative>
-				<narrative xml:lang="fr">Législation et administration sociales ; renforcement des capacités institutionnelles et conseils ; sécurité sociale et autres plans sociaux ; programmes spécifiques pour les personnes âgées, orphelins, handicapés, enfants abandonnés ; dimensions sociales de l’ajustement structurel ; infrastructure et services sociaux non spécifiés, y compris la protection des consommateurs.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16011</code>
-			<name>
-				<narrative>Social protection and welfare services policy, planning and administration</narrative>
-				<narrative xml:lang="fr">Politiques, planification et administration des services de protection sociale</narrative>
-			</name>
-			<description>
-				<narrative>Administration of overall social protection policies, plans, programmes and budgets including legislation, standards and statistics on social protection.</narrative>
-				<narrative xml:lang="fr">Administration des politiques, plans, programmes et budgets généraux de protection sociale y compris les lois, normes et statistiques sur la protection sociale.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16012</code>
-			<name>
-				<narrative>Social security (excl pensions)</narrative>
-				<narrative xml:lang="fr">Protection sociale (excluant retraites)</narrative>
-			</name>
-			<description>
-				<narrative>Social protection shemes in the form of cash or in-kind benefits to people unable to work due to sickness or injury.</narrative>
-				<narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces ou en nature aux personnes inaptes au travail pour cause de maladie ou par suite d'un accident.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16013</code>
-			<name>
-				<narrative>General pensions</narrative>
-				<narrative xml:lang="fr">Retraites</narrative>
-			</name>
-			<description>
-				<narrative>Social protection schemes in the form of cash or in-kind benefits, including pensions, against the risks linked to old age.</narrative>
-				<narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces et en nature contre les risques liés à la vieillesse.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16014</code>
-			<name>
-				<narrative>Civil service pensions</narrative>
-				<narrative xml:lang="fr">Régimes de retraite des fonctionnaires</narrative>
-			</name>
-			<description>
-				<narrative>Pension schemes for government personnel.</narrative>
-				<narrative xml:lang="fr">Les régimes de pension des fonctionnaires.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16015</code>
-			<name>
-				<narrative>Social services (incl youth development and women+ children)</narrative>
-				<narrative xml:lang="fr">Services sociaux (y compris jeunes, femmes et enfants)</narrative>
-			</name>
-			<description>
-				<narrative>Social protection schemes in the form of cash or in-kind benefits to households with dependent children, including parental leave benefits.</narrative>
-				<narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces et en nature aux ménages ayant des enfants à charge, y compris les prestations de congé parental.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16020</code>
-			<name>
-				<narrative>Employment policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de l’emploi et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Employment policy and planning; labour law; labour unions; institution capacity building and advice; support programmes for unemployed; employment creation and income generation programmes; occupational safety and health; combating child labour.</narrative>
-				<narrative xml:lang="fr">Politique et planification de l’emploi ; législation ; syndicats ; renforcement des capacités institutionnelles et conseils ; programmes de l’aide aux chômeurs ; programmes de création d’emplois et de génération de revenus ; sécurité et santé dans le travail ; lutte contre le travail des enfants.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16030</code>
-			<name>
-				<narrative>Housing policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique du logement et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Housing sector policy, planning and programmes; excluding low-cost housing and slum clearance (16040).</narrative>
-				<narrative xml:lang="fr">Politique du logement, planification et programmes ; à l’exclusion du logement à coût réduit (16040).</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16040</code>
-			<name>
-				<narrative>Low-cost housing</narrative>
-				<narrative xml:lang="fr">Logement à coût réduit</narrative>
-			</name>
-			<description>
-				<narrative>Including slum clearance.</narrative>
-				<narrative xml:lang="fr">Y compris la suppression des bidonvilles.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16050</code>
-			<name>
-				<narrative>Multisector aid for basic social services</narrative>
-				<narrative xml:lang="fr">Aide plurisectorielle pour les services sociaux de base</narrative>
-			</name>
-			<description>
-				<narrative>Basic social services are defined to include basic education, basic health, basic nutrition, population/reproductive health and basic drinking water supply and basic sanitation.</narrative>
-				<narrative xml:lang="fr">Les services sociaux de base incluent l’éducation de base, la santé de base, les activités en matière de population/santé et fertilité ainsi que les systèmes de distribution d’eau potable de base et assainissement de base.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16061</code>
-			<name>
-				<narrative>Culture and recreation</narrative>
-				<narrative xml:lang="fr">Culture et loisirs</narrative>
-			</name>
-			<description>
-				<narrative>Including libraries and museums.</narrative>
-				<narrative xml:lang="fr">Y compris bibliothèques et musées.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16062</code>
-			<name>
-				<narrative>Statistical capacity building</narrative>
-				<narrative xml:lang="fr">Renforcement des capacités statistiques</narrative>
-			</name>
-			<description>
-				<narrative>Both in national statistical offices and any other government ministries.</narrative>
-				<narrative xml:lang="fr">Dans les offices statistiques nationaux et les autres ministères concernés.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16063</code>
-			<name>
-				<narrative>Narcotics control</narrative>
-				<narrative xml:lang="fr">Lutte contre le trafic de drogues</narrative>
-			</name>
-			<description>
-				<narrative>In-country and customs controls including training of the police; educational programmes and awareness campaigns to restrict narcotics traffic and in-country distribution.</narrative>
-				<narrative xml:lang="fr">Contrôles intérieurs et contrôles douaniers y compris la formation de la police, programmes d’éducation et de sensibilisation pour limiter le trafic de drogues et la distribution domestique.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16064</code>
-			<name>
-				<narrative>Social mitigation of HIV/AIDS</narrative>
-				<narrative xml:lang="fr">Atténuation de l’impact social du VIH/sida</narrative>
-			</name>
-			<description>
-				<narrative>Special programmes to address the consequences of HIV/AIDS, e.g. social, legal and economic assistance to people living with HIV/AIDS including food security and employment; support to vulnerable groups and children orphaned by HIV/AIDS; human rights of HIV/AIDS affected people.</narrative>
-				<narrative xml:lang="fr">Programmes spéciaux visant les conséquences sociales du VIH/sida, par exemple assistance sociale, juridique et économique aux personnes vivant avec le VIH/sida y compris sécurité alimentaire et emploi ; soutien aux groupes vulnérables et aux enfants orphelins du sida ; droits de l’homme pour les personnes atteintes par le VIH/sida.</narrative>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16065</code>
-			<name>
-				<narrative>Recreation and sport</narrative>
-				<narrative xml:lang="fr">Récréation et sport</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>16066</code>
-			<name>
-				<narrative>Culture</narrative>
-				<narrative xml:lang="fr">Culture</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>160</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21010</code>
-			<name>
-				<narrative>Transport policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique des transports et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Transport sector policy, planning and programmes; aid to transport ministries; institution capacity building and advice; unspecified transport; activities that combine road, rail, water and/or air transport. Whenever possible, report transport of goods under the sector of the good being transported.</narrative>
-				<narrative xml:lang="fr">Politique des transports, planification et programmes ; aide aux ministères du transport ; renforcement des capacités institutionnelles et conseils ; transports non spécifiés ; activités qui recouvrent le transport routier, le transport ferroviaire, le transport par voies d’eau et/ou le transport aérien. Autant que possible, notifier le transport de marchandises sous le secteur économique de la marchandise transportée.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21011</code>
-			<name>
-				<narrative>Transport policy, planning and administration</narrative>
-				<narrative xml:lang="fr">Politiques, planification et administration des transports</narrative>
-			</name>
-			<description>
-				<narrative>Administration of affairs and services concerning transport systems.</narrative>
-				<narrative xml:lang="fr">Administration et fonctionnement des services reliés aux politiques de transport.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21012</code>
-			<name>
-				<narrative>Public transport services</narrative>
-				<narrative xml:lang="fr">Transports en commun</narrative>
-			</name>
-			<description>
-				<narrative>Administration of affairs and services concerning public transport.</narrative>
-				<narrative xml:lang="fr">Administration des affaires et services concernant les transports en commun.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21013</code>
-			<name>
-				<narrative>Transport regulation</narrative>
-				<narrative xml:lang="fr">Réglementation des transports</narrative>
-			</name>
-			<description>
-				<narrative>Supervision and regulation of users, operations, construction and maintenance of transport systems (registration, licensing, inspection of equipment, operator skills and training; safety standards, franchises, tarriffs, levels of service, etc.).</narrative>
-				<narrative xml:lang="fr">Contrôle et réglementation des utilisateurs de systèmes de transport (immatriculation, permis, inspection du matériel, compétences et formation des agents, normes de sûreté, licences, tarifs, niveau des services, etc.).</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21020</code>
-			<name>
-				<narrative>Road transport</narrative>
-				<narrative xml:lang="fr">Transport routier</narrative>
-			</name>
-			<description>
-				<narrative>Road infrastructure, road vehicles; passenger road transport, motor passenger cars.</narrative>
-				<narrative xml:lang="fr">Infrastructure routière, véhicules ; transport routier de voyageurs, voitures particulières.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21021</code>
-			<name>
-				<narrative>Feeder road construction</narrative>
-				<narrative xml:lang="fr">Construction des voies de desserte</narrative>
-			</name>
-			<description>
-				<narrative>Construction or operation of feeder road transport systems and facilities.</narrative>
-				<narrative xml:lang="fr">Construction ou exploitation des voies de desserte et systèmes afférent.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21022</code>
-			<name>
-				<narrative>Feeder road maintenance</narrative>
-				<narrative xml:lang="fr">Entretien des voies de desserte</narrative>
-			</name>
-			<description>
-				<narrative>Maintenance of feeder road transport systems and facilities.</narrative>
-				<narrative xml:lang="fr">Entretien des voies de desserte et systèmes afférents.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21023</code>
-			<name>
-				<narrative>National road construction</narrative>
-				<narrative xml:lang="fr">Construction des routes nationales</narrative>
-			</name>
-			<description>
-				<narrative>Construction or operation of national road transport systems and facilities.</narrative>
-				<narrative xml:lang="fr">Construction ou exploitation des routes nationales et systèmes afférents.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21024</code>
-			<name>
-				<narrative>National road maintenance</narrative>
-				<narrative xml:lang="fr">Entretien des routes nationales</narrative>
-			</name>
-			<description>
-				<narrative>Maintenance of national road transport systems and facilities.</narrative>
-				<narrative xml:lang="fr">Entretien des routes nationales et systèmes afférents.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21030</code>
-			<name>
-				<narrative>Rail transport</narrative>
-				<narrative xml:lang="fr">Transport ferroviaire</narrative>
-			</name>
-			<description>
-				<narrative>Rail infrastructure, rail equipment, locomotives, other rolling stock; including light rail (tram) and underground systems.</narrative>
-				<narrative xml:lang="fr">Infrastructure ferroviaire, matériel ferroviaire, locomotives, autre matériel roulant ; y compris les tramways et les métropolitains.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21040</code>
-			<name>
-				<narrative>Water transport</narrative>
-				<narrative xml:lang="fr">Transport par voies d’eau</narrative>
-			</name>
-			<description>
-				<narrative>Harbours and docks, harbour guidance systems, ships and boats; river and other inland water transport, inland barges and vessels.</narrative>
-				<narrative xml:lang="fr">Ports et docks, systèmes de guidage, navires et bateaux ; transport sur voies navigables intérieures, bateaux de voies d’eau intérieures.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21050</code>
-			<name>
-				<narrative>Air transport</narrative>
-				<narrative xml:lang="fr">Transport aérien</narrative>
-			</name>
-			<description>
-				<narrative>Airports, airport guidance systems, aeroplanes, aeroplane maintenance equipment.</narrative>
-				<narrative xml:lang="fr">Aéroports, systèmes de guidage, avions, équipement d’entretien des avions.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21061</code>
-			<name>
-				<narrative>Storage</narrative>
-				<narrative xml:lang="fr">Stockage</narrative>
-			</name>
-			<description>
-				<narrative>Whether or not related to transportation. Whenever possible, report storage projects under the sector of the resource being stored.</narrative>
-				<narrative xml:lang="fr">Associé ou non au transport. Autant que possible, notifier les projets de stockage sous le secteur économique de la ressource stockée.</narrative>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>21081</code>
-			<name>
-				<narrative>Education and training in transport and storage</narrative>
-				<narrative xml:lang="fr">Éducation/formation dans les transports et le stockage</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>210</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22010</code>
-			<name>
-				<narrative>Communications policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique des communications et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Communications sector policy, planning and programmes; institution capacity building and advice; including postal services development; unspecified communications activities.</narrative>
-				<narrative xml:lang="fr">Politique des communications, planification et programmes ; renforcement des capacités institutionnelles et conseils ; y compris développement des services postaux ; activités de communications non spécifiées.</narrative>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22011</code>
-			<name>
-				<narrative>Communications policy, planning and administration</narrative>
-				<narrative xml:lang="fr">Politiques, planification et administration des communications</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22012</code>
-			<name>
-				<narrative>Postal services</narrative>
-				<narrative xml:lang="fr">Services postaux</narrative>
-			</name>
-			<description>
-				<narrative>Development and operation of postal services.</narrative>
-				<narrative xml:lang="fr">Développement et fonctionnement des services postaux.</narrative>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22013</code>
-			<name>
-				<narrative>Information services</narrative>
-				<narrative xml:lang="fr">Services d'information</narrative>
-			</name>
-			<description>
-				<narrative>Provision of information services.</narrative>
-				<narrative xml:lang="fr">Prestation de services d'information.</narrative>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22020</code>
-			<name>
-				<narrative>Telecommunications</narrative>
-				<narrative xml:lang="fr">Télécommunications</narrative>
-			</name>
-			<description>
-				<narrative>Telephone networks, telecommunication satellites, earth stations.</narrative>
-				<narrative xml:lang="fr">Réseaux de téléphones, satellites, stations terrestres.</narrative>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22030</code>
-			<name>
-				<narrative>Radio/television/print media</narrative>
-				<narrative xml:lang="fr">Radio, télévision, presse écrite</narrative>
-			</name>
-			<description>
-				<narrative>Radio and TV links, equipment; newspapers; printing and publishing.</narrative>
-				<narrative xml:lang="fr">Liaisons et équipement ; journaux ; imprimerie et édition.</narrative>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item>
-			<code>22040</code>
-			<name>
-				<narrative>Information and communication technology (ICT)</narrative>
-				<narrative xml:lang="fr">Technologies de l’information et de la communication (TIC)</narrative>
-			</name>
-			<description>
-				<narrative>Computer hardware and software; internet access; IT training. When sector cannot be specified.</narrative>
-				<narrative xml:lang="fr">Matériel informatique et logiciels ; accès Internet ; formations aux TI. Lorsque le secteur ne peut pas être spécifié.</narrative>
-			</description>
-			<category>220</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23010</code>
-			<name>
-				<narrative>Energy policy and administrative management</narrative>
-			</name>
-			<description>
-				<narrative>Energy sector policy, planning and programmes; aid to energy ministries; institution capacity building and advice; unspecified energy activities including energy conservation.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23020</code>
-			<name>
-				<narrative>Power generation/non-renewable sources</narrative>
-			</name>
-			<description>
-				<narrative>Thermal power plants including when heat source cannot be determined; combined gas-coal power plants.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23030</code>
-			<name>
-				<narrative>Power generation/renewable sources</narrative>
-			</name>
-			<description>
-				<narrative>Including policy, planning, development programmes, surveys and incentives. Fuelwood/ charcoal production should be included under forestry (31261).</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23040</code>
-			<name>
-				<narrative>Electrical transmission/ distribution</narrative>
-			</name>
-			<description>
-				<narrative>Distribution from power source to end user; transmission lines.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23050</code>
-			<name>
-				<narrative>Gas distribution</narrative>
-			</name>
-			<description>
-				<narrative>Delivery for use by ultimate consumer.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23061</code>
-			<name>
-				<narrative>Oil-fired power plants</narrative>
-			</name>
-			<description>
-				<narrative>Including diesel power plants.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23062</code>
-			<name>
-				<narrative>Gas-fired power plants</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23063</code>
-			<name>
-				<narrative>Coal-fired power plants</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23064</code>
-			<name>
-				<narrative>Nuclear power plants</narrative>
-			</name>
-			<description>
-				<narrative>Including nuclear safety.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23065</code>
-			<name>
-				<narrative>Hydro-electric power plants</narrative>
-			</name>
-			<description>
-				<narrative>Including power-generating river barges.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23066</code>
-			<name>
-				<narrative>Geothermal energy</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23067</code>
-			<name>
-				<narrative>Solar energy</narrative>
-			</name>
-			<description>
-				<narrative>Including photo-voltaic cells, solar thermal applications and solar heating.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23068</code>
-			<name>
-				<narrative>Wind power</narrative>
-			</name>
-			<description>
-				<narrative>Wind energy for water lifting and electric power generation.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23069</code>
-			<name>
-				<narrative>Ocean power</narrative>
-			</name>
-			<description>
-				<narrative>Including ocean thermal energy conversion, tidal and wave power.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23070</code>
-			<name>
-				<narrative>Biomass</narrative>
-			</name>
-			<description>
-				<narrative>Densification technologies and use of biomass for direct power generation including biogas, gas obtained from sugar cane and other plant residues, anaerobic digesters.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23081</code>
-			<name>
-				<narrative>Energy education/training</narrative>
-			</name>
-			<description>
-				<narrative>Applies to all energy sub-sectors; all levels of training.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>23082</code>
-			<name>
-				<narrative>Energy research</narrative>
-			</name>
-			<description>
-				<narrative>Including general inventories, surveys.</narrative>
-			</description>
-			<category>230</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23110</code>
-			<name>
-				<narrative>Energy policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique énergétique et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Energy sector policy, planning; aid to energy ministries; institution capacity building and advice; unspecified energy activities.</narrative>
-				<narrative xml:lang="fr">Politique et planification du secteur de l’énergie ; aide aux ministères de l’énergie ; conseils et renforcement des capacités institutionnelles ; activités non précisées.</narrative>
-			</description>
-			<category>231</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23111</code>
-			<name>
-				<narrative>Energy sector policy, planning and administration</narrative>
-				<narrative xml:lang="fr">Politiques, planification et administration du secteur de l'énergie</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>231</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23112</code>
-			<name>
-				<narrative>Energy regulation</narrative>
-				<narrative xml:lang="fr">Réglementation de l'énergie</narrative>
-			</name>
-			<description>
-				<narrative>Regulation of the energy sector, including wholesale and retail electricity provision.</narrative>
-				<narrative xml:lang="fr">Réglementation du secteur de l'énergie, y compris l'approvisionnement d'électricité en gros et au détail.</narrative>
-			</description>
-			<category>231</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23181</code>
-			<name>
-				<narrative>Energy education/training</narrative>
-				<narrative xml:lang="fr">Éducation et formation dans le domaine de l’énergie</narrative>
-			</name>
-			<description>
-				<narrative>All levels of training not included elsewhere.</narrative>
-				<narrative xml:lang="fr">Tous les niveaux de formation ne figurant pas sous un autre code.</narrative>
-			</description>
-			<category>231</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23182</code>
-			<name>
-				<narrative>Energy research</narrative>
-				<narrative xml:lang="fr">Recherche dans le domaine de l’énergie</narrative>
-			</name>
-			<description>
-				<narrative>Including general inventories, surveys.</narrative>
-				<narrative xml:lang="fr">Y compris inventaires et études.</narrative>
-			</description>
-			<category>231</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23183</code>
-			<name>
-				<narrative>Energy conservation and demand-side efficiency</narrative>
-				<narrative xml:lang="fr">Économies d’énergie et efficacité du côté de la demande</narrative>
-			</name>
-			<description>
-				<narrative>All projects in support of energy demand reduction, e.g. building and industry upgrades, smart grids, metering and tariffs. Also includes efficient cook-stoves and biogas projects.</narrative>
-				<narrative xml:lang="fr">Tous les projets visant la réduction de la demande d’énergie, par exemple : modernisation des bâtiments et des industries, réseaux intelligents, compteurs et tarifs. Comprend également les cuisinières efficaces et les projets de biogaz.</narrative>
-			</description>
-			<category>231</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23210</code>
-			<name>
-				<narrative>Energy generation, renewable sources – multiple technologies</narrative>
-				<narrative xml:lang="fr">Production d’énergie, sources renouvelables - multiples technologies</narrative>
-			</name>
-			<description>
-				<narrative>Renewable energy generation programmes that cannot be attributed to one single technology (codes 23220 through 23280 below). Fuelwood/charcoal production should be included under forestry 31261.</narrative>
-				<narrative xml:lang="fr">Programmes de production d’énergie d’origine renouvelable qui ne peuvent être attribués à une seule technologie (codes 23220 à 23280 ci-après). La production de bois de chauffage/charbon de bois devrait figurer sous la rubrique sylviculture 31261.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23220</code>
-			<name>
-				<narrative>Hydro-electric power plants</narrative>
-				<narrative xml:lang="fr">Centrales hydrauliques</narrative>
-			</name>
-			<description>
-				<narrative>Including energy generating river barges.</narrative>
-				<narrative xml:lang="fr">Dont centrales flottantes.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23230</code>
-			<name>
-				<narrative>Solar energy</narrative>
-				<narrative xml:lang="fr">Énergie solaire</narrative>
-			</name>
-			<description>
-				<narrative>Including photo-voltaic cells, solar thermal applications and solar heating.</narrative>
-				<narrative xml:lang="fr">Solaire photovoltaïque, thermodynamique, chauffage solaire.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23240</code>
-			<name>
-				<narrative>Wind energy</narrative>
-				<narrative xml:lang="fr">Énergie éolienne</narrative>
-			</name>
-			<description>
-				<narrative>Wind energy for water lifting and electric power generation.</narrative>
-				<narrative xml:lang="fr">Éoliennes de pompage et production d’électricité.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23250</code>
-			<name>
-				<narrative>Marine energy</narrative>
-				<narrative xml:lang="fr">Énergie marine</narrative>
-			</name>
-			<description>
-				<narrative>Including ocean thermal energy conversion, tidal and wave power.</narrative>
-				<narrative xml:lang="fr">Énergie thermique des mers, énergie marémotrice et houlomotrice.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23260</code>
-			<name>
-				<narrative>Geothermal energy</narrative>
-				<narrative xml:lang="fr">Énergie géothermique</narrative>
-			</name>
-			<description>
-				<narrative>Use of geothermal energy for generating electric power or directly as heat for agriculture, etc.</narrative>
-				<narrative xml:lang="fr">Application de l’énergie géothermique pour produire de l’électricité ou production de chaleur à usage agricole, etc.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23270</code>
-			<name>
-				<narrative>Biofuel-fired power plants</narrative>
-				<narrative xml:lang="fr">Centrales à biocombustibles</narrative>
-			</name>
-			<description>
-				<narrative>Use of solids and liquids produced from biomass for direct power generation. Also includes biogases from anaerobic fermentation (e.g. landfill gas, sewage sludge gas, fermentation of energy crops and manure) and thermal processes (also known as syngas); waste-fired power plants making use of biodegradable municipal waste (household waste and waste from companies and public services that resembles household waste, collected at installations specifically designed for their disposal with recovery of combustible liquids, gases or heat). See code 23360 for non- renewable waste-fired power plants.</narrative>
-				<narrative xml:lang="fr">Utilisation de matières solides et liquides issues de la biomasse pour la production directe d’électricité. Comprend également les biogaz produits par fermentation anaérobie (ex. : gaz de décharge, gaz issus des boues d’épuration, fermentation de végétaux des cultures énergétiques et de déjections animales) et par traitements thermiques (également connus sous l’appellation de gaz de synthèse) ; centrales brûlant des déchets municipaux biodégradables (déchets ménagers et déchets du tertiaire assimilables à des déchets ménagers, collectés dans des installations spécifiquement conçues pour leur élimination et leur récupération sous forme de liquides ou de gaz combustibles ou de chaleur). Voir code 23360 pour la production d’électricité, déchets non renouvelables.</narrative>
-			</description>
-			<category>232</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23310</code>
-			<name>
-				<narrative>Energy generation, non-renewable sources – unspecified</narrative>
-				<narrative xml:lang="fr">Production d’énergie, sources non renouvelables - non spécifié</narrative>
-			</name>
-			<description>
-				<narrative>Thermal power plants including when energy source cannot be determined; combined gas-coal power plants.</narrative>
-				<narrative xml:lang="fr">Centrales thermiques dont la source d’énergie est indéterminée ; centrales mixtes gaz-charbon.</narrative>
-			</description>
-			<category>233</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23320</code>
-			<name>
-				<narrative>Coal-fired electric power plants</narrative>
-				<narrative xml:lang="fr">Centrales au charbon</narrative>
-			</name>
-			<description>
-				<narrative>Thermal electric power plants that use coal as the energy source.</narrative>
-				<narrative xml:lang="fr">Centrales thermiques brûlant du charbon.</narrative>
-			</description>
-			<category>233</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23330</code>
-			<name>
-				<narrative>Oil-fired electric power plants</narrative>
-				<narrative xml:lang="fr">Centrales au fioul</narrative>
-			</name>
-			<description>
-				<narrative>Thermal electric power plants that use fuel oil or diesel fuel as the energy source.</narrative>
-				<narrative xml:lang="fr">Centrales thermiques brûlant du fioul ou du gazole.</narrative>
-			</description>
-			<category>233</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23340</code>
-			<name>
-				<narrative>Natural gas-fired electric power plants</narrative>
-				<narrative xml:lang="fr">Centrales au gaz naturel</narrative>
-			</name>
-			<description>
-				<narrative>Electric power plants that are fuelled by natural gas.</narrative>
-				<narrative xml:lang="fr">Centrales thermiques brûlant du gaz naturel.</narrative>
-			</description>
-			<category>233</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23350</code>
-			<name>
-				<narrative>Fossil fuel electric power plants with carbon capture and storage (CCS)</narrative>
-				<narrative xml:lang="fr">Centrales thermiques classiques avec captage et stockage du carbone (CSC)</narrative>
-			</name>
-			<description>
-				<narrative>Fossil fuel electric power plants employing technologies to capture carbon dioxide emissions. CCS not related to power plants should be included under 41020. CCS activities are not reportable as ODA.</narrative>
-				<narrative xml:lang="fr">Centrales thermiques classiques exploitant une technologie de captage et de stockage des émissions de carbone (CSC). Les techniques de CSC non associées à la production d’électricité devraient figurer sous la rubrique 41020. Les activités de CSC ne sont pas éligibles à l’APD.</narrative>
-			</description>
-			<category>233</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23360</code>
-			<name>
-				<narrative>Non-renewable waste-fired electric power plants</narrative>
-				<narrative xml:lang="fr">Production d’électricité, déchets non renouvelables</narrative>
-			</name>
-			<description>
-				<narrative>Electric power plants that use non-biodegradable industrial and municipal waste as the energy source.</narrative>
-				<narrative xml:lang="fr">Centrales brûlant des déchets industriels et municipaux non biodégradables.</narrative>
-			</description>
-			<category>233</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23410</code>
-			<name>
-				<narrative>Hybrid energy electric power plants</narrative>
-				<narrative xml:lang="fr">Centrales hybrides</narrative>
-			</name>
-			<description>
-				<narrative>Electric power plants that make use of both non-renewable and renewable energy sources.</narrative>
-				<narrative xml:lang="fr">Centrales fonctionnant avec des énergies renouvelables et non renouvelables.</narrative>
-			</description>
-			<category>234</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23510</code>
-			<name>
-				<narrative>Nuclear energy electric power plants</narrative>
-				<narrative xml:lang="fr">Centrales nucléaires</narrative>
-			</name>
-			<description>
-				<narrative>Including nuclear safety.</narrative>
-				<narrative xml:lang="fr">Dont sûreté nucléaire.</narrative>
-			</description>
-			<category>235</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23610</code>
-			<name>
-				<narrative>Heat plants</narrative>
-				<narrative xml:lang="fr">Production de chaleur seule</narrative>
-			</name>
-			<description>
-				<narrative>Power plants which are designed to produce heat only.</narrative>
-				<narrative xml:lang="fr">Installations produisant uniquement de la chaleur.</narrative>
-			</description>
-			<category>236</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23620</code>
-			<name>
-				<narrative>District heating and cooling</narrative>
-				<narrative xml:lang="fr">Réseaux urbains de chaleur et de froid</narrative>
-			</name>
-			<description>
-				<narrative>Distribution of heat generated in a centralised location, or delivery of chilled water, for residential and commercial heating or cooling purposes.</narrative>
-				<narrative xml:lang="fr">Distribution de chaleur produite dans une chaufferie unique, ou d’eau froide, à des fins de climatisation des locaux dans les secteurs résidentiel et tertiaire.</narrative>
-			</description>
-			<category>236</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23630</code>
-			<name>
-				<narrative>Electric power transmission and distribution</narrative>
-				<narrative xml:lang="fr">Transport et distribution d’électricité</narrative>
-			</name>
-			<description>
-				<narrative>Grid distribution from power source to end user; transmission lines. Also includes storage of energy to generate power (e.g. pumped hydro, batteries) and the extension of grid access, often to rural areas.</narrative>
-				<narrative xml:lang="fr">Distribution d’électricité par le réseau, de la source au consommateur final ; lignes de transport. Inclut également le stockage de l’énergie à des fins de production d’électricité (ex. : station de pompage, batteries) et l’extension de l’accès au réseau, souvent dans des zones rurales.</narrative>
-			</description>
-			<category>236</category>
-		</codelist-item>
-		<codelist-item>
-			<code>23640</code>
-			<name>
-				<narrative>Gas distribution</narrative>
-				<narrative xml:lang="fr">Distribution du gaz</narrative>
-			</name>
-			<description>
-				<narrative>Delivery for use by ultimate consumer.</narrative>
-				<narrative xml:lang="fr">Acheminement du gaz jusqu’au consommateur final.</narrative>
-			</description>
-			<category>236</category>
-		</codelist-item>
-		<codelist-item>
-			<code>24010</code>
-			<name>
-				<narrative>Financial policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique des finances et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Finance sector policy, planning and programmes; institution capacity building and advice; financial markets and systems.</narrative>
-				<narrative xml:lang="fr">Politique des finances, planification et programmes ; renforcement des capacités institutionnelles et conseils ; marchés et systèmes financiers.</narrative>
-			</description>
-			<category>240</category>
-		</codelist-item>
-		<codelist-item>
-			<code>24020</code>
-			<name>
-				<narrative>Monetary institutions</narrative>
-				<narrative xml:lang="fr">Institutions monétaires</narrative>
-			</name>
-			<description>
-				<narrative>Central banks.</narrative>
-				<narrative xml:lang="fr">Banques centrales.</narrative>
-			</description>
-			<category>240</category>
-		</codelist-item>
-		<codelist-item>
-			<code>24030</code>
-			<name>
-				<narrative>Formal sector financial intermediaries</narrative>
-				<narrative xml:lang="fr">Intermédiaires financiers officiels</narrative>
-			</name>
-			<description>
-				<narrative>All formal sector financial intermediaries; credit lines; insurance, leasing, venture capital, etc. (except when focused on only one sector).</narrative>
-				<narrative xml:lang="fr">Tous les intermédiaires financiers dans le secteur formel ; lignes de crédit ; assurance, crédit-bail, capital- risque, etc. (sauf ceux spécialisés dans un seul secteur).</narrative>
-			</description>
-			<category>240</category>
-		</codelist-item>
-		<codelist-item>
-			<code>24040</code>
-			<name>
-				<narrative>Informal/semi-formal financial intermediaries</narrative>
-				<narrative xml:lang="fr">Intermédiaires financiers du secteur informel et semi formel</narrative>
-			</name>
-			<description>
-				<narrative>Micro credit, savings and credit co-operatives etc.</narrative>
-				<narrative xml:lang="fr">Micro crédits, coopératives d’épargne et de crédit, etc.</narrative>
-			</description>
-			<category>240</category>
-		</codelist-item>
-		<codelist-item>
-			<code>24081</code>
-			<name>
-				<narrative>Education/training in banking and financial services</narrative>
-				<narrative xml:lang="fr">Éducation/formation bancaire et dans les services financiers</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>240</category>
-		</codelist-item>
-		<codelist-item>
-			<code>25010</code>
-			<name>
-				<narrative>Business support services and institutions</narrative>
-				<narrative xml:lang="fr">Services et institutions de soutien commerciaux</narrative>
-			</name>
-			<description>
-				<narrative>Support to trade and business associations, chambers of commerce; legal and regulatory reform aimed at improving business and investment climate; private sector institution capacity building and advice; trade information; public-private sector networking including trade fairs; e-commerce. Where sector cannot be specified: general support to private sector enterprises (in particular, use code 32130 for enterprises in the industrial sector).</narrative>
-				<narrative xml:lang="fr">Soutien aux associations de commerce et d’entreprises, chambres de commerce ; réformes juridiques et réglementaires afin d’améliorer les activités liées à l’entreprise ; renforcement des capacités institutionnelles du secteur privé et conseils ; information commerciale ; réseaux de liaison entre les secteurs public et privé y compris les foires commerciales ; commerce électronique. Quand le secteur ne peut pas être spécifié : soutien général aux entreprises du secteur privé. En particulier, pour les entreprises du secteur industriel, c’est le code 32130 qui doit être utilisé.</narrative>
-			</description>
-			<category>250</category>
-		</codelist-item>
-		<codelist-item>
-			<code>25020</code>
-			<name>
-				<narrative>Privatisation</narrative>
-				<narrative xml:lang="fr">Privatisation</narrative>
-			</name>
-			<description>
-				<narrative>When sector cannot be specified. Including general state enterprise restructuring or demonopolisation programmes; planning, programming, advice.</narrative>
-				<narrative xml:lang="fr">Lorsque le secteur ne peut être spécifié. Y compris programmes de restructuration d’entreprises publiques et de démonopolisation ; planification, programmation, conseils.</narrative>
-			</description>
-			<category>250</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31110</code>
-			<name>
-				<narrative>Agricultural policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique agricole et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Agricultural sector policy, planning and programmes; aid to agricultural ministries; institution capacity building and advice; unspecified agriculture.</narrative>
-				<narrative xml:lang="fr">Politique agricole, planification et programmes ; aide aux ministères de l’agriculture ; renforcement des capacités institutionnelles et conseils ; activités d’agriculture non spécifiées.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31120</code>
-			<name>
-				<narrative>Agricultural development</narrative>
-				<narrative xml:lang="fr">Développement agricole</narrative>
-			</name>
-			<description>
-				<narrative>Integrated projects; farm development.</narrative>
-				<narrative xml:lang="fr">Projets intégrés ; développement d’exploitations agricoles.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31130</code>
-			<name>
-				<narrative>Agricultural land resources</narrative>
-				<narrative xml:lang="fr">Ressources en terres cultivables</narrative>
-			</name>
-			<description>
-				<narrative>Including soil degradation control; soil improvement; drainage of water logged areas; soil desalination; agricultural land surveys; land reclamation; erosion control, desertification control.</narrative>
-				<narrative xml:lang="fr">Y compris la lutte contre la dégradation des sols ; amélioration des sols ; drainage des zones inondées ; dessalage des sols ; études des terrains agricoles ; remise en état des sols ; lutte contre l’érosion, lutte contre la désertification.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31140</code>
-			<name>
-				<narrative>Agricultural water resources</narrative>
-				<narrative xml:lang="fr">Ressources en eau à usage agricole</narrative>
-			</name>
-			<description>
-				<narrative>Irrigation, reservoirs, hydraulic structures, ground water exploitation for agricultural use.</narrative>
-				<narrative xml:lang="fr">Irrigation, réservoirs, structures hydrauliques, exploitation de nappes phréatiques.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31150</code>
-			<name>
-				<narrative>Agricultural inputs</narrative>
-				<narrative xml:lang="fr">Produits à usage agricole</narrative>
-			</name>
-			<description>
-				<narrative>Supply of seeds, fertilizers, agricultural machinery/equipment.</narrative>
-				<narrative xml:lang="fr">Approvisionnement en semences, engrais, matériel et outillage agricoles.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31161</code>
-			<name>
-				<narrative>Food crop production</narrative>
-				<narrative xml:lang="fr">Production agricole</narrative>
-			</name>
-			<description>
-				<narrative>Including grains (wheat, rice, barley, maize, rye, oats, millet, sorghum); horticulture; vegetables; fruit and berries; other annual and perennial crops. [Use code 32161 for agro-industries.]</narrative>
-				<narrative xml:lang="fr">Y compris céréales (froment, riz, orge, maïs, seigle, avoine, millet, sorgho) ; horticulture ; légumes ; fruits et baies ; autres cultures annuelles et pluriannuelles. [Utiliser le code 32161 pour les agro-industries.]</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31162</code>
-			<name>
-				<narrative>Industrial crops/export crops</narrative>
-				<narrative xml:lang="fr">Production industrielle de récoltes/récoltes destinées à l’exportation</narrative>
-			</name>
-			<description>
-				<narrative>Including sugar; coffee, cocoa, tea; oil seeds, nuts, kernels; fibre crops; tobacco; rubber. [Use code 32161 for agro-industries.]</narrative>
-				<narrative xml:lang="fr">Y compris sucre ; café, cacao, thé ; oléagineux, graines, noix, amandes ; fibres ; tabac ; caoutchouc. [Utiliser le code 32161 pour les agro-industries.]</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31163</code>
-			<name>
-				<narrative>Livestock</narrative>
-				<narrative xml:lang="fr">Bétail</narrative>
-			</name>
-			<description>
-				<narrative>Animal husbandry; animal feed aid.</narrative>
-				<narrative xml:lang="fr">Toutes formes d’élevage ; aliments pour animaux.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31164</code>
-			<name>
-				<narrative>Agrarian reform</narrative>
-				<narrative xml:lang="fr">Réforme agraire</narrative>
-			</name>
-			<description>
-				<narrative>Including agricultural sector adjustment.</narrative>
-				<narrative xml:lang="fr">Y compris ajustement structurel dans le secteur agricole.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31165</code>
-			<name>
-				<narrative>Agricultural alternative development</narrative>
-				<narrative xml:lang="fr">Développement agricole alternatif</narrative>
-			</name>
-			<description>
-				<narrative>Projects to reduce illicit drug cultivation through other agricultural marketing and production opportunities (see code 43050 for non-agricultural alternative development).</narrative>
-				<narrative xml:lang="fr">Projets afin de réduire les cultures illicites (drogue) à travers d’autres opportunités de marketing et production agricoles (voir code 43050 pour développement alternatif non agricole).</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31166</code>
-			<name>
-				<narrative>Agricultural extension</narrative>
-				<narrative xml:lang="fr">Vulgarisation agricole</narrative>
-			</name>
-			<description>
-				<narrative>Non-formal training in agriculture.</narrative>
-				<narrative xml:lang="fr">Formation agricole non formelle.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31181</code>
-			<name>
-				<narrative>Agricultural education/training</narrative>
-				<narrative xml:lang="fr">Éducation et formation dans le domaine agricole</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31182</code>
-			<name>
-				<narrative>Agricultural research</narrative>
-				<narrative xml:lang="fr">Recherche agronomique</narrative>
-			</name>
-			<description>
-				<narrative>Plant breeding, physiology, genetic resources, ecology, taxonomy, disease control, agricultural bio-technology; including livestock research (animal health, breeding and genetics, nutrition, physiology).</narrative>
-				<narrative xml:lang="fr">Étude des espèces végétales, physiologie, ressources génétiques, écologie, taxonomie, lutte contre les maladies, biotechnologie agricole ; y compris recherche vétérinaire (dans les domaines génétiques et sanitaires, nutrition, physiologie).</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31191</code>
-			<name>
-				<narrative>Agricultural services</narrative>
-				<narrative xml:lang="fr">Services agricoles</narrative>
-			</name>
-			<description>
-				<narrative>Marketing policies &amp; organisation; storage and transportation, creation of strategic reserves.</narrative>
-				<narrative xml:lang="fr">Organisation et politiques des marchés ; transport et stockage ; établissements de réserves stratégiques.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31192</code>
-			<name>
-				<narrative>Plant and post-harvest protection and pest control</narrative>
-				<narrative xml:lang="fr">Protection des plantes et des récoltes, lutte antiacridienne</narrative>
-			</name>
-			<description>
-				<narrative>Including integrated plant protection, biological plant protection activities, supply and management of agrochemicals, supply of pesticides, plant protection policy and legislation.</narrative>
-				<narrative xml:lang="fr">Y compris la protection intégrée des plantes, les activités de protection biologique des plantes, la fourniture et la gestion de substances agrochimiques, l’approvisionnement en pesticides ; politique et législation de la protection des plantes.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31193</code>
-			<name>
-				<narrative>Agricultural financial services</narrative>
-				<narrative xml:lang="fr">Services financiers agricoles</narrative>
-			</name>
-			<description>
-				<narrative>Financial intermediaries for the agricultural sector including credit schemes; crop insurance.</narrative>
-				<narrative xml:lang="fr">Intermédiaires financiers du secteur agricole, y compris les plans de crédit ; assurance récoltes.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31194</code>
-			<name>
-				<narrative>Agricultural co-operatives</narrative>
-				<narrative xml:lang="fr">Coopératives agricoles</narrative>
-			</name>
-			<description>
-				<narrative>Including farmers’ organisations.</narrative>
-				<narrative xml:lang="fr">Y compris les organisations d’agriculteurs.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31195</code>
-			<name>
-				<narrative>Livestock/veterinary services</narrative>
-				<narrative xml:lang="fr">Services vétérinaires (bétail)</narrative>
-			</name>
-			<description>
-				<narrative>Animal health and management, genetic resources, feed resources.</narrative>
-				<narrative xml:lang="fr">Santé des animaux, ressources génétiques et nutritives.</narrative>
-			</description>
-			<category>311</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31210</code>
-			<name>
-				<narrative>Forestry policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de la sylviculture et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Forestry sector policy, planning and programmes; institution capacity building and advice; forest surveys; unspecified forestry and agro-forestry activities.</narrative>
-				<narrative xml:lang="fr">Politique de la sylviculture, planification et programmes ; renforcement des capacités institutionnelles et conseils ; études des forêts ; activités sylvicoles et agricoles liées à la sylviculture non spécifiées.</narrative>
-			</description>
-			<category>312</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31220</code>
-			<name>
-				<narrative>Forestry development</narrative>
-				<narrative xml:lang="fr">Développement sylvicole</narrative>
-			</name>
-			<description>
-				<narrative>Afforestation for industrial and rural consumption; exploitation and utilisation; erosion control, desertification control; integrated forestry projects.</narrative>
-				<narrative xml:lang="fr">Boisement pour consommation rurale et industrielle ; exploitation et utilisation ; lutte contre l’érosion, lutte contre la désertification ; projets intégrés.</narrative>
-			</description>
-			<category>312</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31261</code>
-			<name>
-				<narrative>Fuelwood/charcoal</narrative>
-				<narrative xml:lang="fr">Reboisement (bois de chauffage et charbon de bois)</narrative>
-			</name>
-			<description>
-				<narrative>Forestry development whose primary purpose is production of fuelwood and charcoal.</narrative>
-				<narrative xml:lang="fr">Développement sylvicole visant à la production de bois de chauffage et de charbon de bois.</narrative>
-			</description>
-			<category>312</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31281</code>
-			<name>
-				<narrative>Forestry education/training</narrative>
-				<narrative xml:lang="fr">Éducation et formation en sylviculture</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>312</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31282</code>
-			<name>
-				<narrative>Forestry research</narrative>
-				<narrative xml:lang="fr">Recherche en sylviculture</narrative>
-			</name>
-			<description>
-				<narrative>Including artificial regeneration, genetic improvement, production methods, fertilizer, harvesting.</narrative>
-				<narrative xml:lang="fr">Y compris reproduction artificielle et amélioration des espèces, méthodes de production, engrais, coupe et ramassage du bois.</narrative>
-			</description>
-			<category>312</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31291</code>
-			<name>
-				<narrative>Forestry services</narrative>
-				<narrative xml:lang="fr">Services sylvicoles</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>312</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31310</code>
-			<name>
-				<narrative>Fishing policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de la pêche et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Fishing sector policy, planning and programmes; institution capacity building and advice; ocean and coastal fishing; marine and freshwater fish surveys and prospecting; fishing boats/equipment; unspecified fishing activities.</narrative>
-				<narrative xml:lang="fr">Politique de la pêche, planification et programmes ; renforcement des capacités institutionnelles et conseils ; pêche hauturière et côtière ; évaluation, études et prospection du poisson en milieu marin et fluvial ; bateaux et équipements de pêche ; activités de pêche non spécifiées.</narrative>
-			</description>
-			<category>313</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31320</code>
-			<name>
-				<narrative>Fishery development</narrative>
-				<narrative xml:lang="fr">Développement de la pêche</narrative>
-			</name>
-			<description>
-				<narrative>Exploitation and utilisation of fisheries; fish stock protection; aquaculture; integrated fishery projects.</narrative>
-				<narrative xml:lang="fr">Exploitation et utilisation des pêcheries ; sauvegarde des bancs de poisson ; aquaculture ; projets intégrés.</narrative>
-			</description>
-			<category>313</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31381</code>
-			<name>
-				<narrative>Fishery education/training</narrative>
-				<narrative xml:lang="fr">Éducation et formation dans le domaine de la pêche</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>313</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31382</code>
-			<name>
-				<narrative>Fishery research</narrative>
-				<narrative xml:lang="fr">Recherche dans le domaine de la pêche</narrative>
-			</name>
-			<description>
-				<narrative>Pilot fish culture; marine/freshwater biological research.</narrative>
-				<narrative xml:lang="fr">Pisciculture pilote ; recherche biologique aquatique.</narrative>
-			</description>
-			<category>313</category>
-		</codelist-item>
-		<codelist-item>
-			<code>31391</code>
-			<name>
-				<narrative>Fishery services</narrative>
-				<narrative xml:lang="fr">Services dans le domaine de la pêche</narrative>
-			</name>
-			<description>
-				<narrative>Fishing harbours; fish markets; fishery transport and cold storage.</narrative>
-				<narrative xml:lang="fr">Ports de pêche ; vente des produits de la pêche ; transport et entreposage frigorifique du poisson.</narrative>
-			</description>
-			<category>313</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32110</code>
-			<name>
-				<narrative>Industrial policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de l’industrie et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Industrial sector policy, planning and programmes; institution capacity building and advice; unspecified industrial activities; manufacturing of goods not specified below.</narrative>
-				<narrative xml:lang="fr">Politique de l’industrie, planification et programmes ; renforcement des capacités institutionnelles et conseils ; activités industrielles non spécifiées ; industries manufacturières non spécifiées ci-dessous.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32120</code>
-			<name>
-				<narrative>Industrial development</narrative>
-				<narrative xml:lang="fr">Développement industriel</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32130</code>
-			<name>
-				<narrative>Small and medium-sized enterprises (SME) development</narrative>
-				<narrative xml:lang="fr">Développement des Petites et moyennes entreprises (PME)</narrative>
-			</name>
-			<description>
-				<narrative>Direct support to the development of small and medium-sized enterprises in the industrial sector, including accounting, auditing and advisory services.</narrative>
-				<narrative xml:lang="fr">Soutien direct au développement des petites et moyennes entreprises dans le secteur industriel, y compris la comptabilité, l’audit et les services de conseil.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32140</code>
-			<name>
-				<narrative>Cottage industries and handicraft</narrative>
-				<narrative xml:lang="fr">Artisanat</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32161</code>
-			<name>
-				<narrative>Agro-industries</narrative>
-				<narrative xml:lang="fr">Agro-industries</narrative>
-			</name>
-			<description>
-				<narrative>Staple food processing, dairy products, slaughter houses and equipment, meat and fish processing and preserving, oils/fats, sugar refineries, beverages/tobacco, animal feeds production.</narrative>
-				<narrative xml:lang="fr">Industries alimentaires de base, abattoirs et équipements nécessaires, industrie laitière et conserves de viande et de poisson, industries des corps gras, sucreries, production de boissons, tabac, production d’aliments pour animaux.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32162</code>
-			<name>
-				<narrative>Forest industries</narrative>
-				<narrative xml:lang="fr">Industries forestières</narrative>
-			</name>
-			<description>
-				<narrative>Wood production, pulp/paper production.</narrative>
-				<narrative xml:lang="fr">Industrie et travail du bois, production de papier et pâte à papier.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32163</code>
-			<name>
-				<narrative>Textiles, leather and substitutes</narrative>
-				<narrative xml:lang="fr">Industrie textile, cuirs et produits similaires</narrative>
-			</name>
-			<description>
-				<narrative>Including knitting factories.</narrative>
-				<narrative xml:lang="fr">Y compris bonneterie.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32164</code>
-			<name>
-				<narrative>Chemicals</narrative>
-				<narrative xml:lang="fr">Produits chimiques</narrative>
-			</name>
-			<description>
-				<narrative>Industrial and non-industrial production facilities; includes pesticides production.</narrative>
-				<narrative xml:lang="fr">Production industrielle et non industrielle ; y compris fabrication des pesticides.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32165</code>
-			<name>
-				<narrative>Fertilizer plants</narrative>
-				<narrative xml:lang="fr">Production d’engrais chimiques</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32166</code>
-			<name>
-				<narrative>Cement/lime/plaster</narrative>
-				<narrative xml:lang="fr">Ciment, chaux et plâtre</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32167</code>
-			<name>
-				<narrative>Energy manufacturing</narrative>
-				<narrative xml:lang="fr">Fabrication d’énergie</narrative>
-			</name>
-			<description>
-				<narrative>Including gas liquefaction; petroleum refineries.</narrative>
-				<narrative xml:lang="fr">Y compris liquéfaction du gaz ; raffineries de pétrole.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32168</code>
-			<name>
-				<narrative>Pharmaceutical production</narrative>
-				<narrative xml:lang="fr">Produits pharmaceutiques</narrative>
-			</name>
-			<description>
-				<narrative>Medical equipment/supplies; drugs, medicines, vaccines; hygienic products.</narrative>
-				<narrative xml:lang="fr">Matériel médical et fournitures médicales ; médicaments et vaccins ; produits d’hygiène corporelle.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32169</code>
-			<name>
-				<narrative>Basic metal industries</narrative>
-				<narrative xml:lang="fr">Industrie métallurgique de base</narrative>
-			</name>
-			<description>
-				<narrative>Iron and steel, structural metal production.</narrative>
-				<narrative xml:lang="fr">Sidérurgie, éléments de construction métallique.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32170</code>
-			<name>
-				<narrative>Non-ferrous metal industries</narrative>
-				<narrative xml:lang="fr">Industries des métaux non ferreux</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32171</code>
-			<name>
-				<narrative>Engineering</narrative>
-				<narrative xml:lang="fr">Construction mécanique et électrique</narrative>
-			</name>
-			<description>
-				<narrative>Manufacturing of electrical and non-electrical machinery, engines/turbines.</narrative>
-				<narrative xml:lang="fr">Fabrication de machines électriques et non électriques, moteurs et turbines.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32172</code>
-			<name>
-				<narrative>Transport equipment industry</narrative>
-				<narrative xml:lang="fr">Matériel de transport</narrative>
-			</name>
-			<description>
-				<narrative>Shipbuilding, fishing boats building; railroad equipment; motor vehicles and motor passenger cars; aircraft; navigation/guidance systems.</narrative>
-				<narrative xml:lang="fr">Construction de navires, construction de bateaux de pêche ; construction de matériel ferroviaire ; véhicules automobiles et voitures particulières ; construction aéronautique ; systèmes de navigation et de guidage.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32182</code>
-			<name>
-				<narrative>Technological research and development</narrative>
-				<narrative xml:lang="fr">Recherche et développement technologiques</narrative>
-			</name>
-			<description>
-				<narrative>Including industrial standards; quality management; metrology; testing; accreditation; certification.</narrative>
-				<narrative xml:lang="fr">Y compris les standards industriels ; gestion et contrôle de qualité ; métrologie ; accréditation ; certification.</narrative>
-			</description>
-			<category>321</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32210</code>
-			<name>
-				<narrative>Mineral/mining policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de l’industrie extractive et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Mineral and mining sector policy, planning and programmes; mining legislation, mining cadastre, mineral resources inventory, information systems, institution capacity building and advice; unspecified mineral resources exploitation.</narrative>
-				<narrative xml:lang="fr">Politique du secteur des industries extractives, planification et programmes ; législation et cadastre, recensement des richesses minérales, systèmes d’information ; renforcement des capacités institutionnelles et conseils ; exploitation des ressources minérales non spécifiées.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32220</code>
-			<name>
-				<narrative>Mineral prospection and exploration</narrative>
-				<narrative xml:lang="fr">Prospection et exploration des minerais</narrative>
-			</name>
-			<description>
-				<narrative>Geology, geophysics, geochemistry; excluding hydrogeology (14010) and environmental geology (41010), mineral extraction and processing, infrastructure, technology, economics, safety and environment management.</narrative>
-				<narrative xml:lang="fr">Géologie, géophysique et géochimie ; à l’exclusion de hydrogéologie (14010) et géologie de l’environnement (41010), production et extraction minérales, infrastructure, technologie, économie, sécurité et gestion de l’environnement.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32261</code>
-			<name>
-				<narrative>Coal</narrative>
-				<narrative xml:lang="fr">Charbon</narrative>
-			</name>
-			<description>
-				<narrative>Including lignite and peat.</narrative>
-				<narrative xml:lang="fr">Y compris lignite et la tourbe.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32262</code>
-			<name>
-				<narrative>Oil and gas</narrative>
-				<narrative xml:lang="fr">Pétrole et gaz</narrative>
-			</name>
-			<description>
-				<narrative>Petroleum, natural gas, condensates, liquefied petroleum gas (LPG), liquefied natural gas (LNG); including drilling and production, and oil and gas pipelines.</narrative>
-				<narrative xml:lang="fr">Pétrole, gaz naturel, condensés , GPL (Gaz de pétrole liquéfié), GNL (Gaz naturel liquéfié); y compris derricks et plates-formes de forage, et oléoducs et gazoducs.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32263</code>
-			<name>
-				<narrative>Ferrous metals</narrative>
-				<narrative xml:lang="fr">Métaux ferreux</narrative>
-			</name>
-			<description>
-				<narrative>Iron and ferro-alloy metals.</narrative>
-				<narrative xml:lang="fr">Fer et alliages.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32264</code>
-			<name>
-				<narrative>Nonferrous metals</narrative>
-				<narrative xml:lang="fr">Métaux non ferreux</narrative>
-			</name>
-			<description>
-				<narrative>Aluminium, copper, lead, nickel, tin, zinc.</narrative>
-				<narrative xml:lang="fr">Aluminium, cuivre, plomb, nickel, étain et zinc.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32265</code>
-			<name>
-				<narrative>Precious metals/materials</narrative>
-				<narrative xml:lang="fr">Métaux et minerais précieux</narrative>
-			</name>
-			<description>
-				<narrative>Gold, silver, platinum, diamonds, gemstones.</narrative>
-				<narrative xml:lang="fr">Or, argent, platine, diamant et pierres précieuses.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32266</code>
-			<name>
-				<narrative>Industrial minerals</narrative>
-				<narrative xml:lang="fr">Minerais industriels</narrative>
-			</name>
-			<description>
-				<narrative>Baryte, limestone, feldspar, kaolin, sand, gypsym, gravel, ornamental stones.</narrative>
-				<narrative xml:lang="fr">Baryte, chaux, feldspath, kaolin, sable, gypse, gravier, pierres d’ornement.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32267</code>
-			<name>
-				<narrative>Fertilizer minerals</narrative>
-				<narrative xml:lang="fr">Engrais minéraux</narrative>
-			</name>
-			<description>
-				<narrative>Phosphates, potash.</narrative>
-				<narrative xml:lang="fr">Phosphates, potasse.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32268</code>
-			<name>
-				<narrative>Offshore minerals</narrative>
-				<narrative xml:lang="fr">Ressources des fonds marins</narrative>
-			</name>
-			<description>
-				<narrative>Polymetallic nodules, phosphorites, marine placer deposits.</narrative>
-				<narrative xml:lang="fr">Nodules métalliques, phosphorites, sédiments marins.</narrative>
-			</description>
-			<category>322</category>
-		</codelist-item>
-		<codelist-item>
-			<code>32310</code>
-			<name>
-				<narrative>Construction policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de la construction et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Construction sector policy and planning; excluding construction activities within specific sectors (e.g., hospital or school construction).</narrative>
-				<narrative xml:lang="fr">Politique du secteur de la construction, planification ; ne comprend pas les activités de construction identifiables par secteur (par exemple, construction d’hôpitaux ou de bâtiments scolaires).</narrative>
-			</description>
-			<category>323</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33110</code>
-			<name>
-				<narrative>Trade policy and administrative Management</narrative>
-				<narrative xml:lang="fr">Politique commerciale et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Trade policy and planning; support to ministries and departments responsible for trade policy; trade-related legislation and regulatory reforms; policy analysis and implementation of multilateral trade agreements e.g. technical barriers to trade and sanitary and phytosanitary measures (TBT/SPS) except at regional level (see 33130); mainstreaming trade in national development strategies (e.g. poverty reduction strategy papers); wholesale/retail trade; unspecified trade and trade promotion activities.</narrative>
-				<narrative xml:lang="fr">Politique commerciale et planification ; soutien aux ministères et départements responsables de la politique commerciale ; législation et réformes réglementaires dans le domaine du commerce ; analyse politique et mise en œuvre des accords commerciaux multilatéraux ex. sur les obstacles techniques au commerce et les mesures sanitaires et phytosanitaires sauf au niveau régional (voir 33130) ; intégration du commerce dans les stratégies nationales de développement (ex cadres stratégiques de la lutte contre la pauvreté) ; commerce de gros et de détail ; activités non spécifiées dans le domaine du commerce et de la promotion du commerce.</narrative>
-			</description>
-			<category>331</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33120</code>
-			<name>
-				<narrative>Trade facilitation</narrative>
-				<narrative xml:lang="fr">Facilitation du commerce</narrative>
-			</name>
-			<description>
-				<narrative>Simplification and harmonisation of international import and export procedures (e.g. customs valuation, licensing procedures, transport formalities, payments, insurance); support to customs departments and other border agencies, including in particular implementation of the provisions of the WTO Trade Facilitation Agreement; tariff reforms.</narrative>
-				<narrative xml:lang="fr">Simplification et harmonisation des procédures internationales d’importation et d’exportation (ex. évaluations de douane, procédures de licences, formalités de transport, paiements, assurances) ; soutien aux départements douaniers et autres agences frontalières y compris et en particulier la mise en oeuvre des dispositions de l'Accord sur la facilitation des échanges de l'OMC ; réformes tarifaires.</narrative>
-			</description>
-			<category>331</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33130</code>
-			<name>
-				<narrative>Regional trade agreements (RTAs)</narrative>
-				<narrative xml:lang="fr">Accords commerciaux régionaux</narrative>
-			</name>
-			<description>
-				<narrative>Support to regional trade arrangements [e.g. Southern African Development Community (SADC), Association of Southeast Asian Nations (ASEAN), Free Trade Area of the Americas (FTAA), African Caribbean Pacific/European Union (ACP/EU)], including work on technical barriers to trade and sanitary and phytosanitary measures (TBT/SPS) at regional level; elaboration of rules of origin and introduction of special and differential treatment in RTAs.</narrative>
-				<narrative xml:lang="fr">Soutien aux accords commerciaux régionaux [ex. Southern African Development Community (SADC), Association of Southeast Asian Nations (ASEAN), Zone de libre-échange des Amériques (ZLEA), Pays d’Afrique, des Caraïbes et du Pacifique/Union européenne (ACP/UE)] ; y compris le travail sur les obstacles techniques au commerce et les mesures sanitaires et phytosanitaires au niveau régional ; élaboration de règles d’origine et introduction de traitement spécial et différencié dans les accords commerciaux régionaux.</narrative>
-			</description>
-			<category>331</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33140</code>
-			<name>
-				<narrative>Multilateral trade negotiations</narrative>
-				<narrative xml:lang="fr">Négociations commerciales multilatérales</narrative>
-			</name>
-			<description>
-				<narrative>Support developing countries’ effective participation in multilateral trade negotiations, including training of negotiators, assessing impacts of negotiations; accession to the World Trade Organisation (WTO) and other multilateral trade-related organisations.</narrative>
-				<narrative xml:lang="fr">Soutien à la participation effective des pays en développement aux négociations commerciales multilatérales, y compris la formation de négociateurs, l’évaluation de l’impact des négociations ; accession à l’Organisation Mondiale du Commerce (OMC) et aux autres organisations multilatérales liées au commerce.</narrative>
-			</description>
-			<category>331</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33150</code>
-			<name>
-				<narrative>Trade-related adjustment</narrative>
-				<narrative xml:lang="fr">Ajustement lié au commerce</narrative>
-			</name>
-			<description>
-				<narrative>Contributions to the government budget to assist the implementation of recipients’ own trade reforms and adjustments to trade policy measures by other countries; assistance to manage shortfalls in the balance of payments due to changes in the world trading environment.</narrative>
-				<narrative xml:lang="fr">Contributions au budget du gouvernement non réservées afin de soutenir la mise en œuvre des propres réformes commerciales du bénéficiaire et de ses ajustements aux politiques commerciales des autres pays ; assistance à la gestion des déficits de la balance des paiements dus au changement de l’environnement mondial du commerce.</narrative>
-			</description>
-			<category>331</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33181</code>
-			<name>
-				<narrative>Trade education/training</narrative>
-				<narrative xml:lang="fr">Éducation/formation dans le domaine du commerce</narrative>
-			</name>
-			<description>
-				<narrative>Human resources development in trade not included under any of the above codes. Includes university programmes in trade.</narrative>
-				<narrative xml:lang="fr">Développement des ressources humaines dans le domaine du commerce non compris dans les codes ci-dessous. Comprend les programmes universitaires dans le domaine du commerce.</narrative>
-			</description>
-			<category>331</category>
-		</codelist-item>
-		<codelist-item>
-			<code>33210</code>
-			<name>
-				<narrative>Tourism policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique du tourisme et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>332</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41010</code>
-			<name>
-				<narrative>Environmental policy and administrative management</narrative>
-				<narrative xml:lang="fr">Politique de l’environnement et gestion administrative</narrative>
-			</name>
-			<description>
-				<narrative>Environmental policy, laws, regulations and economic instruments; administrational institutions and practices; environmental and land use planning and decision-making procedures; seminars, meetings; miscellaneous conservation and protection measures not specified below.</narrative>
-				<narrative xml:lang="fr">Politique de l’environnement, lois et réglementations environnementales ; institutions et pratiques administratives ; planification de l’environnement et de l’utilisation des terres, procédures de décisions ; séminaires, réunions ; actions de préservation et de protection non spécifiées ci-dessous.</narrative>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41020</code>
-			<name>
-				<narrative>Biosphere protection</narrative>
-				<narrative xml:lang="fr">Protection de la biosphère</narrative>
-			</name>
-			<description>
-				<narrative>Air pollution control, ozone layer preservation; marine pollution control.</narrative>
-				<narrative xml:lang="fr">Lutte contre la pollution de l’air, protection de la couche d’ozone ; lutte contre la pollution marine.</narrative>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41030</code>
-			<name>
-				<narrative>Bio-diversity</narrative>
-				<narrative xml:lang="fr">Diversité biologique</narrative>
-			</name>
-			<description>
-				<narrative>Including natural reserves and actions in the surrounding areas; other measures to protect endangered or vulnerable species and their habitats (e.g. wetlands preservation).</narrative>
-				<narrative xml:lang="fr">Y compris réserves naturelles et actions dans les régions environnantes ; autres mesures visant à protéger les espèces menacées dans leur habitat naturel (par exemple la protection des marécages).</narrative>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41040</code>
-			<name>
-				<narrative>Site preservation</narrative>
-				<narrative xml:lang="fr">Protection des sites</narrative>
-			</name>
-			<description>
-				<narrative>Applies to unique cultural landscape; including sites/objects of historical, archeological, aesthetic, scientific or educational value.</narrative>
-				<narrative xml:lang="fr">Se rapporte à un paysage culturel exceptionnel ; y compris des sites et des objets d’une valeur historique, archéologique, esthétique, scientifique ou éducative.</narrative>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41050</code>
-			<name>
-				<narrative>Flood prevention/control</narrative>
-				<narrative xml:lang="fr">Prévention et lutte contre les inondations</narrative>
-			</name>
-			<description>
-				<narrative>Floods from rivers or the sea; including sea water intrusion control and sea level rise related activities.</narrative>
-				<narrative xml:lang="fr">Inondations de la mer et des rivières ; y compris la lutte contre l’avancée et la montée du niveau de l’eau de la mer.</narrative>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41081</code>
-			<name>
-				<narrative>Environmental education/ training</narrative>
-				<narrative xml:lang="fr">Éducation et formation environnementales</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>41082</code>
-			<name>
-				<narrative>Environmental research</narrative>
-				<narrative xml:lang="fr">Recherche environnementale</narrative>
-			</name>
-			<description>
-				<narrative>Including establishment of databases, inventories/accounts of physical and natural resources; environmental profiles and impact studies if not sector specific.</narrative>
-				<narrative xml:lang="fr">Y compris établissement de bases de données, inventaires et estimations des ressources naturelles et physiques ; profils environnementaux et études d’impact lorsque le secteur ne peut être déterminé.</narrative>
-			</description>
-			<category>410</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43010</code>
-			<name>
-				<narrative>Multisector aid</narrative>
-				<narrative xml:lang="fr">Aide plurisectorielle</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43030</code>
-			<name>
-				<narrative>Urban development and management</narrative>
-				<narrative xml:lang="fr">Développement et gestion urbaine</narrative>
-			</name>
-			<description>
-				<narrative>Integrated urban development projects; local development and urban management; urban infrastructure and services; municipal finances; urban environmental management; urban development and planning; urban renewal and urban housing; land information systems.</narrative>
-				<narrative xml:lang="fr">Projets intégrés de développement urbain ; développement local et gestion urbaine ; infrastructure et services urbains ; gestion municipale ; gestion de l’environnement urbain ; planification ; rénovation urbaine, habitat ; informations sur l’occupation des sols.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43031</code>
-			<name>
-				<narrative>Urban land policy and management</narrative>
-				<narrative xml:lang="fr">Politique et gestion du territoire urbain</narrative>
-			</name>
-			<description>
-				<narrative>Urban development and planning; urban management, land information systems.</narrative>
-				<narrative xml:lang="fr">Planification et gestion du territoire urbain; gestion urbaine, systèmes d'information.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43032</code>
-			<name>
-				<narrative>Urban development</narrative>
-				<narrative xml:lang="fr">Développement urbain</narrative>
-			</name>
-			<description>
-				<narrative>Integrated urban development projects; local development; urban infrastructure and services; municipal finances; urban environment systems; urban renewal and urban housing.</narrative>
-				<narrative xml:lang="fr">Projets intégrés de développement urbain; développement local; infrastructure et services urbains; finances municipales; gestion environnementale urbaine; rénovation urbaine, habitat.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43040</code>
-			<name>
-				<narrative>Rural development</narrative>
-				<narrative xml:lang="fr">Développement rural</narrative>
-			</name>
-			<description>
-				<narrative>Integrated rural development projects; e.g. regional development planning; promotion of decentralised and multi-sectoral competence for planning, co-ordination and management; implementation of regional development and measures (including natural reserve management); land management; land use planning; land settlement and resettlement activities [excluding resettlement of refugees and internally displaced persons (72010)]; functional integration of rural and urban areas; geographical information systems.</narrative>
-				<narrative xml:lang="fr">Projets intégrés de développement rural, par exemple, planification du développement régional ; encouragement à la décentralisation des compétences plurisectorielles concernant la planification, la coordination et la gestion ; mise en œuvre du développement régional et des mesures d’accompagnement (telle que gestion des ressources naturelles) ; gestion et planification des terres ; peuplement des terres et activités de réinstallation des peuples [à l’exclusion de la réinstallation des réfugiés et des personnes déplacées à l’intérieur du pays (72010)] projets d’intégration des zones rurales et urbaines ; systèmes d’information des zones géographiques.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43041</code>
-			<name>
-				<narrative>Rural land policy and management</narrative>
-				<narrative xml:lang="fr">Administration de l'aménagement du territoire rural</narrative>
-			</name>
-			<description>
-				<narrative>Regional development planning; promotion of decentralised and multi-sectoral competence for planning, co-ordination and management; land management; land use planning; geographical information systems.</narrative>
-				<narrative xml:lang="fr">Planification du développement régional; encouragement à la décentralisation des compétences plurisectorielles concernant la planification, la coordination et la gestion; gestion des terres; systèmes d’information géographique.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43042</code>
-			<name>
-				<narrative>Rural development</narrative>
-				<narrative xml:lang="fr">Développement rural</narrative>
-			</name>
-			<description>
-				<narrative>Integrated rural development projects; implementation of regional development and measures (including natural reserve management); land settlement and resettlement activities [excluding resettlement of refugees and internally displaced persons (72010)]; functional integration of rural and urban areas.</narrative>
-				<narrative xml:lang="fr">Projets intégrés de développement rural; mise en œuvre du développement régional (y compris la gestion des réserves naturelles) ; peuplement et réinstallation [à l’exclusion de la réinstallation des réfugiés et des personnes déplacées à l’intérieur du pays (72030)]; intégration des zones rurales et urbaines.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43050</code>
-			<name>
-				<narrative>Non-agricultural alternative development</narrative>
-				<narrative xml:lang="fr">Développement alternatif non agricole</narrative>
-			</name>
-			<description>
-				<narrative>Projects to reduce illicit drug cultivation through, for example, non-agricultural income opportunities, social and physical infrastructure (see code 31165 for agricultural alternative development).</narrative>
-				<narrative xml:lang="fr">Projets visant à réduire les cultures illicites (drogue) à travers, par exemple, des activités créatrices de revenu non agricoles, des infrastructures sociales et physiques (voir code 31165 pour le développement alternatif agricole).</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43081</code>
-			<name>
-				<narrative>Multisector education/training</narrative>
-				<narrative xml:lang="fr">Éducation et formation plurisectorielles</narrative>
-			</name>
-			<description>
-				<narrative>Including scholarships.</narrative>
-				<narrative xml:lang="fr">Y compris les bourses.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>43082</code>
-			<name>
-				<narrative>Research/scientific institutions</narrative>
-				<narrative xml:lang="fr">Institutions scientifiques et de recherche</narrative>
-			</name>
-			<description>
-				<narrative>When sector cannot be identified.</narrative>
-				<narrative xml:lang="fr">Quand le secteur ne peut être déterminé.</narrative>
-			</description>
-			<category>430</category>
-		</codelist-item>
-		<codelist-item>
-			<code>51010</code>
-			<name>
-				<narrative>General budget support-related aid</narrative>
-				<narrative xml:lang="fr">Aide relative au soutien budgétaire général</narrative>
-			</name>
-			<description>
-				<narrative>Unearmarked contributions to the government budget; support for the implementation of macroeconomic reforms (structural adjustment programmes, poverty reduction strategies); general programme assistance (when not allocable by sector).</narrative>
-				<narrative xml:lang="fr">Contributions au budget du gouvernement non réservées ; soutien à la mise en œuvre des réformes macroéconomiques (programmes d’ajustement structurel, stratégies de réduction de la pauvreté) ; y compris l’aide-programme générale (ne pouvant être ventilée par secteur).</narrative>
-			</description>
-			<category>510</category>
-		</codelist-item>
-		<codelist-item>
-			<code>52010</code>
-			<name>
-				<narrative>Food aid/Food security programmes</narrative>
-				<narrative xml:lang="fr">Programmes de sécurité et d’aide alimentaire</narrative>
-			</name>
-			<description>
-				<narrative>Supply of edible human food under national or international programmes including transport costs; cash payments made for food supplies; project food aid and food aid for market sales when benefiting sector not specified; excluding emergency food aid. Report as multilateral: i) food aid by the EU financed out of its budget and allocated pro rata to EU member countries; and ii) core contributions to the World Food Programme.</narrative>
-				<narrative xml:lang="fr">Fourniture nationale ou internationale de produits alimentaires y compris frais de transport ; paiements comptants pour la fourniture de produits alimentaires ; projets d’aide alimentaire et aide alimentaire destinée à la vente quand le secteur bénéficiaire ne peut être précisé ; à l’exclusion de l’aide alimentaire d’urgence. Notifier comme multilatéral : i) l'aide alimentaire consentie par l’UE et financée sur son budget propre puis répartie entre les États membres au pro rata de leur contribution à ce budget ; et ii) les contributions au budget central du PAM.</narrative>
-			</description>
-			<category>520</category>
-		</codelist-item>
-		<codelist-item>
-			<code>53030</code>
-			<name>
-				<narrative>Import support (capital goods)</narrative>
-				<narrative xml:lang="fr">Subventions à l’importation (biens d’équipement)</narrative>
-			</name>
-			<description>
-				<narrative>Capital goods and services; lines of credit.</narrative>
-				<narrative xml:lang="fr">Biens d’équipement et services ; lignes de crédit.</narrative>
-			</description>
-			<category>530</category>
-		</codelist-item>
-		<codelist-item>
-			<code>53040</code>
-			<name>
-				<narrative>Import support (commodities)</narrative>
-				<narrative xml:lang="fr">Subventions à l’importation (produits)</narrative>
-			</name>
-			<description>
-				<narrative>Commodities, general goods and services, oil imports.</narrative>
-				<narrative xml:lang="fr">Produits, biens d’ordre général, importations de pétrole.</narrative>
-			</description>
-			<category>530</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60010</code>
-			<name>
-				<narrative>Action relating to debt</narrative>
-				<narrative xml:lang="fr">Action se rapportant à la dette</narrative>
-			</name>
-			<description>
-				<narrative>Actions falling outside the code headings below.</narrative>
-				<narrative xml:lang="fr">Actions non spécifiées ci-dessous.</narrative>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60020</code>
-			<name>
-				<narrative>Debt forgiveness</narrative>
-				<narrative xml:lang="fr">Annulation de la dette</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60030</code>
-			<name>
-				<narrative>Relief of multilateral debt</narrative>
-				<narrative xml:lang="fr">Allégement de la dette multilatérale</narrative>
-			</name>
-			<description>
-				<narrative>Grants or credits to cover debt owed to multilateral financial institutions; including contributions to Heavily Indebted Poor Countries (HIPC) Trust Fund.</narrative>
-				<narrative xml:lang="fr">Dons ou prêts affectés au remboursement d’échéances dues à des institutions financières multilatérales ; y compris les contributions au fonds spécial pour les Pays pauvres très endettés (PPTE).</narrative>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60040</code>
-			<name>
-				<narrative>Rescheduling and refinancing</narrative>
-				<narrative xml:lang="fr">Rééchelonnement d’échéances et refinancement</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60061</code>
-			<name>
-				<narrative>Debt for development swap</narrative>
-				<narrative xml:lang="fr">Échange de dette à des fins de développement</narrative>
-			</name>
-			<description>
-				<narrative>Allocation of debt claims to use for development (e.g., debt for education, debt for environment).</narrative>
-				<narrative xml:lang="fr">Affectation de créances à des fins de développement (par exemple dette pour l’éducation, dette pour l’environnement, etc.)</narrative>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60062</code>
-			<name>
-				<narrative>Other debt swap</narrative>
-				<narrative xml:lang="fr">Autres échanges de dette</narrative>
-			</name>
-			<description>
-				<narrative>Where the debt swap benefits an external agent i.e. is not specifically for development purposes.</narrative>
-				<narrative xml:lang="fr">Lorsque l’échange de dette profite à un agent extérieur, i.e. n’est pas spécifiquement opéré à des fins de développement.</narrative>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>60063</code>
-			<name>
-				<narrative>Debt buy-back</narrative>
-				<narrative xml:lang="fr">Rachat de la dette</narrative>
-			</name>
-			<description>
-				<narrative>Purchase of debt for the purpose of cancellation.</narrative>
-				<narrative xml:lang="fr">Achat de la dette en vue de son annulation.</narrative>
-			</description>
-			<category>600</category>
-		</codelist-item>
-		<codelist-item>
-			<code>72010</code>
-			<name>
-				<narrative>Material relief assistance and services</narrative>
-				<narrative xml:lang="fr">Assistance matérielle et services d’urgence</narrative>
-			</name>
-			<description>
-				<narrative>Shelter, water, sanitation and health services, supply of medicines and other non-food relief items for the benefit of affected people and to facilitate the return to normal lives and livelihoods; assistance to refugees and internally displaced people in developing countries other than for food (72040) or protection (72050).</narrative>
-				<narrative xml:lang="fr">Fourniture d’abris, d’eau, d’installations sanitaires et de services de santé, de médicaments et d’autres secours non alimentaires dans le but d’aider les populations affectées et de faciliter le retour à une vie et des moyens d’existence normaux ; aide aux personnes déplacées à l’intérieur d’un pays à des fins autres qu’alimentaires (72040) ou de protection (72050).</narrative>
-			</description>
-			<category>720</category>
-		</codelist-item>
-		<codelist-item>
-			<code>72040</code>
-			<name>
-				<narrative>Emergency food aid</narrative>
-				<narrative xml:lang="fr">Aide alimentaire d’urgence</narrative>
-			</name>
-			<description>
-				<narrative>Food aid normally for general free distribution or special supplementary feeding programmes; short-term relief to targeted population groups affected by emergency situations. Excludes non-emergency food security assistance programmes/food aid (52010).</narrative>
-				<narrative xml:lang="fr">Aide alimentaire pour distribution gratuite ou programmes alimentaires complémentaires ; soutien à court terme aux populations affectées par des catastrophes. Sont exclus les programmes non urgents de sécurité et d’aide alimentaire (52010).</narrative>
-			</description>
-			<category>720</category>
-		</codelist-item>
-		<codelist-item>
-			<code>72050</code>
-			<name>
-				<narrative>Relief co-ordination; protection and support services</narrative>
-				<narrative xml:lang="fr">Coordination des secours et services de soutien et de protection</narrative>
-			</name>
-			<description>
-				<narrative>Measures to co-ordinate delivery of humanitarian aid, including logistics and communications systems; measures to promote and protect the safety, well- being, dignity and integrity of civilians and those no longer taking part in hostilities. (Activities designed to protect the security of persons or property through the use or display of force are not reportable as ODA.)</narrative>
-				<narrative xml:lang="fr">Mesures visant à coordonner l’acheminement de l’aide humanitaire, y compris les moyens logistiques et les systèmes de communication ; mesures de promotion et de protection de la sécurité, du bien-être, de la dignité et de l’intégrité des civils et des personnes qui ne prennent plus part aux hostilités. (Les activités ayant pour but de protéger la sécurité des personnes et des biens par l’usage ou la démonstration de la force ne sont pas comptabilisables dans l’APD.)</narrative>
-			</description>
-			<category>720</category>
-		</codelist-item>
-		<codelist-item>
-			<code>73010</code>
-			<name>
-				<narrative>Reconstruction relief and rehabilitation</narrative>
-				<narrative xml:lang="fr">Aide à la reconstruction et réhabilitation</narrative>
-			</name>
-			<description>
-				<narrative>Short-term reconstruction work after emergency or conflict limited to restoring pre-existing infrastructure (e.g. repair or construction of roads, bridges and ports, restoration of essential facilities, such as water and sanitation, shelter, health care services); social and economic rehabilitation in the aftermath of emergencies to facilitate transition and enable populations to return to their previous livelihood or develop a new livelihood in the wake of an emergency situation (e.g. trauma counselling and treatment, employment programmes).</narrative>
-				<narrative xml:lang="fr">Travaux de reconstruction à court terme après une urgence ou un conflit limités à la remise en état des infrastructures préexistantes (par exemple, réparation ou construction de routes, de ponts ou de ports, restauration des services essentiels concernant, par exemple, l’eau et l’assainissement, les abris, les soins de santé) ; réhabilitation sociale et économique après des situations d’urgence pour faciliter la transition et permettre aux populations touchées de retrouver leurs moyens d’existence antérieurs ou d’en trouver de nouveaux au sortir d’une situation d’urgence (par exemple, conseils et traitements en vue d’aider à surmonter les traumatismes subis, programmes d’emploi).</narrative>
-			</description>
-			<category>730</category>
-		</codelist-item>
-		<codelist-item>
-			<code>74010</code>
-			<name>
-				<narrative>Disaster prevention and preparedness</narrative>
-				<narrative xml:lang="fr">Prévention des catastrophes et préparation à leur survenue</narrative>
-			</name>
-			<description>
-				<narrative>Disaster risk reduction activities (e.g. developing knowledge, natural risks cartography, legal norms for construction); early warning systems; emergency contingency stocks and contingency planning including preparations for forced displacement.</narrative>
-				<narrative xml:lang="fr">Activités visant à réduire les risques liés aux catastrophes (par exemple développement des connaissances, établissement d’une cartographie des risques naturels, de normes juridiques pour les constructions) ; systèmes d’alerte précoce, stocks d’urgence et planification d’urgence, y compris préparation à une évacuation.</narrative>
-			</description>
-			<category>740</category>
-		</codelist-item>
-		<codelist-item>
-			<code>91010</code>
-			<name>
-				<narrative>Administrative costs (non-sector allocable)</narrative>
-				<narrative xml:lang="fr">Frais administratifs (non alloués par secteur)</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>910</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>92010</code>
-			<name>
-				<narrative>Support to national NGOs</narrative>
-			</name>
-			<description>
-				<narrative>In the donor country.</narrative>
-			</description>
-			<category>920</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>92020</code>
-			<name>
-				<narrative>Support to international NGOs</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>920</category>
-		</codelist-item>
-		<codelist-item status="withdrawn">
-			<code>92030</code>
-			<name>
-				<narrative>Support to local and regional NGOs</narrative>
-			</name>
-			<description>
-				<narrative>In the recipient country or region.</narrative>
-			</description>
-			<category>920</category>
-		</codelist-item>
-		<codelist-item>
-			<code>93010</code>
-			<name>
-				<narrative>Refugees in donor countries (non-sector allocable)</narrative>
-				<narrative xml:lang="fr">Réfugiés dans le pays donneur (non alloués par secteur)</narrative>
-			</name>
-			<description>
-				<narrative/>
-			</description>
-			<category>930</category>
-		</codelist-item>
-		<codelist-item>
-			<code>99810</code>
-			<name>
-				<narrative>Sectors not specified</narrative>
-				<narrative xml:lang="fr">Secteur non spécifié</narrative>
-			</name>
-			<description>
-				<narrative>Contributions to general development of the recipient should be included under programme assistance (51010).</narrative>
-				<narrative xml:lang="fr">Les contributions au développement général du pays bénéficiaire devraient être incluses dans l’aide programme (51010).</narrative>
-			</description>
-			<category>998</category>
-		</codelist-item>
-		<codelist-item>
-			<code>99820</code>
-			<name>
-				<narrative>Promotion of development awareness (non-sector allocable)</narrative>
-				<narrative xml:lang="fr">Sensibilisation au développement (non alloués par secteur)</narrative>
-			</name>
-			<description>
-				<narrative>Spending in donor country for heightened awareness/interest in development co-operation (brochures, lectures, special research projects, etc.).</narrative>
-				<narrative xml:lang="fr">Dépenses dans le pays donneur afin de renforcer la sensibilisation et l’intérêt dans la coopération pour le développement (brochures, exposés, projets spéciaux de recherche, etc.).</narrative>
-			</description>
-			<category>998</category>
-		</codelist-item>
-	</codelist-items>
+    <metadata>
+        <name>
+            <narrative>DAC 5 Digit Sector</narrative>
+        </name>
+        <url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>11110</code>
+            <name>
+                <narrative>Education policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de l’éducation et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Education sector policy, planning and programmes; aid to education ministries, administration and management systems; institution capacity building and advice; school management and governance; curriculum and materials development; unspecified education activities.</narrative>
+                <narrative xml:lang="fr">Politique de l’éducation, planification et programmes ; aide aux ministères de l’éducation, à l’administration et au développement de systèmes de gestion, renforcement des capacités institutionnelles et conseils ; gestion et direction des écoles, développement des programmes d’études et des matériels pédagogiques ; activités d’éducation non spécifiées.</narrative>
+            </description>
+            <category>111</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11120</code>
+            <name>
+                <narrative>Education facilities and training</narrative>
+                <narrative xml:lang="fr">Équipements scolaires et formation</narrative>
+            </name>
+            <description>
+                <narrative>Educational buildings, equipment, materials; subsidiary services to education (boarding facilities, staff housing); language training; colloquia, seminars, lectures, etc.</narrative>
+                <narrative xml:lang="fr">Bâtiments scolaires, équipement, fournitures ; services pour l’éducation (équipement pour les pensionnaires, logement pour le personnel) ; cours de langues ; colloques, séminaires, conférences, etc.</narrative>
+            </description>
+            <category>111</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11130</code>
+            <name>
+                <narrative>Teacher training</narrative>
+                <narrative xml:lang="fr">Formation des enseignants</narrative>
+            </name>
+            <description>
+                <narrative>Teacher education (where the level of education is unspecified); in-service and pre-service training; materials development.</narrative>
+                <narrative xml:lang="fr">Éducation des enseignants (quand le niveau d’éducation n’est pas spécifié) ; formation et formation continue ; développement des matériels pédagogiques.</narrative>
+            </description>
+            <category>111</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11182</code>
+            <name>
+                <narrative>Educational research</narrative>
+                <narrative xml:lang="fr">Recherche en éducation</narrative>
+            </name>
+            <description>
+                <narrative>Research and studies on education effectiveness, relevance and quality; systematic evaluation and monitoring.</narrative>
+                <narrative xml:lang="fr">Recherche et études sur l’efficacité, la pertinence et la qualité de l’éducation ; évaluation et suivi systématiques.</narrative>
+            </description>
+            <category>111</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11220</code>
+            <name>
+                <narrative>Primary education</narrative>
+                <narrative xml:lang="fr">Enseignement primaire</narrative>
+            </name>
+            <description>
+                <narrative>Formal and non-formal primary education for children; all elementary and first cycle systematic instruction; provision of learning materials.</narrative>
+                <narrative xml:lang="fr">Enseignement primaire formel et non formel pour les enfants ; enseignement élémentaire général ; fournitures scolaires.</narrative>
+            </description>
+            <category>112</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11230</code>
+            <name>
+                <narrative>Basic life skills for youth and adults</narrative>
+                <narrative xml:lang="fr">Éducation pour une meilleure qualité de vie pour les jeunes et les adultes</narrative>
+            </name>
+            <description>
+                <narrative>Formal and non-formal education for basic life skills for young people and adults (adults education); literacy and numeracy training.</narrative>
+                <narrative xml:lang="fr">Éducation formelle et non formelle pour une meilleure qualité de vie pour les jeunes et les adultes (éducation des adultes) ; alphabétisation et apprentissage du calcul.</narrative>
+            </description>
+            <category>112</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11231</code>
+            <name>
+                <narrative>Basic life skills for youth</narrative>
+                <narrative xml:lang="fr">Éducation pour une meilleure qualité de vie pour les jeunes</narrative>
+            </name>
+            <description>
+                <narrative>Formal and non-formal education for basic life skills for young people.</narrative>
+                <narrative xml:lang="fr">Éducation formelle et non formelle pour une meilleure qualité de vie pour les jeunes.</narrative>
+            </description>
+            <category>112</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11232</code>
+            <name>
+                <narrative>Primary education equivalent for adults</narrative>
+                <narrative xml:lang="fr">Education primaire des adultes</narrative>
+            </name>
+            <description>
+                <narrative>Formal primary education for adults.</narrative>
+                <narrative xml:lang="fr">Éducation primaire formelle pour adultes.</narrative>
+            </description>
+            <category>112</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11240</code>
+            <name>
+                <narrative>Early childhood education</narrative>
+                <narrative xml:lang="fr">Éducation de la petite enfance</narrative>
+            </name>
+            <description>
+                <narrative>Formal and non-formal pre-school education.</narrative>
+                <narrative xml:lang="fr">Éducation préscolaire formelle et non formelle.</narrative>
+            </description>
+            <category>112</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11320</code>
+            <name>
+                <narrative>Secondary education</narrative>
+                <narrative xml:lang="fr">Enseignement secondaire</narrative>
+            </name>
+            <description>
+                <narrative>Second cycle systematic instruction at both junior and senior levels.</narrative>
+                <narrative xml:lang="fr">Éducation secondaire généralisée pour les premiers et derniers cycles.</narrative>
+            </description>
+            <category>113</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11321</code>
+            <name>
+                <narrative>Lower secondary education</narrative>
+                <narrative xml:lang="fr">Premier cycle de l'enseignement secondaire</narrative>
+            </name>
+            <description>
+                <narrative>Second cycle systematic instruction at junior level.</narrative>
+                <narrative xml:lang="fr">Éducation secondaire généralisée pour le premier cycle.</narrative>
+            </description>
+            <category>113</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11322</code>
+            <name>
+                <narrative>Upper secondary education</narrative>
+                <narrative xml:lang="fr">Deuxième cycle de l'enseignement secondaire</narrative>
+            </name>
+            <description>
+                <narrative>Second cycle systematic instruction at senior level.</narrative>
+                <narrative xml:lang="fr">Éducation secondaire généralisée pour le dernier cycle.</narrative>
+            </description>
+            <category>113</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11330</code>
+            <name>
+                <narrative>Vocational training</narrative>
+                <narrative xml:lang="fr">Formation professionnelle</narrative>
+            </name>
+            <description>
+                <narrative>Elementary vocational training and secondary level technical education; on-the job training; apprenticeships; including informal vocational training.</narrative>
+                <narrative xml:lang="fr">Formation professionnelle élémentaire et enseignement technique au niveau secondaire ; formation sur le tas ; apprentissage.</narrative>
+            </description>
+            <category>113</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11420</code>
+            <name>
+                <narrative>Higher education</narrative>
+                <narrative xml:lang="fr">Enseignement supérieur</narrative>
+            </name>
+            <description>
+                <narrative>Degree and diploma programmes at universities, colleges and polytechnics; scholarships.</narrative>
+                <narrative xml:lang="fr">Diplômes universitaires, de l’enseignement supérieur, de technologie ; bourses d’études.</narrative>
+            </description>
+            <category>114</category>
+        </codelist-item>
+        <codelist-item>
+            <code>11430</code>
+            <name>
+                <narrative>Advanced technical and managerial training</narrative>
+                <narrative xml:lang="fr">Formation technique supérieure de gestion</narrative>
+            </name>
+            <description>
+                <narrative>Professional-level vocational training programmes and in-service training.</narrative>
+                <narrative xml:lang="fr">Formation professionnelle supérieure et formation sur le tas.</narrative>
+            </description>
+            <category>114</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12110</code>
+            <name>
+                <narrative>Health policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de la santé et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Health sector policy, planning and programmes; aid to health ministries, public health administration; institution capacity building and advice; medical insurance programmes; unspecified health activities.</narrative>
+                <narrative xml:lang="fr">Politique de la santé, planification et programmes ; aide aux ministères de la santé ; administration de la santé publique ; renforcement des capacités institutionnelles et conseils ; programmes d’assurance-maladie ; activités de santé non spécifiés.</narrative>
+            </description>
+            <category>121</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12181</code>
+            <name>
+                <narrative>Medical education/training</narrative>
+                <narrative xml:lang="fr">Éducation et formation médicales</narrative>
+            </name>
+            <description>
+                <narrative>Medical education and training for tertiary level services.</narrative>
+                <narrative xml:lang="fr">Enseignement médical et formation pour les services au niveau tertiaire.</narrative>
+            </description>
+            <category>121</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12182</code>
+            <name>
+                <narrative>Medical research</narrative>
+                <narrative xml:lang="fr">Recherche médicale</narrative>
+            </name>
+            <description>
+                <narrative>General medical research (excluding basic health research).</narrative>
+                <narrative xml:lang="fr">Recherche médicale (à l’exclusion de la recherche sur la santé de base).</narrative>
+            </description>
+            <category>121</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12191</code>
+            <name>
+                <narrative>Medical services</narrative>
+                <narrative xml:lang="fr">Services médicaux</narrative>
+            </name>
+            <description>
+                <narrative>Laboratories, specialised clinics and hospitals (including equipment and supplies); ambulances; dental services; mental health care; medical rehabilitation; control of non-infectious diseases; drug and substance abuse control [excluding narcotics traffic control (16063)].</narrative>
+                <narrative xml:lang="fr">Laboratoires, centres de santé et hôpitaux spécialisés (y compris l’équipement et les fournitures) ; ambulances ; services dentaires ; santé mentale ; rééducation médicale ; lutte contre les maladies à l’exclusion des maladies infectieuses ; lutte contre la toxicomanie [à l’exclusion du trafic de drogues (16063)].</narrative>
+            </description>
+            <category>121</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12220</code>
+            <name>
+                <narrative>Basic health care</narrative>
+                <narrative xml:lang="fr">Soins et services de santé de base</narrative>
+            </name>
+            <description>
+                <narrative>Basic and primary health care programmes; paramedical and nursing care programmes; supply of drugs, medicines and vaccines related to basic health care.</narrative>
+                <narrative xml:lang="fr">Programmes de soins sanitaires primaires et de base ; programmes de soins paramédicaux et infirmiers ; approvisionnement en médicaments et en vaccins relatifs aux soins et services de santé de base.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12230</code>
+            <name>
+                <narrative>Basic health infrastructure</narrative>
+                <narrative xml:lang="fr">Infrastructure pour la santé de base</narrative>
+            </name>
+            <description>
+                <narrative>District-level hospitals, clinics and dispensaries and related medical equipment; excluding specialised hospitals and clinics (12191).</narrative>
+                <narrative xml:lang="fr">Hôpitaux régionaux, centres de santé, dispensaires et équipements médicaux ; à l’exclusion des hôpitaux et centres de santé spécialisés (12191).</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12240</code>
+            <name>
+                <narrative>Basic nutrition</narrative>
+                <narrative xml:lang="fr">Nutrition de base</narrative>
+            </name>
+            <description>
+                <narrative>Direct feeding programmes (maternal feeding, breastfeeding and weaning foods, child feeding, school feeding); determination of micro-nutrient deficiencies; provision of vitamin A, iodine, iron etc.; monitoring of nutritional status; nutrition and food hygiene education; household food security.</narrative>
+                <narrative xml:lang="fr">Programmes pour l’alimentation (alimentation maternelle, allaitement et alimentation du sevrage, alimentation de l’enfant, alimentation à l’école) ; identification des déficiences nutritives ; fourniture de vitamine A, d’iode, de fer, etc. ; surveillance de l’état nutritionnel ; enseignement de la nutrition et de l’hygiène alimentaire ; alimentation domestique.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12250</code>
+            <name>
+                <narrative>Infectious disease control</narrative>
+                <narrative xml:lang="fr">Lutte contre les maladies infectieuses</narrative>
+            </name>
+            <description>
+                <narrative>Immunisation; prevention and control of infectious and parasite diseases, except malaria (12262), tuberculosis (12263), HIV/AIDS and other STDs (13040). It includes diarrheal diseases, vector-borne diseases (e.g. river blindness and guinea worm), viral diseases, mycosis, helminthiasis, zoonosis, diseases by other bacteria and viruses, pediculosis, etc.</narrative>
+                <narrative xml:lang="fr">Vaccination ; prévention et lutte contre les maladies infectieuses parasitaires à l’exception du paludisme (12262), de la tuberculose (12263), du VIH/sida et autres MST (13040). Ceci inclus les diarrhées chroniques, les maladies transmises par un vecteur (par exemple onchocercose, bilharziose), les maladies virales, les mycoses, l’helminthiasis, les zoonoses et les maladies provoquées par d’autres bactéries et virus, pédiculose, etc.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12261</code>
+            <name>
+                <narrative>Health education</narrative>
+                <narrative xml:lang="fr">Éducation sanitaire</narrative>
+            </name>
+            <description>
+                <narrative>Information, education and training of the population for improving health knowledge and practices; public health and awareness campaigns; promotion of improved personal hygiene practices, including use of sanitation facilities and handwashing with soap.</narrative>
+                <narrative xml:lang="fr">Information, éducation et formation de la population pour l’amélioration des connaissances et des pratiques liées à la santé ; campagnes pour la santé publique et programmes de sensibilisation ; promotion de meilleures pratiques d’hygiène personnelle, notamment de l’utilisation d’équipements sanitaires et du savonnage des mains.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12262</code>
+            <name>
+                <narrative>Malaria control</narrative>
+                <narrative xml:lang="fr">Lutte contre le paludisme</narrative>
+            </name>
+            <description>
+                <narrative>Prevention and control of malaria.</narrative>
+                <narrative xml:lang="fr">Prévention et lutte contre le paludisme.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12263</code>
+            <name>
+                <narrative>Tuberculosis control</narrative>
+                <narrative xml:lang="fr">Lutte contre la tuberculose</narrative>
+            </name>
+            <description>
+                <narrative>Immunisation, prevention and control of tuberculosis.</narrative>
+                <narrative xml:lang="fr">Vaccination, prévention et lutte contre la tuberculose.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>12281</code>
+            <name>
+                <narrative>Health personnel development</narrative>
+                <narrative xml:lang="fr">Formation de personnel de santé</narrative>
+            </name>
+            <description>
+                <narrative>Training of health staff for basic health care services.</narrative>
+                <narrative xml:lang="fr">Formation du personnel de santé pour les services et les soins sanitaires de base.</narrative>
+            </description>
+            <category>122</category>
+        </codelist-item>
+        <codelist-item>
+            <code>13010</code>
+            <name>
+                <narrative>Population policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique/programmes en matière de population et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Population/development policies; census work, vital registration; migration data; demographic research/analysis; reproductive health research; unspecified population activities.</narrative>
+                <narrative xml:lang="fr">Politique en matière de population et de développement ; recensement, enregistrement des naissances/décès ; données sur la migration ; recherche et analyse démographiques ; recherche en santé et fertilité ; activités de population non spécifiées.</narrative>
+            </description>
+            <category>130</category>
+        </codelist-item>
+        <codelist-item>
+            <code>13020</code>
+            <name>
+                <narrative>Reproductive health care</narrative>
+                <narrative xml:lang="fr">Soins en matière de fertilité</narrative>
+            </name>
+            <description>
+                <narrative>Promotion of reproductive health; prenatal and postnatal care including delivery; prevention and treatment of infertility; prevention and management of consequences of abortion; safe motherhood activities.</narrative>
+                <narrative xml:lang="fr">Santé et fertilité ; soins prénatals et périnatals, y compris l’accouchement ; prévention et traitement de la stérilité ; prévention et suites de l’avortement ; activités pour une maternité sans risque.</narrative>
+            </description>
+            <category>130</category>
+        </codelist-item>
+        <codelist-item>
+            <code>13030</code>
+            <name>
+                <narrative>Family planning</narrative>
+                <narrative xml:lang="fr">Planification familiale</narrative>
+            </name>
+            <description>
+                <narrative>Family planning services including counselling; information, education and communication (IEC) activities; delivery of contraceptives; capacity building and training.</narrative>
+                <narrative xml:lang="fr">Conseils en planification familiale ; activités d’information, d’éducation et de communication (IEC) ; distribution de produits contraceptifs ; accroissement des moyens et aptitudes, formation.</narrative>
+            </description>
+            <category>130</category>
+        </codelist-item>
+        <codelist-item>
+            <code>13040</code>
+            <name>
+                <narrative>STD control including HIV/AIDS</narrative>
+                <narrative xml:lang="fr">Lutte contre les MST et VIH/sida</narrative>
+            </name>
+            <description>
+                <narrative>All activities related to sexually transmitted diseases and HIV/AIDS control e.g. information, education and communication; testing; prevention; treatment, care.</narrative>
+                <narrative xml:lang="fr">Toutes activités liées au contrôle des maladies sexuellement transmissibles et du VIH/sida ; activités d’information, éducation et communication ; dépistage ; prévention ; traitement, soins.</narrative>
+            </description>
+            <category>130</category>
+        </codelist-item>
+        <codelist-item>
+            <code>13081</code>
+            <name>
+                <narrative>Personnel development for population and reproductive health</narrative>
+                <narrative xml:lang="fr">Formation de personnel en matière de population et de santé et fertilité</narrative>
+            </name>
+            <description>
+                <narrative>Education and training of health staff for population and reproductive health care services.</narrative>
+                <narrative xml:lang="fr">Éducation et formation du personnel de santé pour les services de population ainsi que les soins en matière de santé et fertilité.</narrative>
+            </description>
+            <category>130</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14010</code>
+            <name>
+                <narrative>Water sector policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique et gestion administrative du secteur de l’eau</narrative>
+            </name>
+            <description>
+                <narrative>Water sector policy and governance, including legislation, regulation, planning and management as well as transboundary management of water; institutional capacity development; activities supporting the Integrated Water Resource Management approach (IWRM: see box below).</narrative>
+                <narrative xml:lang="fr">Politique et gouvernance du secteur de l’eau, y compris législation, réglementation, planification et gestion ainsi que gestion transfrontalière de l’eau; renforcement des capacités institutionnelles ; activités favorisant une approche intégrée de la gestion des ressources en eau (GIRE : voir encadré ci-dessous).</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14015</code>
+            <name>
+                <narrative>Water resources conservation (including data collection)</narrative>
+                <narrative xml:lang="fr">Préservation des ressources en eau (y compris collecte de données)</narrative>
+            </name>
+            <description>
+                <narrative>Collection and usage of quantitative and qualitative data on water resources; creation and sharing of water knowledge; conservation and rehabilitation of inland surface waters (rivers, lakes etc.), ground water and coastal waters; prevention of water contamination.</narrative>
+                <narrative xml:lang="fr">Collecte et utilisation de données quantitatives et qualitatives sur les ressources en eau ; création et mise en commun de connaissances sur l’eau ; préservation et remise en état des eaux intérieures de surface (rivières, lacs, etc.), des nappes souterraines et des eaux côtières ; prévention de la contamination des eaux.</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14020</code>
+            <name>
+                <narrative>Water supply and sanitation - large systems</narrative>
+                <narrative xml:lang="fr">Approvisionnement en eau et assainissement – systèmes à grande échelle</narrative>
+            </name>
+            <description>
+                <narrative>Programmes where components according to 14021 and 14022 cannot be identified. When components are known, they should individually be reported under their respective purpose codes: water supply (14021), sanitation (14022), and hygiene (12261).</narrative>
+                <narrative xml:lang="fr">Programmes dont les composantes relatives aux codes 14021 et 14022 ne peuvent être identifiées séparément. Lorsque les composantes sont connues, elles devraient être individuellement notifiées sous leurs codes respectifs : approvisionnement en eau [14021], assainissement [14022] et hygiène [12261].</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14021</code>
+            <name>
+                <narrative>Water supply - large systems</narrative>
+                <narrative xml:lang="fr">Approvisionnement en eau – systèmes à grande échelle</narrative>
+            </name>
+            <description>
+                <narrative>Potable water treatment plants; intake works; storage; water supply pumping stations; large scale transmission / conveyance and distribution systems.</narrative>
+                <narrative xml:lang="fr">Usines de traitement d’eau potable ; ouvrages d’adduction ; stockage ; stations de pompage pour l’approvisionnement en eau ; réseaux d’adduction et de distribution à grande échelle.</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14022</code>
+            <name>
+                <narrative>Sanitation - large systems</narrative>
+                <narrative xml:lang="fr">Assainissement – systèmes à grande échelle</narrative>
+            </name>
+            <description>
+                <narrative>Large scale sewerage including trunk sewers and sewage pumping stations; domestic and industrial waste water treatment plants.</narrative>
+                <narrative xml:lang="fr">Réseaux d’assainissement à grande échelle y compris égouts et stations de pompage des eaux d’égouts ; usines de traitement des eaux usées domestiques et industrielles.</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14030</code>
+            <name>
+                <narrative>Basic drinking water supply and basic sanitation</narrative>
+                <narrative xml:lang="fr">Approvisionnement en eau potable et assainissement - dispositifs de base</narrative>
+            </name>
+            <description>
+                <narrative>Programmes where components according to 14031 and 14032 cannot be identified. When components are known, they should individually be reported under their respective purpose codes: water supply (14031), sanitation (14032), and hygiene (12261).</narrative>
+                <narrative xml:lang="fr">Programmes dont les composantes relatives aux codes 14031 et 14032 ne peuvent être identifiées séparément. Lorsque les composantes sont connues, elles devraient être individuellement notifiées sous leurs codes respectifs : approvisionnement en eau [14031], assainissement [14032] et hygiène [12261].</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14031</code>
+            <name>
+                <narrative>Basic drinking water supply</narrative>
+                <narrative xml:lang="fr">Approvisionnement en eau potable – dispositifs de base</narrative>
+            </name>
+            <description>
+                <narrative>Rural water supply schemes using handpumps, spring catchments, gravity-fed systems, rainwater collection and fog harvesting, storage tanks, small distribution systems typically with shared connections/points of use. Urban schemes using handpumps and local neighbourhood networks including those with shared connections.</narrative>
+                <narrative xml:lang="fr">Dispositifs ruraux d’approvisionnement en eau reposant sur des pompes manuelles, des captages de sources, des systèmes par gravité, la collecte des eaux de pluie et de brouillard, des citernes, des systèmes simplifiés de distribution avec points d’eau collectifs/branchements partagés. Dispositifs urbains utilisant des pompes manuelles et mini-réseaux, y compris ceux avec branchements partagés et bornes-fontaines.</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14032</code>
+            <name>
+                <narrative>Basic sanitation</narrative>
+                <narrative xml:lang="fr">Assainissement – dispositifs de base</narrative>
+            </name>
+            <description>
+                <narrative>Latrines, on-site disposal and alternative sanitation systems, including the promotion of household and community investments in the construction of these facilities. (Use code 12261 for activities promoting improved personal hygiene practices.)</narrative>
+                <narrative xml:lang="fr">Latrines, dispositifs d’assainissement autonomes et systèmes alternatifs, y compris la promotion d’investissements de la part des ménages et des communautés locales dans la construction d’équipements de ce type. (Utiliser le code 12261 pour les activités de promotion des règles d’hygiène personnelle.)</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14040</code>
+            <name>
+                <narrative>River basins’ development</narrative>
+                <narrative xml:lang="fr">Aménagement de bassins fluviaux</narrative>
+            </name>
+            <description>
+                <narrative>Infrastructure-focused integrated river basin projects and related institutional activities; river flow control; dams and reservoirs [excluding dams primarily for irrigation (31140) and hydropower (23220) and activities related to river transport (21040)].</narrative>
+                <narrative xml:lang="fr">Projets de bassins fluviaux centrés sur les infrastructures et activités institutionnelles connexes ; régulation des cours d’eau ; barrages et réservoirs [à l’exclusion des barrages hydroélectriques (23220) et barrag es pour l’irrigation (31140) et activités liées au transport fluvial (21040)].</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14050</code>
+            <name>
+                <narrative>Waste management / disposal</narrative>
+                <narrative xml:lang="fr">Traitement des déchets</narrative>
+            </name>
+            <description>
+                <narrative>Municipal and industrial solid waste management, including hazardous and toxic waste; collection, disposal and treatment; landfill areas; composting and reuse.</narrative>
+                <narrative xml:lang="fr">Au niveau municipal et industriel, y compris les déchets dangereux et toxiques ; enlèvement et traitement ; zones d’enfouissement des déchets ; compost et recyclage.</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>14081</code>
+            <name>
+                <narrative>Education and training in water supply and sanitation</narrative>
+                <narrative xml:lang="fr">Éducation et formation en matière d’approvisionnement en eau et d’assainissement</narrative>
+            </name>
+            <description>
+                <narrative>Education and training for sector professionals and service providers.</narrative>
+                <narrative xml:lang="fr">Activités d’éducation et de formation destinées aux professionnels et fournisseurs de services de ce secteur.</narrative>
+            </description>
+            <category>140</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15110</code>
+            <name>
+                <narrative>Public sector policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politiques publiques et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Institution-building assistance to strengthen core public sector management systems and capacities. This includes macro-economic and other policy management, co-ordination, planning and reform; human resource management; organisational development; civil service reform; e-government; development planning, monitoring and evaluation; support to ministries involved in aid co-ordination; other ministries and government departments when sector cannot be specified. (Use specific sector codes for development of systems and capacities in sector ministries.)</narrative>
+                <narrative xml:lang="fr">Aide au renforcement des institutions visant à consolider les capacités et systèmes principaux de gestion du secteur public. Ceci recouvre la gestion macroéconomique et la gestion d’autres politiques, la coordination, la planification et la réforme ; la gestion des ressources humaines ; le développement organisationnel ; la réforme de la fonction publique ; l’administration électronique ; la planification, le suivi et l’évaluation du développement ; le soutien aux ministères participant à la coordination de l’aide ; d’autres ministères et services gouvernementaux lorsque le secteur ne peut pas être précisé. (Utiliser des codes sectoriels spécifiques pour le renforcement des systèmes et des capacités dans les ministères sectoriels.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15111</code>
+            <name>
+                <narrative>Public Finance Management (PFM)</narrative>
+                <narrative xml:lang="fr">Gestion des finances publiques</narrative>
+            </name>
+            <description>
+                <narrative>Fiscal policy and planning; support to ministries of finance; strengthening financial and managerial accountability; public expenditure management; improving financial management systems; budget drafting; inter-governmental fiscal relations, public audit, public debt. (Use code 15114 for domestic revenue mobilisation and code 33120 for customs).</narrative>
+                <narrative xml:lang="fr">Politique et planification budgétaires ; soutien aux ministères des finances ; renforcement de la responsabilité financière et administrative ; gestion des dépenses publiques ; amélioration des systèmes de gestion financière ; préparation du budget ; relations budgétaires intergouvernementales, audit public, dette publique. (Utiliser les codes 15114 pour la mobilisation des ressources intérieures et 33120 pour les douanes.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15112</code>
+            <name>
+                <narrative>Decentralisation and support to subnational government</narrative>
+                <narrative xml:lang="fr">Décentralisation et soutien aux administrations infranationales</narrative>
+            </name>
+            <description>
+                <narrative>Decentralisation processes (including political, administrative and fiscal dimensions); intergovernmental relations and federalism; strengthening departments of regional and local government, regional and local authorities and their national associations. (Use specific sector codes for decentralisation of sector management and services.)</narrative>
+                <narrative xml:lang="fr">Processus de décentralisation (y compris aspects politiques, administratifs et budgétaires) ; relations intergouvernementales et fédéralisme ; renforcement des services des administrations régionales et locales, des autorités régionales et locales et de leurs associations nationales. (Utiliser des codes sectoriels spécifiques pour la décentralisation de la gestion et des services sectoriels.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15113</code>
+            <name>
+                <narrative>Anti-corruption organisations and institutions</narrative>
+                <narrative xml:lang="fr">Organisations et institutions pour la lutte contre la corruption</narrative>
+            </name>
+            <description>
+                <narrative>Specialised organisations, institutions and frameworks for the prevention of and combat against corruption, bribery, money- laundering and other aspects of organised crime, with or without law enforcement powers, e.g. anti-corruption commissions and monitoring bodies, special investigation services, institutions and initiatives of integrity and ethics oversight, specialised NGOs, other civil society and citizens’ organisations directly concerned with corruption.</narrative>
+                <narrative xml:lang="fr">Organisations, institutions et cadres spécialisés dans la prévention et la lutte contre la corruption active et passive, le blanchiment d’argent et d’autres aspects du crime organisé, dotés ou non de pouvoirs pour faire respecter la loi, comme les commissions chargées de la lutte contre la corruption et les organismes de suivi, les services spéciaux d’enquête, les institutions et les initiatives de contrôle de l’intégrité et de l’éthique, les ONG spécialisées, d’autres organisations de citoyens et de la société civile s’occupant directement de lutter contre la corruption.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15114</code>
+            <name>
+                <narrative>Domestic Revenue Mobilisation</narrative>
+                <narrative xml:lang="fr">Mobilisation des ressources intérieures</narrative>
+            </name>
+            <description>
+                <narrative>Support to domestic revenue mobilisation/tax policy, analysis and administration as well as non-tax public revenue, which includes work with ministries of finance, line ministries, revenue authorities or other local, regional or national public bodies. (Use code 16010 for social security and other social protection.)</narrative>
+                <narrative xml:lang="fr">Soutien à la mobilisation des ressources intérieures/politique fiscale, analyse et administration ainsi que les recettes non-fiscales, incluant le travail avec les ministères des finances, les ministères de tutelle, les autorités fiscales ou autres institutions publiques locales, régionales ou nationales (Utiliser le code 16010 pour la sécurité sociale et autres plans sociaux.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15116</code>
+            <name>
+                <narrative>Tax collection</narrative>
+                <narrative xml:lang="fr">Recouvrement de l'impôt</narrative>
+            </name>
+            <description>
+                <narrative>Operation of the inland revenue authority.</narrative>
+                <narrative xml:lang="fr">Fonctionnement de l'autorité nationale de recouvrement des impôts.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15117</code>
+            <name>
+                <narrative>Budget planning</narrative>
+                <narrative xml:lang="fr">Planification budgétaire</narrative>
+            </name>
+            <description>
+                <narrative>Operation of the budget office and planning as part of the budget process.</narrative>
+                <narrative xml:lang="fr">Fonctionnement des services de préparation du budget.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15118</code>
+            <name>
+                <narrative>National audit</narrative>
+                <narrative xml:lang="fr">Contrôle interne national</narrative>
+            </name>
+            <description>
+                <narrative>Operation of the accounting and audit services.</narrative>
+                <narrative xml:lang="fr">Administration et fonctionnement des services de vérification.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15119</code>
+            <name>
+                <narrative>Debt and aid management</narrative>
+                <narrative xml:lang="fr">Gestion de l'aide et de la dette publique</narrative>
+            </name>
+            <description>
+                <narrative>Management of public debt and foreign aid received (in the partner country). For reporting on debt reorganisation, use codes 600xx.</narrative>
+                <narrative xml:lang="fr">Gestion de la dette publique et de l'aide étrangère reçue (par le pays partenaire). Pour rapporter des ré-échelonnements de dette, utiliser les codes 600xx.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>15120</code>
+            <name>
+                <narrative>Public sector financial management</narrative>
+            </name>
+            <description>
+                <narrative>Strengthening financial and managerial accountability; public expenditure management; improving financial management systems; tax assessment procedures; budget drafting; field auditing; measures against waste, fraud and corruption.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15121</code>
+            <name>
+                <narrative>Foreign affairs</narrative>
+                <narrative xml:lang="fr">Affaires étrangères</narrative>
+            </name>
+            <description>
+                <narrative>Administration of external affairs and services.</narrative>
+                <narrative xml:lang="fr">Administration des affaires étrangères et services associés.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15122</code>
+            <name>
+                <narrative>Diplomatic missions</narrative>
+                <narrative xml:lang="fr">Missions diplomatiques</narrative>
+            </name>
+            <description>
+                <narrative>Operation of diplomatic and consular missions stationed abroad or at offices of international organisations.</narrative>
+                <narrative xml:lang="fr">Fonctionnement des missions diplomatiques ou consulaires à l'étranger ou auprès d'organisations internationales.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15123</code>
+            <name>
+                <narrative>Administration of developing countries' foreign aid</narrative>
+                <narrative xml:lang="fr">Gestion de l'aide étrangère des pays en développement</narrative>
+            </name>
+            <description>
+                <narrative>Support to administration of developing countries' foreign aid (including triangular and south-south cooperation).</narrative>
+                <narrative xml:lang="fr">Soutien à la gestion de l'aide étrangère offerte par les pays en développement (y compris la cooperation triangulaire et sud-sud).</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15124</code>
+            <name>
+                <narrative>General personnel services</narrative>
+                <narrative xml:lang="fr">Services généraux de personnel</narrative>
+            </name>
+            <description>
+                <narrative>Administration and operation of the civil service including policies, procedures and regulations.</narrative>
+                <narrative xml:lang="fr">Administration et fonctionnement de services généraux de personnel, y compris les politiques, réglements et procédures.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15125</code>
+            <name>
+                <narrative>Central procurement</narrative>
+                <narrative xml:lang="fr">Services centralisés d'approvisionnement et d'achat</narrative>
+            </name>
+            <description>
+                <narrative>Administration and operation of centralised supply and purchasing services.</narrative>
+                <narrative xml:lang="fr">Administration et fonction des services centralisés d'approvisionnement et d'achat.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15126</code>
+            <name>
+                <narrative>Other general public services</narrative>
+                <narrative xml:lang="fr">Autres services généraux</narrative>
+            </name>
+            <description>
+                <narrative>Maintenance and storage of government records and archives, operation of government-owned or occupied buildings, central motor vehicle pools, government-operated printing offices, centralised computer and data processing services, etc.</narrative>
+                <narrative xml:lang="fr">Tenue et stockage de dossiers et archives des administrations publiques, exploitation d'immeubles dont des administrations publiques sont propriétaires ou occupants, parcs centraux de véhicules, imprimeries exploitées par des administrations publiques, services centraux de calcul et d'informatique, etc.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15127</code>
+            <name>
+                <narrative>National monitoring and evaluation</narrative>
+                <narrative xml:lang="fr">Suivi et evaluation au niveau national</narrative>
+            </name>
+            <description>
+                <narrative>Operation or support of institutions providing national monitoring and evaluation.</narrative>
+                <narrative xml:lang="fr">Administration ou fonctionnement des services s'occupant de suivi et d'évaluation au niveau national.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15128</code>
+            <name>
+                <narrative>Local government finance</narrative>
+                <narrative xml:lang="fr">Financement des gouvernements locaux</narrative>
+            </name>
+            <description>
+                <narrative>Financial transfers to local government; support to institutions managing such transfers. (Use specific sector codes for sector-related transfers.)</narrative>
+                <narrative xml:lang="fr">Transferts financiers aux gouvernements locaux; soutien aux institutions administrant ces transferts. (Pour des transferts concernant des secteurs particuliers, utiliser les codes sectoriels appropriés.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15129</code>
+            <name>
+                <narrative>Other central transfers to institutions</narrative>
+                <narrative xml:lang="fr">Autres transferts du centre à des institutions</narrative>
+            </name>
+            <description>
+                <narrative>Transfers to non sector-specific autonomous bodies or state-owned enterprises outside of local government finance; support to institutions managing such transfers. (Use specific sector codes for sector-related transfers.)</narrative>
+                <narrative xml:lang="fr">Transferts aux organisations autonomes ou entreprises d'États non inclus dans le financement des gouvernements locaux; soutien aux institutions administrant ces transferts.(Pour des transferts concernant des secteurs particuliers, utiliser les codes sectoriels appropriés.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15130</code>
+            <name>
+                <narrative>Legal and judicial development</narrative>
+                <narrative xml:lang="fr">Développement des services légaux et judiciaires</narrative>
+            </name>
+            <description>
+                <narrative>Support to institutions, systems and procedures of the justice sector, both formal and informal; support to ministries of justice, the interior and home affairs; judges and courts; legal drafting services; bar and lawyers associations; professional legal education; maintenance of law and order and public safety; border management; law enforcement agencies, police, prisons and their supervision; ombudsmen; alternative dispute resolution, arbitration and mediation; legal aid and counsel; traditional, indigenous and paralegal practices that fall outside the formal legal system. Measures that support the improvement of legal frameworks, constitutions, laws and regulations; legislative and constitutional drafting and review; legal reform; integration of formal and informal systems of law. Public legal education; dissemination of information on entitlements and remedies for injustice; awareness campaigns. (Use codes 152xx for activities that are primarily aimed at supporting security system reform or undertaken in connection with post-conflict and peace building activities.)</narrative>
+                <narrative xml:lang="fr">Soutien aux institutions, systèmes et procédures du secteur de la justice, aussi bien officiels que non officiels ; soutien aux ministères de la justice et de l’intérieur ; juges et tribunaux ; services de rédaction des actes juridiques ; associations d’avocats et de juristes ; formation juridique professionnelle ; maintien de l’ordre et de la sécurité publique ; gestion des frontières ; organismes chargés de faire respecter la loi, police, prisons et leur supervision ; médiateurs ; mécanismes alternatifs de règlement des conflits, d’arbitrage et de médiation ; aide et conseil juridiques ; pratiques traditionnelles, indigènes et paralégales ne faisant pas partie du système juridique officiel. Mesures à l’appui de l’amélioration des cadres juridiques, constitutions, lois et réglementations ; rédaction et révision de textes législatifs et constitutionnels ; réforme juridique ; intégration des systèmes légaux officiels et non officiels. Éducation juridique ; diffusion d’informations sur les droits et les voies de recours en cas d’injustice ; campagnes de sensibilisation. (Utiliser les codes 152xx pour les activités ayant principalement pour objet de soutenir la réforme des systèmes de sécurité ou entreprises en liaison avec des activités de maintien de la paix à l’issue d’un conflit.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15131</code>
+            <name>
+                <narrative>Justice, law and order policy, planning and administration</narrative>
+                <narrative xml:lang="fr">Développement et administration des politiques de justice et de maintien de l'ordre</narrative>
+            </name>
+            <description>
+                <narrative>Judicial law and order sectors; policy development within ministries of justice or equivalents.</narrative>
+                <narrative xml:lang="fr">Justice et maintien de l'ordre; développement des politiques dans les ministères de la justice ou leur équivalent.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15132</code>
+            <name>
+                <narrative>Police</narrative>
+                <narrative xml:lang="fr">Police</narrative>
+            </name>
+            <description>
+                <narrative>Police affairs and services.</narrative>
+                <narrative xml:lang="fr">Administration des affaires et services de police.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15133</code>
+            <name>
+                <narrative>Fire and rescue services</narrative>
+                <narrative xml:lang="fr">Incendies et services de sauvetage</narrative>
+            </name>
+            <description>
+                <narrative>Fire-prevention and fire-fighting affairs and services.</narrative>
+                <narrative xml:lang="fr">Administration des affaires et services de protection et de lutte contre l'incendie.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15134</code>
+            <name>
+                <narrative>Judicial affairs</narrative>
+                <narrative xml:lang="fr">Système judiciaire</narrative>
+            </name>
+            <description>
+                <narrative>Civil and criminal law courts and the judicial system, including enforcement of fines and legal settlements imposed by the courts and operation of parole and probation systems.</narrative>
+                <narrative xml:lang="fr">Administration, fonctionnement ou soutien des tribunaux civils et pénals et du système judiciaire, y compris mise à exécution des amendes et des obligations imposées par les tribunaux, et suivi des programmes de mise en liberté conditionnelle et de mise à l'épreuve.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15135</code>
+            <name>
+                <narrative>Ombudsman</narrative>
+                <narrative xml:lang="fr">Ombudsman</narrative>
+            </name>
+            <description>
+                <narrative>Independent service representing the interests of the public by investigating and addressing complaints of unfair treatment or maladministration.</narrative>
+                <narrative xml:lang="fr">Officier indépendant représentant les intérêts du public en faisant enquête et en remédiant aux plaintes de traitement inéquitable ou de mauvaise gestion.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15136</code>
+            <name>
+                <narrative>Immigration</narrative>
+                <narrative xml:lang="fr">Immigration</narrative>
+            </name>
+            <description>
+                <narrative>Immigration affairs and services, including alien registration, issuing work and travel documents to immigrants.</narrative>
+                <narrative xml:lang="fr">Administration des affaires et services d'immigration, y compris l'enregistrement des étrangers et la délivrance de documents de travail et de voyage aux immigrants.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15137</code>
+            <name>
+                <narrative>Prisons</narrative>
+                <narrative xml:lang="fr">Prisons</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>15140</code>
+            <name>
+                <narrative>Government administration</narrative>
+            </name>
+            <description>
+                <narrative>Systems of government including parliament, local government, decentralisation; civil service and civil service reform. Including general services by government (or commissioned by government) not elsewhere specified e.g. police, fire protection; cartography, meteorology, legal metrology, aerial surveys and remote sensing; administrative buildings.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15142</code>
+            <name>
+                <narrative>Macroeconomic policy</narrative>
+                <narrative xml:lang="fr">Politique macroéconomique</narrative>
+            </name>
+            <description>
+                <narrative>Macroeconomic policy development and implementation.</narrative>
+                <narrative xml:lang="fr">Développement et mise en œuvre de la politique macroéconomique.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15143</code>
+            <name>
+                <narrative>Meteorological services</narrative>
+                <narrative xml:lang="fr">Services météorologiques</narrative>
+            </name>
+            <description>
+                <narrative>Operation or support of institutions dealing with weather forecasting.</narrative>
+                <narrative xml:lang="fr">Administration ou fonctionnement des institutions s'occupant de météorologie.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15144</code>
+            <name>
+                <narrative>National standards development</narrative>
+                <narrative xml:lang="fr">Élaboration des normes nationales</narrative>
+            </name>
+            <description>
+                <narrative>Operation or support of institutions dealing with national standards development. (Use code 16062 for statistical capacity-building.)</narrative>
+                <narrative xml:lang="fr">Administration ou fonctionnement des institutions s'occupant des normes nationales. (Utiliser le code 16062 pour le renforcement des capacités statistiques)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15150</code>
+            <name>
+                <narrative>Democratic participation and civil society</narrative>
+                <narrative xml:lang="fr">Participation démocratique et société civile</narrative>
+            </name>
+            <description>
+                <narrative>Support to the exercise of democracy and diverse forms of participation of citizens beyond elections (15151); direct democracy instruments such as referenda and citizens’ initiatives; support to organisations to represent and advocate for their members, to monitor, engage and hold governments to account, and to help citizens learn to act in the public sphere; curricula and teaching for civic education at various levels. (This purpose code is restricted to activities targeting governance issues. When assistance to civil society is for non-governance purposes use other appropriate purpose codes.)</narrative>
+                <narrative xml:lang="fr">Soutien à l’exercice de la démocratie et à diverses formes de participation des citoyens, excepté les élections (15151) ; instruments de démocratie directe comme les référendums et les initiatives de citoyens ; soutien aux organisations pour représenter et défendre leurs membres, assurer un suivi, participer et demander des comptes aux gouvernements, et pour aider les citoyens à apprendre à agir dans la sphère publique ; programmes d’études et enseignement de l’éducation civique à différents niveaux. (Ce code-objet est limité aux activités ciblées sur des questions de gouvernance. Lorsque l’aide à la société civile ne concerne pas la gouvernance, utiliser d’autres codes-objet appropriés.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15151</code>
+            <name>
+                <narrative>Elections</narrative>
+                <narrative xml:lang="fr">Élections</narrative>
+            </name>
+            <description>
+                <narrative>Electoral management bodies and processes, election observation, voters' education. (Use code 15230 when in the context of an international peacekeeping operation).</narrative>
+                <narrative xml:lang="fr">Organes et processus de gestion électorale, observation des processus électoraux, éducation civique des électeurs. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d’une opération internationale de maintien de la paix.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15152</code>
+            <name>
+                <narrative>Legislatures and political parties</narrative>
+                <narrative xml:lang="fr">Assemblées législatives et partis politiques</narrative>
+            </name>
+            <description>
+                <narrative>Assistance to strengthen key functions of legislatures/ parliaments including subnational assemblies and councils (representation; oversight; legislation), such as improving the capacity of legislative bodies, improving legislatures’ committees and administrative procedures,; research and information management systems; providing training programmes for legislators and support personnel. Assistance to political parties and strengthening of party systems.</narrative>
+                <narrative xml:lang="fr">Aide au renforcement des fonctions clés des assemblées législatives/parlements, y compris des assemblées et conseils infranationaux (représentation ; surveillance ; législation), par exemple amélioration des capacités des organes législatifs, amélioration du fonctionnement des commissions et des procédures administratives des assemblées législatives ; systèmes de gestion de la recherche et de l’information ; mise en place de programmes de formation à l’intention des législateurs et du personnel de soutien. Aide aux partis politiques et renforcement des systèmes de partis.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15153</code>
+            <name>
+                <narrative>Media and free flow of information</narrative>
+                <narrative xml:lang="fr">Médias et liberté de l’information</narrative>
+            </name>
+            <description>
+                <narrative>Activities that support free and uncensored flow of information on public issues; activities that increase the editorial and technical skills and the integrity of the print and broadcast media, e.g. training of journalists. (Use codes 22010-22040 for provision of equipment and capital assistance to media.)</narrative>
+                <narrative xml:lang="fr">Activités qui favorisent une diffusion libre et non censurée de l’information sur les questions publiques ; activités visant à améliorer les compétences rédactionnelles et techniques, et l’intégrité des médias – presse écrite, radio et télévision – par exemple, formation des journalistes. (Utiliser les codes 22010-22040 pour la fourniture d’équipements et d’une aide financière aux médias.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15154</code>
+            <name>
+                <narrative>Executive office</narrative>
+                <narrative xml:lang="fr">Exécutif</narrative>
+            </name>
+            <description>
+                <narrative>Administration, operation or support of executive office. Includes office of the chief executive at all levels of government (monarch, governor-general, president, prime minister, governor, mayor, etc.).</narrative>
+                <narrative xml:lang="fr">Administration, fonctionnement des organes exécutifs, y compris le cabinet du chef de l'exécutif à tous les niveaux de gouvernement (monarque, gouverneur général, président, premier ministre, gouverneur, maire, etc.).</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15155</code>
+            <name>
+                <narrative>Tax policy and administration support</narrative>
+                <narrative xml:lang="fr">Politique et administration fiscales</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15156</code>
+            <name>
+                <narrative>Other non-tax revenue mobilisation</narrative>
+                <narrative xml:lang="fr">Mobilisation des ressources intérieures autre que les recettes non-fiscales</narrative>
+            </name>
+            <description>
+                <narrative>Non-tax public revenue, which includes line ministries, revenue authorities or other local, regional or national public bodies.</narrative>
+                <narrative xml:lang="fr">Recettes non-fiscales incluant les ministères de tutelle, les autorités fiscales ou autres institutions publiques locales, régionales ou nationales.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15160</code>
+            <name>
+                <narrative>Human rights</narrative>
+                <narrative xml:lang="fr">Droits de la personne</narrative>
+            </name>
+            <description>
+                <narrative>Measures to support specialised official human rights institutions and mechanisms at universal, regional, national and local levels in their statutory roles to promote and protect civil and political, economic, social and cultural rights as defined in international conventions and covenants; translation of international human rights commitments into national legislation; reporting and follow-up; human rights dialogue. Human rights defenders and human rights NGOs; human rights advocacy, activism, mobilisation; awareness raising and public human rights education. Human rights programming targeting specific groups, e.g. children, persons with disabilities, migrants, ethnic, religious, linguistic and sexual minorities, indigenous people and those suffering from caste discrimination, victims of trafficking, victims of torture. (Use code 15230 when in the context of a peacekeeping operation and code 15180 for ending violence against women and girls.)</narrative>
+                <narrative xml:lang="fr">Mesures visant à soutenir les institutions et mécanismes spécialisés dans les droits de la personne opérant aux niveaux mondial, régional, national ou local, dans leur mission officielle de promotion et de protection des droits civils et politiques, économiques, sociaux et culturels tels qu’ils sont définis dans les conventions et pactes internationaux ; transposition dans la législation nationale des engagements internationaux concernant les droits de la personne ; notification et suivi ; dialogue sur les droits de la personne. Défenseurs des droits de la personne et ONG œuvrant dans ce domaine ; promotion des droits de la personne, défense active, mobilisation ; activités de sensibilisation et éducation des citoyens aux droits de la personne. Élaboration de programmes concernant les droits de la personne, ciblés sur des groupes particuliers, comme les enfants, les individus en situation de handicap, les migrants, les minorités ethniques, religieuses, linguistiques et sexuelles, les populations autochtones et celles qui sont victimes de discrimination de caste, les victimes de la traite d’êtres humains, les victimes de la torture. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d’une opération internationale de maintien de la paix et code 15180 pour les activités visant l’élimination de la violence à l’égard des femmes et des filles.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>15161</code>
+            <name>
+                <narrative>Elections</narrative>
+            </name>
+            <description>
+                <narrative>Electoral assistance and monitoring, voters' education [other than in connection with UN peace building (15230)].</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>15162</code>
+            <name>
+                <narrative>Human rights</narrative>
+            </name>
+            <description>
+                <narrative>Monitoring of human rights performance; support for national and regional human rights bodies; protection of ethnic, religious and cultural minorities [other than in connection with un peace building (15230)].</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>15163</code>
+            <name>
+                <narrative>Free flow of information</narrative>
+            </name>
+            <description>
+                <narrative>Uncensored flow of information on public issues, including activities that increase the professionalism, skills and integrity of the print and broadcast media (e.g. training of journalists).</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>15164</code>
+            <name>
+                <narrative>Women's equality organisations and institutions</narrative>
+            </name>
+            <description>
+                <narrative>Support for institutions and organisations (governmental and non-governmental) working for gender equality and women's empowerment.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15170</code>
+            <name>
+                <narrative>Women’s equality organisations and institutions</narrative>
+                <narrative xml:lang="fr">Organisations et institutions pour la lutte contre la corruption</narrative>
+            </name>
+            <description>
+                <narrative>Support for institutions and organisations (governmental and non-governmental) working for gender equality and women’s empowerment.</narrative>
+                <narrative xml:lang="fr">Soutien aux institutions et organisations (gouvernementales et non gouvernementales) qui œuvrent pour l’égalité homme-femme et l’autonomisation des femmes.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15180</code>
+            <name>
+                <narrative>Ending violence against women and girls</narrative>
+                <narrative xml:lang="fr">Élimination de la violence à l’égard des femmes et des filles</narrative>
+            </name>
+            <description>
+                <narrative>Support to programmes designed to prevent and eliminate all forms of violence against women and girls/gender-based violence. This encompasses a broad range of forms of physical, sexual and psychological violence including but not limited to: intimate partner violence (domestic violence); sexual violence; female genital mutilation/cutting (FGM/C); child, early and forced marriage; acid throwing; honour killings; and trafficking of women and girls. Prevention activities may include efforts to empower women and girls; change attitudes, norms and behaviour; adopt and enact legal reforms; and strengthen implementation of laws and policies on ending violence against women and girls, including through strengthening institutional capacity. Interventions to respond to violence against women and girls/gender-based violence may include expanding access to services including legal assistance, psychosocial counselling and health care; training personnel to respond more effectively to the needs of survivors; and ensuring investigation, prosecution and punishment of perpetrators of violence.</narrative>
+                <narrative xml:lang="fr">Soutien à des programmes visant à prévenir et éliminer toutes les formes de violence à l’égard des femmes et des filles/violence basée sur le genre. Cette définition recouvre des formes diverses de violence physique, sexuelle et psychologique et s'entend comme englobant, sans y être limitée : la violence infligée par un partenaire intime (violence domestique) ; la violence sexuelle ; les mutilations génitales féminines/excision (MGF/E); les mariages d’enfants, précoces et forcés ; les attaques à l’acide ; les crimes d’honneur ; et la traite des femmes et des filles. Les activités de prévention peuvent notamment inclure les efforts visant soutenir l’autonomisation des femmes et des filles ; le changement des attitudes, normes et comportements ; l’adoption et la mise en oeuvre de réformes légales ; et le renforcement de l’application des lois et des politiques visant à mettre fin à la violence à l’égard des femmes et des filles, y compris à travers le renforcement des capacités institutionnelles. Les interventions visant à répondre à la violence à l’égard des femmes et des filles/violence basée sur le genre peuvent notamment inclure l’élargissement de l’accès aux services y compris à l’assistance juridique, l’accompagnement psychologique et les soins médicaux ; la formation du personnel en vue de répondre plus efficacement aux besoins des survivantes ; et les actions visant à garantir l’ouverture d’enquêtes, la poursuite en justice et la condamnation des auteurs de violence.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15185</code>
+            <name>
+                <narrative>Local government administration</narrative>
+                <narrative xml:lang="fr">Administration publique locale</narrative>
+            </name>
+            <description>
+                <narrative>Decentralisation processes (including political, administrative and fiscal dimensions); intergovernmental relations and federalism; strengthening local authorities.</narrative>
+                <narrative xml:lang="fr">Processus de décentralisation (y compris aspects politiques, administratifs et budgétaires) ; relations intergouvernementales et fédéralisme ; renforcement des autorités locales.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15210</code>
+            <name>
+                <narrative>Security system management and reform</narrative>
+                <narrative xml:lang="fr">Gestion et réforme des systèmes de sécurité</narrative>
+            </name>
+            <description>
+                <narrative>Technical co-operation provided to parliament, government ministries, law enforcement agencies and the judiciary to assist review and reform of the security system to improve democratic governance and civilian control; technical co-operation provided to government to improve civilian oversight and democratic control of budgeting, management, accountability and auditing of security expenditure, including military budgets, as part of a public expenditure management programme; assistance to civil society to enhance its competence and capacity to scrutinise the security system so that it is managed in accordance with democratic norms and principles of accountability, transparency and good governance. [Other than in the context of an international peacekeeping operation (15230).]</narrative>
+                <narrative xml:lang="fr">Coopération technique en faveur des parlements, des ministères publics, des services chargés de faire respecter la loi et des instances judiciaires pour aider à examiner et à réformer les systèmes de sécurité afin d’améliorer la gouvernance démocratique et le contrôle par les civils ; coopération technique en faveur des gouvernements à l’appui du renforcement de la supervision civile et du contrôle démocratique sur la budgétisation, la gestion, la transparence et l’audit des dépenses de sécurité, y compris les dépenses militaires, dans le cadre d’un programme d’amélioration de la gestion des dépenses publiques ; assistance apportée à la société civile en vue de renforcer ses compétences en matière de sécurité et sa capacité de veiller à ce que le système de sécurité soit géré conformément aux normes démocratiques et aux principes de responsabilité, de transparence et de bonne gouvernance. [Autre que dans le cadre d’une opération internationale de maintien de la paix (15230)].</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15220</code>
+            <name>
+                <narrative>Civilian peace-building, conflict prevention and resolution</narrative>
+                <narrative xml:lang="fr">Dispositifs civils de construction de la paix, et de prévention et de règlement des conflits</narrative>
+            </name>
+            <description>
+                <narrative>Support for civilian activities related to peace building, conflict prevention and resolution, including capacity building, monitoring, dialogue and information exchange. Bilateral participation in international civilian peace missions such as those conducted by the UN Department of Political Affairs (UNDPA) or the European Union (European Security and Defence Policy), and contributions to civilian peace funds or commissions (e.g. Peacebuilding Commission, Peacebuilding thematic window of the MDG achievement fund etc.). The contributions can take the form of financing or provision of equipment or civilian or military personnel (e.g. for training civilians). (Use code 15230 for bilateral participation in international peacekeeping operations).</narrative>
+                <narrative xml:lang="fr">Aide à des activités civiles de construction de la paix, et de prévention et de règlement des conflits, y compris renforcement des capacités, suivi, dialogue et échange d’informations. Participation bilatérale à des missions civiles internationales en faveur de la paix comme celles qui sont conduites par le Département des affaires politiques des Nations unies (UNDPA) ou l’Union européenne (Politique européenne de sécurité et de défense), et contributions à des fonds ou commissions civils pour la paix (par exemple, Commission de consolidation de la paix, guichet thématique « Construction de la paix » du Fonds pour la réalisation des OMD, etc.). Les contributions peuvent être apportées sous la forme d’un financement ou à travers la fourniture de matériel ou de personnel civil ou militaire (par exemple, pour la formation des civils). (Utiliser le code 15230 pour la participation bilatérale à des opérations internationales de maintien de la paix.)</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15230</code>
+            <name>
+                <narrative>Participation in international peacekeeping operations</narrative>
+                <narrative xml:lang="fr">Participation à des opérations internationales de maintien de la paix</narrative>
+            </name>
+            <description>
+                <narrative>Bilateral participation in peacekeeping operations mandated or authorised by the United Nations (UN) through Security Council resolutions, and conducted by international organisations, e.g. UN, NATO, the European Union (Security and Defence Policy security-related operations), or regional groupings of developing countries. Direct contributions to the UN Department for Peacekeeping Operations (UNDPKO) budget are excluded from bilateral ODA (they are reportable in part as multilateral ODA, see Annex 9). The activities that can be reported as bilateral ODA under this code are limited to: human rights and election monitoring; reintegration of demobilised soldiers; rehabilitation of basic national infrastructure; monitoring or retraining of civil administrators and police forces; security sector reform and other rule of law-related activities; training in customs and border control procedures; advice or training in fiscal or macroeconomic stabilisation policy; repatriation and demobilisation of armed factions, and disposal of their weapons; explosive mine removal. The enforcement aspects of international peacekeeping operations are not reportable as ODA. ODA-eligible bilateral participation in peacekeeping operations can take the form of financing or provision of equipment or military or civilian personnel (e.g. police officers). The reportable cost is calculated as the excess over what the personnel and equipment would have cost to maintain had they not been assigned to take part in a peace operation. Costs for military contingents participating in UNDPKO peacekeeping operations are not reportable as ODA. International peacekeeping operations may include humanitarian-type activities (contributions to the form of equipment or personnel), as described in codes 7xxxx. These should be included under code 15230 if they are an integrated part of the activities above, otherwise they should be reported as humanitarian aid.NB: When using this code, indicate the name of the operation in the short description of the activity reported.</narrative>
+                <narrative xml:lang="fr">Participation bilatérale à des opérations de maintien de la paix mandatées ou autorisées par les Nations unies (NU) à travers des résolutions du Conseil de sécurité, et conduites par des organisations internationales, par exemple les Nations unies, l’OTAN, l’Union européenne (opérations liées à la sécurité dans le cadre de la Politique européenne de sécurité et de défense) ou des groupements régionaux de pays en développement. Les contributions directes au budget du Département des opérations de maintien de la paix des NU (UNDPKO) ne sont pas à notifier comme opérations bilatérales (elles comptent en partie comme APD multilatérale, voir l’annexe 9). Les activités qui peuvent être notifiées au titre de l’APD bilatérale sous ce code sont uniquement les suivantes : droits de l’homme et supervision des élections ; réinsertion des soldats démobilisés ; remise en état des infrastructures de base du pays ; supervision ou recyclage des administrateurs civils et des forces de police ; réforme des systèmes de sécurité et autres activités liées à l’État de droit ; formation aux procédures douanières et de contrôle aux frontières ; conseil ou formation concernant les politiques budgétaires ou macroéconomiques de stabilisation ; rapatriement et démobilisation des factions armées et destruction de leurs armes ; déminage. Les activités d’imposition de la paix entreprises dans le cadre des opérations internationales de maintien de la paix ne sont comptabilisables dans l’APD. Les contributions bilatérales comptabilisables dans l’APD au titre des opérations de maintien de la paix peuvent être apportées sous la forme d’un financement ou à travers la fourniture de matériel ou de personnel militaire ou civil (par exemple, fonctionnaires de police). Le coût à notifier est donné par le surcoût encouru pour l’entretien du personnel et du matériel du fait qu’ils ont pris part à une opération de maintien de la paix. Les coûts relatifs aux contingents militaires participant à des opérations de maintien de la paix de l’UNDPKO ne sont pas comptabilisables en APD. Les opérations internationales de maintien de la paix peuvent comprendre des activités de type humanitaire (contributions apportées sous la forme de matériel ou de personnel), comme celles qui sont décrites sous les codes 7xxxx. Elles doivent être incluses sous le code 15230 si elles font partie intégrante des activités ci-dessus, sinon elles doivent être notifiées sous l’aide humanitaire. NB : Lors de l’utilisation de ce code, indiquer le nom de l’opération dans la description succincte de l’activité notifiée.</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15240</code>
+            <name>
+                <narrative>Reintegration and SALW control</narrative>
+                <narrative xml:lang="fr">Réintégration et contrôle des armes légères et de petit calibre</narrative>
+            </name>
+            <description>
+                <narrative>Reintegration of demobilised military personnel into the economy; conversion of production facilities from military to civilian outputs; technical co-operation to control, prevent and/or reduce the proliferation of small arms and light weapons (SALW) – see para. 80 of the Directives for definition of SALW activities covered. [Other than in the context of an international peacekeeping operation (15230) or child soldiers (15261)].</narrative>
+                <narrative xml:lang="fr">Réinsertion du personnel militaire démobilisé dans la vie économique et civile ; conversion des usines d’armes en usines de produits à usage civil ; coopération technique destinée à contrôler, prévenir et/ou réduire la prolifération d’armes légères et de petit calibre – voir le paragraphe 80 des Directives pour la définition des activités couvertes. [Autre que dans le cadre d’une opération internationale de maintien de la paix (15230) ou enfants soldats (15261)].</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15250</code>
+            <name>
+                <narrative>Removal of land mines and explosive remnants of war</narrative>
+                <narrative xml:lang="fr">Enlèvement des mines terrestres et restes explosifs de guerre</narrative>
+            </name>
+            <description>
+                <narrative>All activities related to land mines and explosive remnants of war which have benefits to developing countries as their main objective, including removal of land mines and explosive remnants of war, and stockpile destruction for developmental purposes [other than in the context of an international peacekeeping operation (15230)]; risk education and awareness raising; rehabilitation, reintegration and assistance to victims, and research and development on demining and clearance. Only activities for civilian purposes are ODA-eligible.</narrative>
+                <narrative xml:lang="fr">Toutes les activités liées aux mines terrestres et aux restes explosifs de guerre dont le but essentiel est de bénéficier aux pays en développement, y compris l’enlèvement des mines terrestres et des restes explosifs de guerre et la destruction des stocks à des fins de développement [autre qu’en rapport compris l’enlèvement des mines terrestres et des restes explosifs de guerre et la destruction des stocks à des fins de développement [autre qu’en rapport avec la participation à des opérations internationales de maintien de la paix (15230)] ; sensibilisation au risque ; réhabilitation, réinsertion et assistance aux victimes, et les activités de recherche et développement sur le déminage. Seules les activités menées à fins civiles sont éligibles à l’APD.</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item>
+            <code>15261</code>
+            <name>
+                <narrative>Child soldiers (Prevention and demobilisation)</narrative>
+                <narrative xml:lang="fr">Enfants soldats (Prévention et démobilisation)</narrative>
+            </name>
+            <description>
+                <narrative>Technical co-operation provided to government – and assistance to civil society organisations – to support and apply legislation designed to prevent the recruitment of child soldiers, and to demobilise, disarm, reintegrate, repatriate and resettle (DDR) child soldiers.</narrative>
+                <narrative xml:lang="fr">Coopération technique en faveur des gouvernements – et assistance aux organisations de la société civile – à l’appui de l’adoption et de l’application de lois destinées à empêcher le recrutement d’enfants en tant que soldats ; appui à la démobilisation, au désarmement, à la réinsertion, au rapatriement et à la réintégration (DDR) des enfants soldats.</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16010</code>
+            <name>
+                <narrative>Social/ welfare services</narrative>
+                <narrative xml:lang="fr">Services sociaux</narrative>
+            </name>
+            <description>
+                <narrative>Social legislation and administration; institution capacity building and advice; social security and other social schemes; special programmes for the elderly, orphans, the disabled, street children; social dimensions of structural adjustment; unspecified social infrastructure and services, including consumer protection.</narrative>
+                <narrative xml:lang="fr">Législation et administration sociales ; renforcement des capacités institutionnelles et conseils ; sécurité sociale et autres plans sociaux ; programmes spécifiques pour les personnes âgées, orphelins, handicapés, enfants abandonnés ; dimensions sociales de l’ajustement structurel ; infrastructure et services sociaux non spécifiés, y compris la protection des consommateurs.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16011</code>
+            <name>
+                <narrative>Social protection and welfare services policy, planning and administration</narrative>
+                <narrative xml:lang="fr">Politiques, planification et administration des services de protection sociale</narrative>
+            </name>
+            <description>
+                <narrative>Administration of overall social protection policies, plans, programmes and budgets including legislation, standards and statistics on social protection.</narrative>
+                <narrative xml:lang="fr">Administration des politiques, plans, programmes et budgets généraux de protection sociale y compris les lois, normes et statistiques sur la protection sociale.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16012</code>
+            <name>
+                <narrative>Social security (excl pensions)</narrative>
+                <narrative xml:lang="fr">Protection sociale (excluant retraites)</narrative>
+            </name>
+            <description>
+                <narrative>Social protection shemes in the form of cash or in-kind benefits to people unable to work due to sickness or injury.</narrative>
+                <narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces ou en nature aux personnes inaptes au travail pour cause de maladie ou par suite d'un accident.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16013</code>
+            <name>
+                <narrative>General pensions</narrative>
+                <narrative xml:lang="fr">Retraites</narrative>
+            </name>
+            <description>
+                <narrative>Social protection schemes in the form of cash or in-kind benefits, including pensions, against the risks linked to old age.</narrative>
+                <narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces et en nature contre les risques liés à la vieillesse.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16014</code>
+            <name>
+                <narrative>Civil service pensions</narrative>
+                <narrative xml:lang="fr">Régimes de retraite des fonctionnaires</narrative>
+            </name>
+            <description>
+                <narrative>Pension schemes for government personnel.</narrative>
+                <narrative xml:lang="fr">Les régimes de pension des fonctionnaires.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16015</code>
+            <name>
+                <narrative>Social services (incl youth development and women+ children)</narrative>
+                <narrative xml:lang="fr">Services sociaux (y compris jeunes, femmes et enfants)</narrative>
+            </name>
+            <description>
+                <narrative>Social protection schemes in the form of cash or in-kind benefits to households with dependent children, including parental leave benefits.</narrative>
+                <narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces et en nature aux ménages ayant des enfants à charge, y compris les prestations de congé parental.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16020</code>
+            <name>
+                <narrative>Employment policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de l’emploi et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Employment policy and planning; labour law; labour unions; institution capacity building and advice; support programmes for unemployed; employment creation and income generation programmes; occupational safety and health; combating child labour.</narrative>
+                <narrative xml:lang="fr">Politique et planification de l’emploi ; législation ; syndicats ; renforcement des capacités institutionnelles et conseils ; programmes de l’aide aux chômeurs ; programmes de création d’emplois et de génération de revenus ; sécurité et santé dans le travail ; lutte contre le travail des enfants.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16030</code>
+            <name>
+                <narrative>Housing policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique du logement et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Housing sector policy, planning and programmes; excluding low-cost housing and slum clearance (16040).</narrative>
+                <narrative xml:lang="fr">Politique du logement, planification et programmes ; à l’exclusion du logement à coût réduit (16040).</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16040</code>
+            <name>
+                <narrative>Low-cost housing</narrative>
+                <narrative xml:lang="fr">Logement à coût réduit</narrative>
+            </name>
+            <description>
+                <narrative>Including slum clearance.</narrative>
+                <narrative xml:lang="fr">Y compris la suppression des bidonvilles.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16050</code>
+            <name>
+                <narrative>Multisector aid for basic social services</narrative>
+                <narrative xml:lang="fr">Aide plurisectorielle pour les services sociaux de base</narrative>
+            </name>
+            <description>
+                <narrative>Basic social services are defined to include basic education, basic health, basic nutrition, population/reproductive health and basic drinking water supply and basic sanitation.</narrative>
+                <narrative xml:lang="fr">Les services sociaux de base incluent l’éducation de base, la santé de base, les activités en matière de population/santé et fertilité ainsi que les systèmes de distribution d’eau potable de base et assainissement de base.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16061</code>
+            <name>
+                <narrative>Culture and recreation</narrative>
+                <narrative xml:lang="fr">Culture et loisirs</narrative>
+            </name>
+            <description>
+                <narrative>Including libraries and museums.</narrative>
+                <narrative xml:lang="fr">Y compris bibliothèques et musées.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16062</code>
+            <name>
+                <narrative>Statistical capacity building</narrative>
+                <narrative xml:lang="fr">Renforcement des capacités statistiques</narrative>
+            </name>
+            <description>
+                <narrative>Both in national statistical offices and any other government ministries.</narrative>
+                <narrative xml:lang="fr">Dans les offices statistiques nationaux et les autres ministères concernés.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16063</code>
+            <name>
+                <narrative>Narcotics control</narrative>
+                <narrative xml:lang="fr">Lutte contre le trafic de drogues</narrative>
+            </name>
+            <description>
+                <narrative>In-country and customs controls including training of the police; educational programmes and awareness campaigns to restrict narcotics traffic and in-country distribution.</narrative>
+                <narrative xml:lang="fr">Contrôles intérieurs et contrôles douaniers y compris la formation de la police, programmes d’éducation et de sensibilisation pour limiter le trafic de drogues et la distribution domestique.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16064</code>
+            <name>
+                <narrative>Social mitigation of HIV/AIDS</narrative>
+                <narrative xml:lang="fr">Atténuation de l’impact social du VIH/sida</narrative>
+            </name>
+            <description>
+                <narrative>Special programmes to address the consequences of HIV/AIDS, e.g. social, legal and economic assistance to people living with HIV/AIDS including food security and employment; support to vulnerable groups and children orphaned by HIV/AIDS; human rights of HIV/AIDS affected people.</narrative>
+                <narrative xml:lang="fr">Programmes spéciaux visant les conséquences sociales du VIH/sida, par exemple assistance sociale, juridique et économique aux personnes vivant avec le VIH/sida y compris sécurité alimentaire et emploi ; soutien aux groupes vulnérables et aux enfants orphelins du sida ; droits de l’homme pour les personnes atteintes par le VIH/sida.</narrative>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16065</code>
+            <name>
+                <narrative>Recreation and sport</narrative>
+                <narrative xml:lang="fr">Récréation et sport</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>16066</code>
+            <name>
+                <narrative>Culture</narrative>
+                <narrative xml:lang="fr">Culture</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>160</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21010</code>
+            <name>
+                <narrative>Transport policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique des transports et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Transport sector policy, planning and programmes; aid to transport ministries; institution capacity building and advice; unspecified transport; activities that combine road, rail, water and/or air transport. Whenever possible, report transport of goods under the sector of the good being transported.</narrative>
+                <narrative xml:lang="fr">Politique des transports, planification et programmes ; aide aux ministères du transport ; renforcement des capacités institutionnelles et conseils ; transports non spécifiés ; activités qui recouvrent le transport routier, le transport ferroviaire, le transport par voies d’eau et/ou le transport aérien. Autant que possible, notifier le transport de marchandises sous le secteur économique de la marchandise transportée.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21011</code>
+            <name>
+                <narrative>Transport policy, planning and administration</narrative>
+                <narrative xml:lang="fr">Politiques, planification et administration des transports</narrative>
+            </name>
+            <description>
+                <narrative>Administration of affairs and services concerning transport systems.</narrative>
+                <narrative xml:lang="fr">Administration et fonctionnement des services reliés aux politiques de transport.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21012</code>
+            <name>
+                <narrative>Public transport services</narrative>
+                <narrative xml:lang="fr">Transports en commun</narrative>
+            </name>
+            <description>
+                <narrative>Administration of affairs and services concerning public transport.</narrative>
+                <narrative xml:lang="fr">Administration des affaires et services concernant les transports en commun.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21013</code>
+            <name>
+                <narrative>Transport regulation</narrative>
+                <narrative xml:lang="fr">Réglementation des transports</narrative>
+            </name>
+            <description>
+                <narrative>Supervision and regulation of users, operations, construction and maintenance of transport systems (registration, licensing, inspection of equipment, operator skills and training; safety standards, franchises, tarriffs, levels of service, etc.).</narrative>
+                <narrative xml:lang="fr">Contrôle et réglementation des utilisateurs de systèmes de transport (immatriculation, permis, inspection du matériel, compétences et formation des agents, normes de sûreté, licences, tarifs, niveau des services, etc.).</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21020</code>
+            <name>
+                <narrative>Road transport</narrative>
+                <narrative xml:lang="fr">Transport routier</narrative>
+            </name>
+            <description>
+                <narrative>Road infrastructure, road vehicles; passenger road transport, motor passenger cars.</narrative>
+                <narrative xml:lang="fr">Infrastructure routière, véhicules ; transport routier de voyageurs, voitures particulières.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21021</code>
+            <name>
+                <narrative>Feeder road construction</narrative>
+                <narrative xml:lang="fr">Construction des voies de desserte</narrative>
+            </name>
+            <description>
+                <narrative>Construction or operation of feeder road transport systems and facilities.</narrative>
+                <narrative xml:lang="fr">Construction ou exploitation des voies de desserte et systèmes afférents.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21022</code>
+            <name>
+                <narrative>Feeder road maintenance</narrative>
+                <narrative xml:lang="fr">Entretien des voies de desserte</narrative>
+            </name>
+            <description>
+                <narrative>Maintenance of feeder road transport systems and facilities.</narrative>
+                <narrative xml:lang="fr">Entretien des voies de desserte et systèmes afférents.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21023</code>
+            <name>
+                <narrative>National road construction</narrative>
+                <narrative xml:lang="fr">Construction des routes nationales</narrative>
+            </name>
+            <description>
+                <narrative>Construction or operation of national road transport systems and facilities.</narrative>
+                <narrative xml:lang="fr">Construction ou exploitation des routes nationales et systèmes afférents.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21024</code>
+            <name>
+                <narrative>National road maintenance</narrative>
+                <narrative xml:lang="fr">Entretien des routes nationales</narrative>
+            </name>
+            <description>
+                <narrative>Maintenance of national road transport systems and facilities.</narrative>
+                <narrative xml:lang="fr">Entretien des routes nationales et systèmes afférents.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21030</code>
+            <name>
+                <narrative>Rail transport</narrative>
+                <narrative xml:lang="fr">Transport ferroviaire</narrative>
+            </name>
+            <description>
+                <narrative>Rail infrastructure, rail equipment, locomotives, other rolling stock; including light rail (tram) and underground systems.</narrative>
+                <narrative xml:lang="fr">Infrastructure ferroviaire, matériel ferroviaire, locomotives, autre matériel roulant ; y compris les tramways et les métropolitains.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21040</code>
+            <name>
+                <narrative>Water transport</narrative>
+                <narrative xml:lang="fr">Transport par voies d’eau</narrative>
+            </name>
+            <description>
+                <narrative>Harbours and docks, harbour guidance systems, ships and boats; river and other inland water transport, inland barges and vessels.</narrative>
+                <narrative xml:lang="fr">Ports et docks, systèmes de guidage, navires et bateaux ; transport sur voies navigables intérieures, bateaux de voies d’eau intérieures.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21050</code>
+            <name>
+                <narrative>Air transport</narrative>
+                <narrative xml:lang="fr">Transport aérien</narrative>
+            </name>
+            <description>
+                <narrative>Airports, airport guidance systems, aeroplanes, aeroplane maintenance equipment.</narrative>
+                <narrative xml:lang="fr">Aéroports, systèmes de guidage, avions, équipement d’entretien des avions.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21061</code>
+            <name>
+                <narrative>Storage</narrative>
+                <narrative xml:lang="fr">Stockage</narrative>
+            </name>
+            <description>
+                <narrative>Whether or not related to transportation. Whenever possible, report storage projects under the sector of the resource being stored.</narrative>
+                <narrative xml:lang="fr">Associé ou non au transport. Autant que possible, notifier les projets de stockage sous le secteur économique de la ressource stockée.</narrative>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>21081</code>
+            <name>
+                <narrative>Education and training in transport and storage</narrative>
+                <narrative xml:lang="fr">Éducation/formation dans les transports et le stockage</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>210</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22010</code>
+            <name>
+                <narrative>Communications policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique des communications et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Communications sector policy, planning and programmes; institution capacity building and advice; including postal services development; unspecified communications activities.</narrative>
+                <narrative xml:lang="fr">Politique des communications, planification et programmes ; renforcement des capacités institutionnelles et conseils ; y compris développement des services postaux ; activités de communications non spécifiées.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22011</code>
+            <name>
+                <narrative>Communications policy, planning and administration</narrative>
+                <narrative xml:lang="fr">Politiques, planification et administration des communications</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22012</code>
+            <name>
+                <narrative>Postal services</narrative>
+                <narrative xml:lang="fr">Services postaux</narrative>
+            </name>
+            <description>
+                <narrative>Development and operation of postal services.</narrative>
+                <narrative xml:lang="fr">Développement et fonctionnement des services postaux.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22013</code>
+            <name>
+                <narrative>Information services</narrative>
+                <narrative xml:lang="fr">Services d'information</narrative>
+            </name>
+            <description>
+                <narrative>Provision of information services.</narrative>
+                <narrative xml:lang="fr">Prestation de services d'information.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22020</code>
+            <name>
+                <narrative>Telecommunications</narrative>
+                <narrative xml:lang="fr">Télécommunications</narrative>
+            </name>
+            <description>
+                <narrative>Telephone networks, telecommunication satellites, earth stations.</narrative>
+                <narrative xml:lang="fr">Réseaux de téléphones, satellites, stations terrestres.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22030</code>
+            <name>
+                <narrative>Radio/television/print media</narrative>
+                <narrative xml:lang="fr">Radio, télévision, presse écrite</narrative>
+            </name>
+            <description>
+                <narrative>Radio and TV links, equipment; newspapers; printing and publishing.</narrative>
+                <narrative xml:lang="fr">Liaisons et équipement ; journaux ; imprimerie et édition.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item>
+            <code>22040</code>
+            <name>
+                <narrative>Information and communication technology (ICT)</narrative>
+                <narrative xml:lang="fr">Technologies de l’information et de la communication (TIC)</narrative>
+            </name>
+            <description>
+                <narrative>Computer hardware and software; internet access; IT training. When sector cannot be specified.</narrative>
+                <narrative xml:lang="fr">Matériel informatique et logiciels ; accès Internet ; formations aux TI. Lorsque le secteur ne peut pas être spécifié.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23010</code>
+            <name>
+                <narrative>Energy policy and administrative management</narrative>
+            </name>
+            <description>
+                <narrative>Energy sector policy, planning and programmes; aid to energy ministries; institution capacity building and advice; unspecified energy activities including energy conservation.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23020</code>
+            <name>
+                <narrative>Power generation/non-renewable sources</narrative>
+            </name>
+            <description>
+                <narrative>Thermal power plants including when heat source cannot be determined; combined gas-coal power plants.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23030</code>
+            <name>
+                <narrative>Power generation/renewable sources</narrative>
+            </name>
+            <description>
+                <narrative>Including policy, planning, development programmes, surveys and incentives. Fuelwood/ charcoal production should be included under forestry (31261).</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23040</code>
+            <name>
+                <narrative>Electrical transmission/ distribution</narrative>
+            </name>
+            <description>
+                <narrative>Distribution from power source to end user; transmission lines.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23050</code>
+            <name>
+                <narrative>Gas distribution</narrative>
+            </name>
+            <description>
+                <narrative>Delivery for use by ultimate consumer.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23061</code>
+            <name>
+                <narrative>Oil-fired power plants</narrative>
+            </name>
+            <description>
+                <narrative>Including diesel power plants.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23062</code>
+            <name>
+                <narrative>Gas-fired power plants</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23063</code>
+            <name>
+                <narrative>Coal-fired power plants</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23064</code>
+            <name>
+                <narrative>Nuclear power plants</narrative>
+            </name>
+            <description>
+                <narrative>Including nuclear safety.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23065</code>
+            <name>
+                <narrative>Hydro-electric power plants</narrative>
+            </name>
+            <description>
+                <narrative>Including power-generating river barges.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23066</code>
+            <name>
+                <narrative>Geothermal energy</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23067</code>
+            <name>
+                <narrative>Solar energy</narrative>
+            </name>
+            <description>
+                <narrative>Including photo-voltaic cells, solar thermal applications and solar heating.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23068</code>
+            <name>
+                <narrative>Wind power</narrative>
+            </name>
+            <description>
+                <narrative>Wind energy for water lifting and electric power generation.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23069</code>
+            <name>
+                <narrative>Ocean power</narrative>
+            </name>
+            <description>
+                <narrative>Including ocean thermal energy conversion, tidal and wave power.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23070</code>
+            <name>
+                <narrative>Biomass</narrative>
+            </name>
+            <description>
+                <narrative>Densification technologies and use of biomass for direct power generation including biogas, gas obtained from sugar cane and other plant residues, anaerobic digesters.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23081</code>
+            <name>
+                <narrative>Energy education/training</narrative>
+            </name>
+            <description>
+                <narrative>Applies to all energy sub-sectors; all levels of training.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>23082</code>
+            <name>
+                <narrative>Energy research</narrative>
+            </name>
+            <description>
+                <narrative>Including general inventories, surveys.</narrative>
+            </description>
+            <category>230</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23110</code>
+            <name>
+                <narrative>Energy policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique énergétique et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Energy sector policy, planning; aid to energy ministries; institution capacity building and advice; unspecified energy activities.</narrative>
+                <narrative xml:lang="fr">Politique et planification du secteur de l’énergie ; aide aux ministères de l’énergie ; conseils et renforcement des capacités institutionnelles ; activités non précisées.</narrative>
+            </description>
+            <category>231</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23111</code>
+            <name>
+                <narrative>Energy sector policy, planning and administration</narrative>
+                <narrative xml:lang="fr">Politiques, planification et administration du secteur de l'énergie</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>231</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23112</code>
+            <name>
+                <narrative>Energy regulation</narrative>
+                <narrative xml:lang="fr">Réglementation de l'énergie</narrative>
+            </name>
+            <description>
+                <narrative>Regulation of the energy sector, including wholesale and retail electricity provision.</narrative>
+                <narrative xml:lang="fr">Réglementation du secteur de l'énergie, y compris l'approvisionnement d'électricité en gros et au détail.</narrative>
+            </description>
+            <category>231</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23181</code>
+            <name>
+                <narrative>Energy education/training</narrative>
+                <narrative xml:lang="fr">Éducation et formation dans le domaine de l’énergie</narrative>
+            </name>
+            <description>
+                <narrative>All levels of training not included elsewhere.</narrative>
+                <narrative xml:lang="fr">Tous les niveaux de formation ne figurant pas sous un autre code.</narrative>
+            </description>
+            <category>231</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23182</code>
+            <name>
+                <narrative>Energy research</narrative>
+                <narrative xml:lang="fr">Recherche dans le domaine de l’énergie</narrative>
+            </name>
+            <description>
+                <narrative>Including general inventories, surveys.</narrative>
+                <narrative xml:lang="fr">Y compris inventaires et études.</narrative>
+            </description>
+            <category>231</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23183</code>
+            <name>
+                <narrative>Energy conservation and demand-side efficiency</narrative>
+                <narrative xml:lang="fr">Économies d’énergie et efficacité du côté de la demande</narrative>
+            </name>
+            <description>
+                <narrative>All projects in support of energy demand reduction, e.g. building and industry upgrades, smart grids, metering and tariffs. Also includes efficient cook-stoves and biogas projects.</narrative>
+                <narrative xml:lang="fr">Tous les projets visant la réduction de la demande d’énergie, par exemple : modernisation des bâtiments et des industries, réseaux intelligents, compteurs et tarifs. Comprend également les cuisinières efficaces et les projets de biogaz.</narrative>
+            </description>
+            <category>231</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23210</code>
+            <name>
+                <narrative>Energy generation, renewable sources – multiple technologies</narrative>
+                <narrative xml:lang="fr">Production d’énergie, sources renouvelables - multiples technologies</narrative>
+            </name>
+            <description>
+                <narrative>Renewable energy generation programmes that cannot be attributed to one single technology (codes 23220 through 23280 below). Fuelwood/charcoal production should be included under forestry 31261.</narrative>
+                <narrative xml:lang="fr">Programmes de production d’énergie d’origine renouvelable qui ne peuvent être attribués à une seule technologie (codes 23220 à 23280 ci-après). La production de bois de chauffage/charbon de bois devrait figurer sous la rubrique sylviculture 31261.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23220</code>
+            <name>
+                <narrative>Hydro-electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales hydrauliques</narrative>
+            </name>
+            <description>
+                <narrative>Including energy generating river barges.</narrative>
+                <narrative xml:lang="fr">Dont centrales flottantes.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23230</code>
+            <name>
+                <narrative>Solar energy</narrative>
+                <narrative xml:lang="fr">Énergie solaire</narrative>
+            </name>
+            <description>
+                <narrative>Including photo-voltaic cells, solar thermal applications and solar heating.</narrative>
+                <narrative xml:lang="fr">Solaire photovoltaïque, thermodynamique, chauffage solaire.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23240</code>
+            <name>
+                <narrative>Wind energy</narrative>
+                <narrative xml:lang="fr">Énergie éolienne</narrative>
+            </name>
+            <description>
+                <narrative>Wind energy for water lifting and electric power generation.</narrative>
+                <narrative xml:lang="fr">Éoliennes de pompage et production d’électricité.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23250</code>
+            <name>
+                <narrative>Marine energy</narrative>
+                <narrative xml:lang="fr">Énergie marine</narrative>
+            </name>
+            <description>
+                <narrative>Including ocean thermal energy conversion, tidal and wave power.</narrative>
+                <narrative xml:lang="fr">Énergie thermique des mers, énergie marémotrice et houlomotrice.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23260</code>
+            <name>
+                <narrative>Geothermal energy</narrative>
+                <narrative xml:lang="fr">Énergie géothermique</narrative>
+            </name>
+            <description>
+                <narrative>Use of geothermal energy for generating electric power or directly as heat for agriculture, etc.</narrative>
+                <narrative xml:lang="fr">Application de l’énergie géothermique pour produire de l’électricité ou production de chaleur à usage agricole, etc.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23270</code>
+            <name>
+                <narrative>Biofuel-fired power plants</narrative>
+                <narrative xml:lang="fr">Centrales à biocombustibles</narrative>
+            </name>
+            <description>
+                <narrative>Use of solids and liquids produced from biomass for direct power generation. Also includes biogases from anaerobic fermentation (e.g. landfill gas, sewage sludge gas, fermentation of energy crops and manure) and thermal processes (also known as syngas); waste-fired power plants making use of biodegradable municipal waste (household waste and waste from companies and public services that resembles household waste, collected at installations specifically designed for their disposal with recovery of combustible liquids, gases or heat). See code 23360 for non- renewable waste-fired power plants.</narrative>
+                <narrative xml:lang="fr">Utilisation de matières solides et liquides issues de la biomasse pour la production directe d’électricité. Comprend également les biogaz produits par fermentation anaérobie (ex. : gaz de décharge, gaz issus des boues d’épuration, fermentation de végétaux des cultures énergétiques et de déjections animales) et par traitements thermiques (également connus sous l’appellation de gaz de synthèse) ; centrales brûlant des déchets municipaux biodégradables (déchets ménagers et déchets du tertiaire assimilables à des déchets ménagers, collectés dans des installations spécifiquement conçues pour leur élimination et leur récupération sous forme de liquides ou de gaz combustibles ou de chaleur). Voir code 23360 pour la production d’électricité, déchets non renouvelables.</narrative>
+            </description>
+            <category>232</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23310</code>
+            <name>
+                <narrative>Energy generation, non-renewable sources – unspecified</narrative>
+                <narrative xml:lang="fr">Production d’énergie, sources non renouvelables - non spécifié</narrative>
+            </name>
+            <description>
+                <narrative>Thermal power plants including when energy source cannot be determined; combined gas-coal power plants.</narrative>
+                <narrative xml:lang="fr">Centrales thermiques dont la source d’énergie est indéterminée ; centrales mixtes gaz-charbon.</narrative>
+            </description>
+            <category>233</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23320</code>
+            <name>
+                <narrative>Coal-fired electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales au charbon</narrative>
+            </name>
+            <description>
+                <narrative>Thermal electric power plants that use coal as the energy source.</narrative>
+                <narrative xml:lang="fr">Centrales thermiques brûlant du charbon.</narrative>
+            </description>
+            <category>233</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23330</code>
+            <name>
+                <narrative>Oil-fired electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales au fioul</narrative>
+            </name>
+            <description>
+                <narrative>Thermal electric power plants that use fuel oil or diesel fuel as the energy source.</narrative>
+                <narrative xml:lang="fr">Centrales thermiques brûlant du fioul ou du gazole.</narrative>
+            </description>
+            <category>233</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23340</code>
+            <name>
+                <narrative>Natural gas-fired electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales au gaz naturel</narrative>
+            </name>
+            <description>
+                <narrative>Electric power plants that are fuelled by natural gas.</narrative>
+                <narrative xml:lang="fr">Centrales thermiques brûlant du gaz naturel.</narrative>
+            </description>
+            <category>233</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23350</code>
+            <name>
+                <narrative>Fossil fuel electric power plants with carbon capture and storage (CCS)</narrative>
+                <narrative xml:lang="fr">Centrales thermiques classiques avec captage et stockage du carbone (CSC)</narrative>
+            </name>
+            <description>
+                <narrative>Fossil fuel electric power plants employing technologies to capture carbon dioxide emissions. CCS not related to power plants should be included under 41020. CCS activities are not reportable as ODA.</narrative>
+                <narrative xml:lang="fr">Centrales thermiques classiques exploitant une technologie de captage et de stockage des émissions de carbone (CSC). Les techniques de CSC non associées à la production d’électricité devraient figurer sous la rubrique 41020. Les activités de CSC ne sont pas éligibles à l’APD.</narrative>
+            </description>
+            <category>233</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23360</code>
+            <name>
+                <narrative>Non-renewable waste-fired electric power plants</narrative>
+                <narrative xml:lang="fr">Production d’électricité, déchets non renouvelables</narrative>
+            </name>
+            <description>
+                <narrative>Electric power plants that use non-biodegradable industrial and municipal waste as the energy source.</narrative>
+                <narrative xml:lang="fr">Centrales brûlant des déchets industriels et municipaux non biodégradables.</narrative>
+            </description>
+            <category>233</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23410</code>
+            <name>
+                <narrative>Hybrid energy electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales hybrides</narrative>
+            </name>
+            <description>
+                <narrative>Electric power plants that make use of both non-renewable and renewable energy sources.</narrative>
+                <narrative xml:lang="fr">Centrales fonctionnant avec des énergies renouvelables et non renouvelables.</narrative>
+            </description>
+            <category>234</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23510</code>
+            <name>
+                <narrative>Nuclear energy electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales nucléaires</narrative>
+            </name>
+            <description>
+                <narrative>Including nuclear safety.</narrative>
+                <narrative xml:lang="fr">Dont sûreté nucléaire.</narrative>
+            </description>
+            <category>235</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23610</code>
+            <name>
+                <narrative>Heat plants</narrative>
+                <narrative xml:lang="fr">Production de chaleur seule</narrative>
+            </name>
+            <description>
+                <narrative>Power plants which are designed to produce heat only.</narrative>
+                <narrative xml:lang="fr">Installations produisant uniquement de la chaleur.</narrative>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23620</code>
+            <name>
+                <narrative>District heating and cooling</narrative>
+                <narrative xml:lang="fr">Réseaux urbains de chaleur et de froid</narrative>
+            </name>
+            <description>
+                <narrative>Distribution of heat generated in a centralised location, or delivery of chilled water, for residential and commercial heating or cooling purposes.</narrative>
+                <narrative xml:lang="fr">Distribution de chaleur produite dans une chaufferie unique, ou d’eau froide, à des fins de climatisation des locaux dans les secteurs résidentiel et tertiaire.</narrative>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23630</code>
+            <name>
+                <narrative>Electric power transmission and distribution</narrative>
+                <narrative xml:lang="fr">Transport et distribution d’électricité</narrative>
+            </name>
+            <description>
+                <narrative>Grid distribution from power source to end user; transmission lines. Also includes storage of energy to generate power (e.g. pumped hydro, batteries) and the extension of grid access, often to rural areas.</narrative>
+                <narrative xml:lang="fr">Distribution d’électricité par le réseau, de la source au consommateur final ; lignes de transport. Inclut également le stockage de l’énergie à des fins de production d’électricité (ex. : station de pompage, batteries) et l’extension de l’accès au réseau, souvent dans des zones rurales.</narrative>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item>
+            <code>23640</code>
+            <name>
+                <narrative>Gas distribution</narrative>
+                <narrative xml:lang="fr">Distribution du gaz</narrative>
+            </name>
+            <description>
+                <narrative>Delivery for use by ultimate consumer.</narrative>
+                <narrative xml:lang="fr">Acheminement du gaz jusqu’au consommateur final.</narrative>
+            </description>
+            <category>236</category>
+        </codelist-item>
+        <codelist-item>
+            <code>24010</code>
+            <name>
+                <narrative>Financial policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique des finances et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Finance sector policy, planning and programmes; institution capacity building and advice; financial markets and systems.</narrative>
+                <narrative xml:lang="fr">Politique des finances, planification et programmes ; renforcement des capacités institutionnelles et conseils ; marchés et systèmes financiers.</narrative>
+            </description>
+            <category>240</category>
+        </codelist-item>
+        <codelist-item>
+            <code>24020</code>
+            <name>
+                <narrative>Monetary institutions</narrative>
+                <narrative xml:lang="fr">Institutions monétaires</narrative>
+            </name>
+            <description>
+                <narrative>Central banks.</narrative>
+                <narrative xml:lang="fr">Banques centrales.</narrative>
+            </description>
+            <category>240</category>
+        </codelist-item>
+        <codelist-item>
+            <code>24030</code>
+            <name>
+                <narrative>Formal sector financial intermediaries</narrative>
+                <narrative xml:lang="fr">Intermédiaires financiers officiels</narrative>
+            </name>
+            <description>
+                <narrative>All formal sector financial intermediaries; credit lines; insurance, leasing, venture capital, etc. (except when focused on only one sector).</narrative>
+                <narrative xml:lang="fr">Tous les intermédiaires financiers dans le secteur formel ; lignes de crédit ; assurance, crédit-bail, capital- risque, etc. (sauf ceux spécialisés dans un seul secteur).</narrative>
+            </description>
+            <category>240</category>
+        </codelist-item>
+        <codelist-item>
+            <code>24040</code>
+            <name>
+                <narrative>Informal/semi-formal financial intermediaries</narrative>
+                <narrative xml:lang="fr">Intermédiaires financiers du secteur informel et semi formel</narrative>
+            </name>
+            <description>
+                <narrative>Micro credit, savings and credit co-operatives etc.</narrative>
+                <narrative xml:lang="fr">Micro crédits, coopératives d’épargne et de crédit, etc.</narrative>
+            </description>
+            <category>240</category>
+        </codelist-item>
+        <codelist-item>
+            <code>24081</code>
+            <name>
+                <narrative>Education/training in banking and financial services</narrative>
+                <narrative xml:lang="fr">Éducation/formation bancaire et dans les services financiers</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>240</category>
+        </codelist-item>
+        <codelist-item>
+            <code>25010</code>
+            <name>
+                <narrative>Business support services and institutions</narrative>
+                <narrative xml:lang="fr">Services et institutions de soutien commerciaux</narrative>
+            </name>
+            <description>
+                <narrative>Support to trade and business associations, chambers of commerce; legal and regulatory reform aimed at improving business and investment climate; private sector institution capacity building and advice; trade information; public-private sector networking including trade fairs; e-commerce. Where sector cannot be specified: general support to private sector enterprises (in particular, use code 32130 for enterprises in the industrial sector).</narrative>
+                <narrative xml:lang="fr">Soutien aux associations de commerce et d’entreprises, chambres de commerce ; réformes juridiques et réglementaires afin d’améliorer les activités liées à l’entreprise ; renforcement des capacités institutionnelles du secteur privé et conseils ; information commerciale ; réseaux de liaison entre les secteurs public et privé y compris les foires commerciales ; commerce électronique. Quand le secteur ne peut pas être spécifié : soutien général aux entreprises du secteur privé. En particulier, pour les entreprises du secteur industriel, c’est le code 32130 qui doit être utilisé.</narrative>
+            </description>
+            <category>250</category>
+        </codelist-item>
+        <codelist-item>
+            <code>25020</code>
+            <name>
+                <narrative>Privatisation</narrative>
+                <narrative xml:lang="fr">Privatisation</narrative>
+            </name>
+            <description>
+                <narrative>When sector cannot be specified. Including general state enterprise restructuring or demonopolisation programmes; planning, programming, advice.</narrative>
+                <narrative xml:lang="fr">Lorsque le secteur ne peut être spécifié. Y compris programmes de restructuration d’entreprises publiques et de démonopolisation ; planification, programmation, conseils.</narrative>
+            </description>
+            <category>250</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31110</code>
+            <name>
+                <narrative>Agricultural policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique agricole et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Agricultural sector policy, planning and programmes; aid to agricultural ministries; institution capacity building and advice; unspecified agriculture.</narrative>
+                <narrative xml:lang="fr">Politique agricole, planification et programmes ; aide aux ministères de l’agriculture ; renforcement des capacités institutionnelles et conseils ; activités d’agriculture non spécifiées.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31120</code>
+            <name>
+                <narrative>Agricultural development</narrative>
+                <narrative xml:lang="fr">Développement agricole</narrative>
+            </name>
+            <description>
+                <narrative>Integrated projects; farm development.</narrative>
+                <narrative xml:lang="fr">Projets intégrés ; développement d’exploitations agricoles.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31130</code>
+            <name>
+                <narrative>Agricultural land resources</narrative>
+                <narrative xml:lang="fr">Ressources en terres cultivables</narrative>
+            </name>
+            <description>
+                <narrative>Including soil degradation control; soil improvement; drainage of water logged areas; soil desalination; agricultural land surveys; land reclamation; erosion control, desertification control.</narrative>
+                <narrative xml:lang="fr">Y compris la lutte contre la dégradation des sols ; amélioration des sols ; drainage des zones inondées ; dessalage des sols ; études des terrains agricoles ; remise en état des sols ; lutte contre l’érosion, lutte contre la désertification.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31140</code>
+            <name>
+                <narrative>Agricultural water resources</narrative>
+                <narrative xml:lang="fr">Ressources en eau à usage agricole</narrative>
+            </name>
+            <description>
+                <narrative>Irrigation, reservoirs, hydraulic structures, ground water exploitation for agricultural use.</narrative>
+                <narrative xml:lang="fr">Irrigation, réservoirs, structures hydrauliques, exploitation de nappes phréatiques.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31150</code>
+            <name>
+                <narrative>Agricultural inputs</narrative>
+                <narrative xml:lang="fr">Produits à usage agricole</narrative>
+            </name>
+            <description>
+                <narrative>Supply of seeds, fertilizers, agricultural machinery/equipment.</narrative>
+                <narrative xml:lang="fr">Approvisionnement en semences, engrais, matériel et outillage agricoles.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31161</code>
+            <name>
+                <narrative>Food crop production</narrative>
+                <narrative xml:lang="fr">Production agricole</narrative>
+            </name>
+            <description>
+                <narrative>Including grains (wheat, rice, barley, maize, rye, oats, millet, sorghum); horticulture; vegetables; fruit and berries; other annual and perennial crops. [Use code 32161 for agro-industries.]</narrative>
+                <narrative xml:lang="fr">Y compris céréales (froment, riz, orge, maïs, seigle, avoine, millet, sorgho) ; horticulture ; légumes ; fruits et baies ; autres cultures annuelles et pluriannuelles. [Utiliser le code 32161 pour les agro-industries.]</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31162</code>
+            <name>
+                <narrative>Industrial crops/export crops</narrative>
+                <narrative xml:lang="fr">Production industrielle de récoltes/récoltes destinées à l’exportation</narrative>
+            </name>
+            <description>
+                <narrative>Including sugar; coffee, cocoa, tea; oil seeds, nuts, kernels; fibre crops; tobacco; rubber. [Use code 32161 for agro-industries.]</narrative>
+                <narrative xml:lang="fr">Y compris sucre ; café, cacao, thé ; oléagineux, graines, noix, amandes ; fibres ; tabac ; caoutchouc. [Utiliser le code 32161 pour les agro-industries.]</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31163</code>
+            <name>
+                <narrative>Livestock</narrative>
+                <narrative xml:lang="fr">Bétail</narrative>
+            </name>
+            <description>
+                <narrative>Animal husbandry; animal feed aid.</narrative>
+                <narrative xml:lang="fr">Toutes formes d’élevage ; aliments pour animaux.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31164</code>
+            <name>
+                <narrative>Agrarian reform</narrative>
+                <narrative xml:lang="fr">Réforme agraire</narrative>
+            </name>
+            <description>
+                <narrative>Including agricultural sector adjustment.</narrative>
+                <narrative xml:lang="fr">Y compris ajustement structurel dans le secteur agricole.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31165</code>
+            <name>
+                <narrative>Agricultural alternative development</narrative>
+                <narrative xml:lang="fr">Développement agricole alternatif</narrative>
+            </name>
+            <description>
+                <narrative>Projects to reduce illicit drug cultivation through other agricultural marketing and production opportunities (see code 43050 for non-agricultural alternative development).</narrative>
+                <narrative xml:lang="fr">Projets afin de réduire les cultures illicites (drogue) à travers d’autres opportunités de marketing et production agricoles (voir code 43050 pour développement alternatif non agricole).</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31166</code>
+            <name>
+                <narrative>Agricultural extension</narrative>
+                <narrative xml:lang="fr">Vulgarisation agricole</narrative>
+            </name>
+            <description>
+                <narrative>Non-formal training in agriculture.</narrative>
+                <narrative xml:lang="fr">Formation agricole non formelle.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31181</code>
+            <name>
+                <narrative>Agricultural education/training</narrative>
+                <narrative xml:lang="fr">Éducation et formation dans le domaine agricole</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31182</code>
+            <name>
+                <narrative>Agricultural research</narrative>
+                <narrative xml:lang="fr">Recherche agronomique</narrative>
+            </name>
+            <description>
+                <narrative>Plant breeding, physiology, genetic resources, ecology, taxonomy, disease control, agricultural bio-technology; including livestock research (animal health, breeding and genetics, nutrition, physiology).</narrative>
+                <narrative xml:lang="fr">Étude des espèces végétales, physiologie, ressources génétiques, écologie, taxonomie, lutte contre les maladies, biotechnologie agricole ; y compris recherche vétérinaire (dans les domaines génétiques et sanitaires, nutrition, physiologie).</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31191</code>
+            <name>
+                <narrative>Agricultural services</narrative>
+                <narrative xml:lang="fr">Services agricoles</narrative>
+            </name>
+            <description>
+                <narrative>Marketing policies &amp; organisation; storage and transportation, creation of strategic reserves.</narrative>
+                <narrative xml:lang="fr">Organisation et politiques des marchés ; transport et stockage ; établissements de réserves stratégiques.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31192</code>
+            <name>
+                <narrative>Plant and post-harvest protection and pest control</narrative>
+                <narrative xml:lang="fr">Protection des plantes et des récoltes, lutte antiacridienne</narrative>
+            </name>
+            <description>
+                <narrative>Including integrated plant protection, biological plant protection activities, supply and management of agrochemicals, supply of pesticides, plant protection policy and legislation.</narrative>
+                <narrative xml:lang="fr">Y compris la protection intégrée des plantes, les activités de protection biologique des plantes, la fourniture et la gestion de substances agrochimiques, l’approvisionnement en pesticides ; politique et législation de la protection des plantes.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31193</code>
+            <name>
+                <narrative>Agricultural financial services</narrative>
+                <narrative xml:lang="fr">Services financiers agricoles</narrative>
+            </name>
+            <description>
+                <narrative>Financial intermediaries for the agricultural sector including credit schemes; crop insurance.</narrative>
+                <narrative xml:lang="fr">Intermédiaires financiers du secteur agricole, y compris les plans de crédit ; assurance récoltes.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31194</code>
+            <name>
+                <narrative>Agricultural co-operatives</narrative>
+                <narrative xml:lang="fr">Coopératives agricoles</narrative>
+            </name>
+            <description>
+                <narrative>Including farmers’ organisations.</narrative>
+                <narrative xml:lang="fr">Y compris les organisations d’agriculteurs.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31195</code>
+            <name>
+                <narrative>Livestock/veterinary services</narrative>
+                <narrative xml:lang="fr">Services vétérinaires (bétail)</narrative>
+            </name>
+            <description>
+                <narrative>Animal health and management, genetic resources, feed resources.</narrative>
+                <narrative xml:lang="fr">Santé des animaux, ressources génétiques et nutritives.</narrative>
+            </description>
+            <category>311</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31210</code>
+            <name>
+                <narrative>Forestry policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de la sylviculture et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Forestry sector policy, planning and programmes; institution capacity building and advice; forest surveys; unspecified forestry and agro-forestry activities.</narrative>
+                <narrative xml:lang="fr">Politique de la sylviculture, planification et programmes ; renforcement des capacités institutionnelles et conseils ; études des forêts ; activités sylvicoles et agricoles liées à la sylviculture non spécifiées.</narrative>
+            </description>
+            <category>312</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31220</code>
+            <name>
+                <narrative>Forestry development</narrative>
+                <narrative xml:lang="fr">Développement sylvicole</narrative>
+            </name>
+            <description>
+                <narrative>Afforestation for industrial and rural consumption; exploitation and utilisation; erosion control, desertification control; integrated forestry projects.</narrative>
+                <narrative xml:lang="fr">Boisement pour consommation rurale et industrielle ; exploitation et utilisation ; lutte contre l’érosion, lutte contre la désertification ; projets intégrés.</narrative>
+            </description>
+            <category>312</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31261</code>
+            <name>
+                <narrative>Fuelwood/charcoal</narrative>
+                <narrative xml:lang="fr">Reboisement (bois de chauffage et charbon de bois)</narrative>
+            </name>
+            <description>
+                <narrative>Forestry development whose primary purpose is production of fuelwood and charcoal.</narrative>
+                <narrative xml:lang="fr">Développement sylvicole visant à la production de bois de chauffage et de charbon de bois.</narrative>
+            </description>
+            <category>312</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31281</code>
+            <name>
+                <narrative>Forestry education/training</narrative>
+                <narrative xml:lang="fr">Éducation et formation en sylviculture</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>312</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31282</code>
+            <name>
+                <narrative>Forestry research</narrative>
+                <narrative xml:lang="fr">Recherche en sylviculture</narrative>
+            </name>
+            <description>
+                <narrative>Including artificial regeneration, genetic improvement, production methods, fertilizer, harvesting.</narrative>
+                <narrative xml:lang="fr">Y compris reproduction artificielle et amélioration des espèces, méthodes de production, engrais, coupe et ramassage du bois.</narrative>
+            </description>
+            <category>312</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31291</code>
+            <name>
+                <narrative>Forestry services</narrative>
+                <narrative xml:lang="fr">Services sylvicoles</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>312</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31310</code>
+            <name>
+                <narrative>Fishing policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de la pêche et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Fishing sector policy, planning and programmes; institution capacity building and advice; ocean and coastal fishing; marine and freshwater fish surveys and prospecting; fishing boats/equipment; unspecified fishing activities.</narrative>
+                <narrative xml:lang="fr">Politique de la pêche, planification et programmes ; renforcement des capacités institutionnelles et conseils ; pêche hauturière et côtière ; évaluation, études et prospection du poisson en milieu marin et fluvial ; bateaux et équipements de pêche ; activités de pêche non spécifiées.</narrative>
+            </description>
+            <category>313</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31320</code>
+            <name>
+                <narrative>Fishery development</narrative>
+                <narrative xml:lang="fr">Développement de la pêche</narrative>
+            </name>
+            <description>
+                <narrative>Exploitation and utilisation of fisheries; fish stock protection; aquaculture; integrated fishery projects.</narrative>
+                <narrative xml:lang="fr">Exploitation et utilisation des pêcheries ; sauvegarde des bancs de poisson ; aquaculture ; projets intégrés.</narrative>
+            </description>
+            <category>313</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31381</code>
+            <name>
+                <narrative>Fishery education/training</narrative>
+                <narrative xml:lang="fr">Éducation et formation dans le domaine de la pêche</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>313</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31382</code>
+            <name>
+                <narrative>Fishery research</narrative>
+                <narrative xml:lang="fr">Recherche dans le domaine de la pêche</narrative>
+            </name>
+            <description>
+                <narrative>Pilot fish culture; marine/freshwater biological research.</narrative>
+                <narrative xml:lang="fr">Pisciculture pilote ; recherche biologique aquatique.</narrative>
+            </description>
+            <category>313</category>
+        </codelist-item>
+        <codelist-item>
+            <code>31391</code>
+            <name>
+                <narrative>Fishery services</narrative>
+                <narrative xml:lang="fr">Services dans le domaine de la pêche</narrative>
+            </name>
+            <description>
+                <narrative>Fishing harbours; fish markets; fishery transport and cold storage.</narrative>
+                <narrative xml:lang="fr">Ports de pêche ; vente des produits de la pêche ; transport et entreposage frigorifique du poisson.</narrative>
+            </description>
+            <category>313</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32110</code>
+            <name>
+                <narrative>Industrial policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de l’industrie et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Industrial sector policy, planning and programmes; institution capacity building and advice; unspecified industrial activities; manufacturing of goods not specified below.</narrative>
+                <narrative xml:lang="fr">Politique de l’industrie, planification et programmes ; renforcement des capacités institutionnelles et conseils ; activités industrielles non spécifiées ; industries manufacturières non spécifiées ci-dessous.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32120</code>
+            <name>
+                <narrative>Industrial development</narrative>
+                <narrative xml:lang="fr">Développement industriel</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32130</code>
+            <name>
+                <narrative>Small and medium-sized enterprises (SME) development</narrative>
+                <narrative xml:lang="fr">Développement des Petites et moyennes entreprises (PME)</narrative>
+            </name>
+            <description>
+                <narrative>Direct support to the development of small and medium-sized enterprises in the industrial sector, including accounting, auditing and advisory services.</narrative>
+                <narrative xml:lang="fr">Soutien direct au développement des petites et moyennes entreprises dans le secteur industriel, y compris la comptabilité, l’audit et les services de conseil.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32140</code>
+            <name>
+                <narrative>Cottage industries and handicraft</narrative>
+                <narrative xml:lang="fr">Artisanat</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32161</code>
+            <name>
+                <narrative>Agro-industries</narrative>
+                <narrative xml:lang="fr">Agro-industries</narrative>
+            </name>
+            <description>
+                <narrative>Staple food processing, dairy products, slaughter houses and equipment, meat and fish processing and preserving, oils/fats, sugar refineries, beverages/tobacco, animal feeds production.</narrative>
+                <narrative xml:lang="fr">Industries alimentaires de base, abattoirs et équipements nécessaires, industrie laitière et conserves de viande et de poisson, industries des corps gras, sucreries, production de boissons, tabac, production d’aliments pour animaux.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32162</code>
+            <name>
+                <narrative>Forest industries</narrative>
+                <narrative xml:lang="fr">Industries forestières</narrative>
+            </name>
+            <description>
+                <narrative>Wood production, pulp/paper production.</narrative>
+                <narrative xml:lang="fr">Industrie et travail du bois, production de papier et pâte à papier.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32163</code>
+            <name>
+                <narrative>Textiles, leather and substitutes</narrative>
+                <narrative xml:lang="fr">Industrie textile, cuirs et produits similaires</narrative>
+            </name>
+            <description>
+                <narrative>Including knitting factories.</narrative>
+                <narrative xml:lang="fr">Y compris bonneterie.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32164</code>
+            <name>
+                <narrative>Chemicals</narrative>
+                <narrative xml:lang="fr">Produits chimiques</narrative>
+            </name>
+            <description>
+                <narrative>Industrial and non-industrial production facilities; includes pesticides production.</narrative>
+                <narrative xml:lang="fr">Production industrielle et non industrielle ; y compris fabrication des pesticides.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32165</code>
+            <name>
+                <narrative>Fertilizer plants</narrative>
+                <narrative xml:lang="fr">Production d’engrais chimiques</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32166</code>
+            <name>
+                <narrative>Cement/lime/plaster</narrative>
+                <narrative xml:lang="fr">Ciment, chaux et plâtre</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32167</code>
+            <name>
+                <narrative>Energy manufacturing</narrative>
+                <narrative xml:lang="fr">Fabrication d’énergie</narrative>
+            </name>
+            <description>
+                <narrative>Including gas liquefaction; petroleum refineries.</narrative>
+                <narrative xml:lang="fr">Y compris liquéfaction du gaz ; raffineries de pétrole.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32168</code>
+            <name>
+                <narrative>Pharmaceutical production</narrative>
+                <narrative xml:lang="fr">Produits pharmaceutiques</narrative>
+            </name>
+            <description>
+                <narrative>Medical equipment/supplies; drugs, medicines, vaccines; hygienic products.</narrative>
+                <narrative xml:lang="fr">Matériel médical et fournitures médicales ; médicaments et vaccins ; produits d’hygiène corporelle.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32169</code>
+            <name>
+                <narrative>Basic metal industries</narrative>
+                <narrative xml:lang="fr">Industrie métallurgique de base</narrative>
+            </name>
+            <description>
+                <narrative>Iron and steel, structural metal production.</narrative>
+                <narrative xml:lang="fr">Sidérurgie, éléments de construction métallique.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32170</code>
+            <name>
+                <narrative>Non-ferrous metal industries</narrative>
+                <narrative xml:lang="fr">Industries des métaux non ferreux</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32171</code>
+            <name>
+                <narrative>Engineering</narrative>
+                <narrative xml:lang="fr">Construction mécanique et électrique</narrative>
+            </name>
+            <description>
+                <narrative>Manufacturing of electrical and non-electrical machinery, engines/turbines.</narrative>
+                <narrative xml:lang="fr">Fabrication de machines électriques et non électriques, moteurs et turbines.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32172</code>
+            <name>
+                <narrative>Transport equipment industry</narrative>
+                <narrative xml:lang="fr">Matériel de transport</narrative>
+            </name>
+            <description>
+                <narrative>Shipbuilding, fishing boats building; railroad equipment; motor vehicles and motor passenger cars; aircraft; navigation/guidance systems.</narrative>
+                <narrative xml:lang="fr">Construction de navires, construction de bateaux de pêche ; construction de matériel ferroviaire ; véhicules automobiles et voitures particulières ; construction aéronautique ; systèmes de navigation et de guidage.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32182</code>
+            <name>
+                <narrative>Technological research and development</narrative>
+                <narrative xml:lang="fr">Recherche et développement technologiques</narrative>
+            </name>
+            <description>
+                <narrative>Including industrial standards; quality management; metrology; testing; accreditation; certification.</narrative>
+                <narrative xml:lang="fr">Y compris les standards industriels ; gestion et contrôle de qualité ; métrologie ; accréditation ; certification.</narrative>
+            </description>
+            <category>321</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32210</code>
+            <name>
+                <narrative>Mineral/mining policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de l’industrie extractive et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Mineral and mining sector policy, planning and programmes; mining legislation, mining cadastre, mineral resources inventory, information systems, institution capacity building and advice; unspecified mineral resources exploitation.</narrative>
+                <narrative xml:lang="fr">Politique du secteur des industries extractives, planification et programmes ; législation et cadastre, recensement des richesses minérales, systèmes d’information ; renforcement des capacités institutionnelles et conseils ; exploitation des ressources minérales non spécifiées.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32220</code>
+            <name>
+                <narrative>Mineral prospection and exploration</narrative>
+                <narrative xml:lang="fr">Prospection et exploration des minerais</narrative>
+            </name>
+            <description>
+                <narrative>Geology, geophysics, geochemistry; excluding hydrogeology (14010) and environmental geology (41010), mineral extraction and processing, infrastructure, technology, economics, safety and environment management.</narrative>
+                <narrative xml:lang="fr">Géologie, géophysique et géochimie ; à l’exclusion de hydrogéologie (14010) et géologie de l’environnement (41010), production et extraction minérales, infrastructure, technologie, économie, sécurité et gestion de l’environnement.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32261</code>
+            <name>
+                <narrative>Coal</narrative>
+                <narrative xml:lang="fr">Charbon</narrative>
+            </name>
+            <description>
+                <narrative>Including lignite and peat.</narrative>
+                <narrative xml:lang="fr">Y compris lignite et la tourbe.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32262</code>
+            <name>
+                <narrative>Oil and gas</narrative>
+                <narrative xml:lang="fr">Pétrole et gaz</narrative>
+            </name>
+            <description>
+                <narrative>Petroleum, natural gas, condensates, liquefied petroleum gas (LPG), liquefied natural gas (LNG); including drilling and production, and oil and gas pipelines.</narrative>
+                <narrative xml:lang="fr">Pétrole, gaz naturel, condensés , GPL (Gaz de pétrole liquéfié), GNL (Gaz naturel liquéfié); y compris derricks et plates-formes de forage, et oléoducs et gazoducs.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32263</code>
+            <name>
+                <narrative>Ferrous metals</narrative>
+                <narrative xml:lang="fr">Métaux ferreux</narrative>
+            </name>
+            <description>
+                <narrative>Iron and ferro-alloy metals.</narrative>
+                <narrative xml:lang="fr">Fer et alliages.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32264</code>
+            <name>
+                <narrative>Nonferrous metals</narrative>
+                <narrative xml:lang="fr">Métaux non ferreux</narrative>
+            </name>
+            <description>
+                <narrative>Aluminium, copper, lead, nickel, tin, zinc.</narrative>
+                <narrative xml:lang="fr">Aluminium, cuivre, plomb, nickel, étain et zinc.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32265</code>
+            <name>
+                <narrative>Precious metals/materials</narrative>
+                <narrative xml:lang="fr">Métaux et minerais précieux</narrative>
+            </name>
+            <description>
+                <narrative>Gold, silver, platinum, diamonds, gemstones.</narrative>
+                <narrative xml:lang="fr">Or, argent, platine, diamant et pierres précieuses.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32266</code>
+            <name>
+                <narrative>Industrial minerals</narrative>
+                <narrative xml:lang="fr">Minerais industriels</narrative>
+            </name>
+            <description>
+                <narrative>Baryte, limestone, feldspar, kaolin, sand, gypsym, gravel, ornamental stones.</narrative>
+                <narrative xml:lang="fr">Baryte, chaux, feldspath, kaolin, sable, gypse, gravier, pierres d’ornement.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32267</code>
+            <name>
+                <narrative>Fertilizer minerals</narrative>
+                <narrative xml:lang="fr">Engrais minéraux</narrative>
+            </name>
+            <description>
+                <narrative>Phosphates, potash.</narrative>
+                <narrative xml:lang="fr">Phosphates, potasse.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32268</code>
+            <name>
+                <narrative>Offshore minerals</narrative>
+                <narrative xml:lang="fr">Ressources des fonds marins</narrative>
+            </name>
+            <description>
+                <narrative>Polymetallic nodules, phosphorites, marine placer deposits.</narrative>
+                <narrative xml:lang="fr">Nodules métalliques, phosphorites, sédiments marins.</narrative>
+            </description>
+            <category>322</category>
+        </codelist-item>
+        <codelist-item>
+            <code>32310</code>
+            <name>
+                <narrative>Construction policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de la construction et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Construction sector policy and planning; excluding construction activities within specific sectors (e.g., hospital or school construction).</narrative>
+                <narrative xml:lang="fr">Politique du secteur de la construction, planification ; ne comprend pas les activités de construction identifiables par secteur (par exemple, construction d’hôpitaux ou de bâtiments scolaires).</narrative>
+            </description>
+            <category>323</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33110</code>
+            <name>
+                <narrative>Trade policy and administrative Management</narrative>
+                <narrative xml:lang="fr">Politique commerciale et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Trade policy and planning; support to ministries and departments responsible for trade policy; trade-related legislation and regulatory reforms; policy analysis and implementation of multilateral trade agreements e.g. technical barriers to trade and sanitary and phytosanitary measures (TBT/SPS) except at regional level (see 33130); mainstreaming trade in national development strategies (e.g. poverty reduction strategy papers); wholesale/retail trade; unspecified trade and trade promotion activities.</narrative>
+                <narrative xml:lang="fr">Politique commerciale et planification ; soutien aux ministères et départements responsables de la politique commerciale ; législation et réformes réglementaires dans le domaine du commerce ; analyse politique et mise en œuvre des accords commerciaux multilatéraux ex. sur les obstacles techniques au commerce et les mesures sanitaires et phytosanitaires sauf au niveau régional (voir 33130) ; intégration du commerce dans les stratégies nationales de développement (ex cadres stratégiques de la lutte contre la pauvreté) ; commerce de gros et de détail ; activités non spécifiées dans le domaine du commerce et de la promotion du commerce.</narrative>
+            </description>
+            <category>331</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33120</code>
+            <name>
+                <narrative>Trade facilitation</narrative>
+                <narrative xml:lang="fr">Facilitation du commerce</narrative>
+            </name>
+            <description>
+                <narrative>Simplification and harmonisation of international import and export procedures (e.g. customs valuation, licensing procedures, transport formalities, payments, insurance); support to customs departments and other border agencies, including in particular implementation of the provisions of the WTO Trade Facilitation Agreement; tariff reforms.</narrative>
+                <narrative xml:lang="fr">Simplification et harmonisation des procédures internationales d’importation et d’exportation (ex. évaluations de douane, procédures de licences, formalités de transport, paiements, assurances) ; soutien aux départements douaniers et autres agences frontalières y compris et en particulier la mise en oeuvre des dispositions de l'Accord sur la facilitation des échanges de l'OMC ; réformes tarifaires.</narrative>
+            </description>
+            <category>331</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33130</code>
+            <name>
+                <narrative>Regional trade agreements (RTAs)</narrative>
+                <narrative xml:lang="fr">Accords commerciaux régionaux</narrative>
+            </name>
+            <description>
+                <narrative>Support to regional trade arrangements [e.g. Southern African Development Community (SADC), Association of Southeast Asian Nations (ASEAN), Free Trade Area of the Americas (FTAA), African Caribbean Pacific/European Union (ACP/EU)], including work on technical barriers to trade and sanitary and phytosanitary measures (TBT/SPS) at regional level; elaboration of rules of origin and introduction of special and differential treatment in RTAs.</narrative>
+                <narrative xml:lang="fr">Soutien aux accords commerciaux régionaux [ex. Southern African Development Community (SADC), Association of Southeast Asian Nations (ASEAN), Zone de libre-échange des Amériques (ZLEA), Pays d’Afrique, des Caraïbes et du Pacifique/Union européenne (ACP/UE)] ; y compris le travail sur les obstacles techniques au commerce et les mesures sanitaires et phytosanitaires au niveau régional ; élaboration de règles d’origine et introduction de traitement spécial et différencié dans les accords commerciaux régionaux.</narrative>
+            </description>
+            <category>331</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33140</code>
+            <name>
+                <narrative>Multilateral trade negotiations</narrative>
+                <narrative xml:lang="fr">Négociations commerciales multilatérales</narrative>
+            </name>
+            <description>
+                <narrative>Support developing countries’ effective participation in multilateral trade negotiations, including training of negotiators, assessing impacts of negotiations; accession to the World Trade Organisation (WTO) and other multilateral trade-related organisations.</narrative>
+                <narrative xml:lang="fr">Soutien à la participation effective des pays en développement aux négociations commerciales multilatérales, y compris la formation de négociateurs, l’évaluation de l’impact des négociations ; accession à l’Organisation Mondiale du Commerce (OMC) et aux autres organisations multilatérales liées au commerce.</narrative>
+            </description>
+            <category>331</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33150</code>
+            <name>
+                <narrative>Trade-related adjustment</narrative>
+                <narrative xml:lang="fr">Ajustement lié au commerce</narrative>
+            </name>
+            <description>
+                <narrative>Contributions to the government budget to assist the implementation of recipients’ own trade reforms and adjustments to trade policy measures by other countries; assistance to manage shortfalls in the balance of payments due to changes in the world trading environment.</narrative>
+                <narrative xml:lang="fr">Contributions au budget du gouvernement non réservées afin de soutenir la mise en œuvre des propres réformes commerciales du bénéficiaire et de ses ajustements aux politiques commerciales des autres pays ; assistance à la gestion des déficits de la balance des paiements dus au changement de l’environnement mondial du commerce.</narrative>
+            </description>
+            <category>331</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33181</code>
+            <name>
+                <narrative>Trade education/training</narrative>
+                <narrative xml:lang="fr">Éducation/formation dans le domaine du commerce</narrative>
+            </name>
+            <description>
+                <narrative>Human resources development in trade not included under any of the above codes. Includes university programmes in trade.</narrative>
+                <narrative xml:lang="fr">Développement des ressources humaines dans le domaine du commerce non compris dans les codes ci-dessous. Comprend les programmes universitaires dans le domaine du commerce.</narrative>
+            </description>
+            <category>331</category>
+        </codelist-item>
+        <codelist-item>
+            <code>33210</code>
+            <name>
+                <narrative>Tourism policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique du tourisme et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>332</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41010</code>
+            <name>
+                <narrative>Environmental policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de l’environnement et gestion administrative</narrative>
+            </name>
+            <description>
+                <narrative>Environmental policy, laws, regulations and economic instruments; administrational institutions and practices; environmental and land use planning and decision-making procedures; seminars, meetings; miscellaneous conservation and protection measures not specified below.</narrative>
+                <narrative xml:lang="fr">Politique de l’environnement, lois et réglementations environnementales ; institutions et pratiques administratives ; planification de l’environnement et de l’utilisation des terres, procédures de décisions ; séminaires, réunions ; actions de préservation et de protection non spécifiées ci-dessous.</narrative>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41020</code>
+            <name>
+                <narrative>Biosphere protection</narrative>
+                <narrative xml:lang="fr">Protection de la biosphère</narrative>
+            </name>
+            <description>
+                <narrative>Air pollution control, ozone layer preservation; marine pollution control.</narrative>
+                <narrative xml:lang="fr">Lutte contre la pollution de l’air, protection de la couche d’ozone ; lutte contre la pollution marine.</narrative>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41030</code>
+            <name>
+                <narrative>Bio-diversity</narrative>
+                <narrative xml:lang="fr">Diversité biologique</narrative>
+            </name>
+            <description>
+                <narrative>Including natural reserves and actions in the surrounding areas; other measures to protect endangered or vulnerable species and their habitats (e.g. wetlands preservation).</narrative>
+                <narrative xml:lang="fr">Y compris réserves naturelles et actions dans les régions environnantes ; autres mesures visant à protéger les espèces menacées dans leur habitat naturel (par exemple la protection des marécages).</narrative>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41040</code>
+            <name>
+                <narrative>Site preservation</narrative>
+                <narrative xml:lang="fr">Protection des sites</narrative>
+            </name>
+            <description>
+                <narrative>Applies to unique cultural landscape; including sites/objects of historical, archeological, aesthetic, scientific or educational value.</narrative>
+                <narrative xml:lang="fr">Se rapporte à un paysage culturel exceptionnel ; y compris des sites et des objets d’une valeur historique, archéologique, esthétique, scientifique ou éducative.</narrative>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41050</code>
+            <name>
+                <narrative>Flood prevention/control</narrative>
+                <narrative xml:lang="fr">Prévention et lutte contre les inondations</narrative>
+            </name>
+            <description>
+                <narrative>Floods from rivers or the sea; including sea water intrusion control and sea level rise related activities.</narrative>
+                <narrative xml:lang="fr">Inondations de la mer et des rivières ; y compris la lutte contre l’avancée et la montée du niveau de l’eau de la mer.</narrative>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41081</code>
+            <name>
+                <narrative>Environmental education/ training</narrative>
+                <narrative xml:lang="fr">Éducation et formation environnementales</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>41082</code>
+            <name>
+                <narrative>Environmental research</narrative>
+                <narrative xml:lang="fr">Recherche environnementale</narrative>
+            </name>
+            <description>
+                <narrative>Including establishment of databases, inventories/accounts of physical and natural resources; environmental profiles and impact studies if not sector specific.</narrative>
+                <narrative xml:lang="fr">Y compris établissement de bases de données, inventaires et estimations des ressources naturelles et physiques ; profils environnementaux et études d’impact lorsque le secteur ne peut être déterminé.</narrative>
+            </description>
+            <category>410</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43010</code>
+            <name>
+                <narrative>Multisector aid</narrative>
+                <narrative xml:lang="fr">Aide plurisectorielle</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43030</code>
+            <name>
+                <narrative>Urban development and management</narrative>
+                <narrative xml:lang="fr">Développement et gestion urbaine</narrative>
+            </name>
+            <description>
+                <narrative>Integrated urban development projects; local development and urban management; urban infrastructure and services; municipal finances; urban environmental management; urban development and planning; urban renewal and urban housing; land information systems.</narrative>
+                <narrative xml:lang="fr">Projets intégrés de développement urbain ; développement local et gestion urbaine ; infrastructure et services urbains ; gestion municipale ; gestion de l’environnement urbain ; planification ; rénovation urbaine, habitat ; informations sur l’occupation des sols.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43031</code>
+            <name>
+                <narrative>Urban land policy and management</narrative>
+                <narrative xml:lang="fr">Politique et gestion du territoire urbain</narrative>
+            </name>
+            <description>
+                <narrative>Urban development and planning; urban management, land information systems.</narrative>
+                <narrative xml:lang="fr">Planification et gestion du territoire urbain; gestion urbaine, systèmes d'information.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43032</code>
+            <name>
+                <narrative>Urban development</narrative>
+                <narrative xml:lang="fr">Développement urbain</narrative>
+            </name>
+            <description>
+                <narrative>Integrated urban development projects; local development; urban infrastructure and services; municipal finances; urban environment systems; urban renewal and urban housing.</narrative>
+                <narrative xml:lang="fr">Projets intégrés de développement urbain; développement local; infrastructure et services urbains; finances municipales; gestion environnementale urbaine; rénovation urbaine, habitat.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43040</code>
+            <name>
+                <narrative>Rural development</narrative>
+                <narrative xml:lang="fr">Développement rural</narrative>
+            </name>
+            <description>
+                <narrative>Integrated rural development projects; e.g. regional development planning; promotion of decentralised and multi-sectoral competence for planning, co-ordination and management; implementation of regional development and measures (including natural reserve management); land management; land use planning; land settlement and resettlement activities [excluding resettlement of refugees and internally displaced persons (72010)]; functional integration of rural and urban areas; geographical information systems.</narrative>
+                <narrative xml:lang="fr">Projets intégrés de développement rural, par exemple, planification du développement régional ; encouragement à la décentralisation des compétences plurisectorielles concernant la planification, la coordination et la gestion ; mise en œuvre du développement régional et des mesures d’accompagnement (telle que gestion des ressources naturelles) ; gestion et planification des terres ; peuplement des terres et activités de réinstallation des peuples [à l’exclusion de la réinstallation des réfugiés et des personnes déplacées à l’intérieur du pays (72010)] projets d’intégration des zones rurales et urbaines ; systèmes d’information des zones géographiques.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43041</code>
+            <name>
+                <narrative>Rural land policy and management</narrative>
+                <narrative xml:lang="fr">Administration de l'aménagement du territoire rural</narrative>
+            </name>
+            <description>
+                <narrative>Regional development planning; promotion of decentralised and multi-sectoral competence for planning, co-ordination and management; land management; land use planning; geographical information systems.</narrative>
+                <narrative xml:lang="fr">Planification du développement régional; encouragement à la décentralisation des compétences plurisectorielles concernant la planification, la coordination et la gestion; gestion des terres; systèmes d’information géographique.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43042</code>
+            <name>
+                <narrative>Rural development</narrative>
+                <narrative xml:lang="fr">Développement rural</narrative>
+            </name>
+            <description>
+                <narrative>Integrated rural development projects; implementation of regional development and measures (including natural reserve management); land settlement and resettlement activities [excluding resettlement of refugees and internally displaced persons (72010)]; functional integration of rural and urban areas.</narrative>
+                <narrative xml:lang="fr">Projets intégrés de développement rural; mise en œuvre du développement régional (y compris la gestion des réserves naturelles) ; peuplement et réinstallation [à l’exclusion de la réinstallation des réfugiés et des personnes déplacées à l’intérieur du pays (72030)]; intégration des zones rurales et urbaines.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43050</code>
+            <name>
+                <narrative>Non-agricultural alternative development</narrative>
+                <narrative xml:lang="fr">Développement alternatif non agricole</narrative>
+            </name>
+            <description>
+                <narrative>Projects to reduce illicit drug cultivation through, for example, non-agricultural income opportunities, social and physical infrastructure (see code 31165 for agricultural alternative development).</narrative>
+                <narrative xml:lang="fr">Projets visant à réduire les cultures illicites (drogue) à travers, par exemple, des activités créatrices de revenu non agricoles, des infrastructures sociales et physiques (voir code 31165 pour le développement alternatif agricole).</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43081</code>
+            <name>
+                <narrative>Multisector education/training</narrative>
+                <narrative xml:lang="fr">Éducation et formation plurisectorielles</narrative>
+            </name>
+            <description>
+                <narrative>Including scholarships.</narrative>
+                <narrative xml:lang="fr">Y compris les bourses.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>43082</code>
+            <name>
+                <narrative>Research/scientific institutions</narrative>
+                <narrative xml:lang="fr">Institutions scientifiques et de recherche</narrative>
+            </name>
+            <description>
+                <narrative>When sector cannot be identified.</narrative>
+                <narrative xml:lang="fr">Quand le secteur ne peut être déterminé.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item>
+            <code>51010</code>
+            <name>
+                <narrative>General budget support-related aid</narrative>
+                <narrative xml:lang="fr">Aide relative au soutien budgétaire général</narrative>
+            </name>
+            <description>
+                <narrative>Unearmarked contributions to the government budget; support for the implementation of macroeconomic reforms (structural adjustment programmes, poverty reduction strategies); general programme assistance (when not allocable by sector).</narrative>
+                <narrative xml:lang="fr">Contributions au budget du gouvernement non réservées ; soutien à la mise en œuvre des réformes macroéconomiques (programmes d’ajustement structurel, stratégies de réduction de la pauvreté) ; y compris l’aide-programme générale (ne pouvant être ventilée par secteur).</narrative>
+            </description>
+            <category>510</category>
+        </codelist-item>
+        <codelist-item>
+            <code>52010</code>
+            <name>
+                <narrative>Food aid/Food security programmes</narrative>
+                <narrative xml:lang="fr">Programmes de sécurité et d’aide alimentaire</narrative>
+            </name>
+            <description>
+                <narrative>Supply of edible human food under national or international programmes including transport costs; cash payments made for food supplies; project food aid and food aid for market sales when benefiting sector not specified; excluding emergency food aid. Report as multilateral: i) food aid by the EU financed out of its budget and allocated pro rata to EU member countries; and ii) core contributions to the World Food Programme.</narrative>
+                <narrative xml:lang="fr">Fourniture nationale ou internationale de produits alimentaires y compris frais de transport ; paiements comptants pour la fourniture de produits alimentaires ; projets d’aide alimentaire et aide alimentaire destinée à la vente quand le secteur bénéficiaire ne peut être précisé ; à l’exclusion de l’aide alimentaire d’urgence. Notifier comme multilatéral : i) l'aide alimentaire consentie par l’UE et financée sur son budget propre puis répartie entre les États membres au pro rata de leur contribution à ce budget ; et ii) les contributions au budget central du PAM.</narrative>
+            </description>
+            <category>520</category>
+        </codelist-item>
+        <codelist-item>
+            <code>53030</code>
+            <name>
+                <narrative>Import support (capital goods)</narrative>
+                <narrative xml:lang="fr">Subventions à l’importation (biens d’équipement)</narrative>
+            </name>
+            <description>
+                <narrative>Capital goods and services; lines of credit.</narrative>
+                <narrative xml:lang="fr">Biens d’équipement et services ; lignes de crédit.</narrative>
+            </description>
+            <category>530</category>
+        </codelist-item>
+        <codelist-item>
+            <code>53040</code>
+            <name>
+                <narrative>Import support (commodities)</narrative>
+                <narrative xml:lang="fr">Subventions à l’importation (produits)</narrative>
+            </name>
+            <description>
+                <narrative>Commodities, general goods and services, oil imports.</narrative>
+                <narrative xml:lang="fr">Produits, biens d’ordre général, importations de pétrole.</narrative>
+            </description>
+            <category>530</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60010</code>
+            <name>
+                <narrative>Action relating to debt</narrative>
+                <narrative xml:lang="fr">Action se rapportant à la dette</narrative>
+            </name>
+            <description>
+                <narrative>Actions falling outside the code headings below.</narrative>
+                <narrative xml:lang="fr">Actions non spécifiées ci-dessous.</narrative>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60020</code>
+            <name>
+                <narrative>Debt forgiveness</narrative>
+                <narrative xml:lang="fr">Annulation de la dette</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60030</code>
+            <name>
+                <narrative>Relief of multilateral debt</narrative>
+                <narrative xml:lang="fr">Allégement de la dette multilatérale</narrative>
+            </name>
+            <description>
+                <narrative>Grants or credits to cover debt owed to multilateral financial institutions; including contributions to Heavily Indebted Poor Countries (HIPC) Trust Fund.</narrative>
+                <narrative xml:lang="fr">Dons ou prêts affectés au remboursement d’échéances dues à des institutions financières multilatérales ; y compris les contributions au fonds spécial pour les Pays pauvres très endettés (PPTE).</narrative>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60040</code>
+            <name>
+                <narrative>Rescheduling and refinancing</narrative>
+                <narrative xml:lang="fr">Rééchelonnement d’échéances et refinancement</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60061</code>
+            <name>
+                <narrative>Debt for development swap</narrative>
+                <narrative xml:lang="fr">Échange de dette à des fins de développement</narrative>
+            </name>
+            <description>
+                <narrative>Allocation of debt claims to use for development (e.g., debt for education, debt for environment).</narrative>
+                <narrative xml:lang="fr">Affectation de créances à des fins de développement (par exemple dette pour l’éducation, dette pour l’environnement, etc.)</narrative>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60062</code>
+            <name>
+                <narrative>Other debt swap</narrative>
+                <narrative xml:lang="fr">Autres échanges de dette</narrative>
+            </name>
+            <description>
+                <narrative>Where the debt swap benefits an external agent i.e. is not specifically for development purposes.</narrative>
+                <narrative xml:lang="fr">Lorsque l’échange de dette profite à un agent extérieur, i.e. n’est pas spécifiquement opéré à des fins de développement.</narrative>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>60063</code>
+            <name>
+                <narrative>Debt buy-back</narrative>
+                <narrative xml:lang="fr">Rachat de la dette</narrative>
+            </name>
+            <description>
+                <narrative>Purchase of debt for the purpose of cancellation.</narrative>
+                <narrative xml:lang="fr">Achat de la dette en vue de son annulation.</narrative>
+            </description>
+            <category>600</category>
+        </codelist-item>
+        <codelist-item>
+            <code>72010</code>
+            <name>
+                <narrative>Material relief assistance and services</narrative>
+                <narrative xml:lang="fr">Assistance matérielle et services d’urgence</narrative>
+            </name>
+            <description>
+                <narrative>Shelter, water, sanitation and health services, supply of medicines and other non-food relief items for the benefit of affected people and to facilitate the return to normal lives and livelihoods; assistance to refugees and internally displaced people in developing countries other than for food (72040) or protection (72050).</narrative>
+                <narrative xml:lang="fr">Fourniture d’abris, d’eau, d’installations sanitaires et de services de santé, de médicaments et d’autres secours non alimentaires dans le but d’aider les populations affectées et de faciliter le retour à une vie et des moyens d’existence normaux ; aide aux personnes déplacées à l’intérieur d’un pays à des fins autres qu’alimentaires (72040) ou de protection (72050).</narrative>
+            </description>
+            <category>720</category>
+        </codelist-item>
+        <codelist-item>
+            <code>72040</code>
+            <name>
+                <narrative>Emergency food aid</narrative>
+                <narrative xml:lang="fr">Aide alimentaire d’urgence</narrative>
+            </name>
+            <description>
+                <narrative>Food aid normally for general free distribution or special supplementary feeding programmes; short-term relief to targeted population groups affected by emergency situations. Excludes non-emergency food security assistance programmes/food aid (52010).</narrative>
+                <narrative xml:lang="fr">Aide alimentaire pour distribution gratuite ou programmes alimentaires complémentaires ; soutien à court terme aux populations affectées par des catastrophes. Sont exclus les programmes non urgents de sécurité et d’aide alimentaire (52010).</narrative>
+            </description>
+            <category>720</category>
+        </codelist-item>
+        <codelist-item>
+            <code>72050</code>
+            <name>
+                <narrative>Relief co-ordination; protection and support services</narrative>
+                <narrative xml:lang="fr">Coordination des secours et services de soutien et de protection</narrative>
+            </name>
+            <description>
+                <narrative>Measures to co-ordinate delivery of humanitarian aid, including logistics and communications systems; measures to promote and protect the safety, well- being, dignity and integrity of civilians and those no longer taking part in hostilities. (Activities designed to protect the security of persons or property through the use or display of force are not reportable as ODA.)</narrative>
+                <narrative xml:lang="fr">Mesures visant à coordonner l’acheminement de l’aide humanitaire, y compris les moyens logistiques et les systèmes de communication ; mesures de promotion et de protection de la sécurité, du bien-être, de la dignité et de l’intégrité des civils et des personnes qui ne prennent plus part aux hostilités. (Les activités ayant pour but de protéger la sécurité des personnes et des biens par l’usage ou la démonstration de la force ne sont pas comptabilisables dans l’APD.)</narrative>
+            </description>
+            <category>720</category>
+        </codelist-item>
+        <codelist-item>
+            <code>73010</code>
+            <name>
+                <narrative>Reconstruction relief and rehabilitation</narrative>
+                <narrative xml:lang="fr">Aide à la reconstruction et réhabilitation</narrative>
+            </name>
+            <description>
+                <narrative>Short-term reconstruction work after emergency or conflict limited to restoring pre-existing infrastructure (e.g. repair or construction of roads, bridges and ports, restoration of essential facilities, such as water and sanitation, shelter, health care services); social and economic rehabilitation in the aftermath of emergencies to facilitate transition and enable populations to return to their previous livelihood or develop a new livelihood in the wake of an emergency situation (e.g. trauma counselling and treatment, employment programmes).</narrative>
+                <narrative xml:lang="fr">Travaux de reconstruction à court terme après une urgence ou un conflit limités à la remise en état des infrastructures préexistantes (par exemple, réparation ou construction de routes, de ponts ou de ports, restauration des services essentiels concernant, par exemple, l’eau et l’assainissement, les abris, les soins de santé) ; réhabilitation sociale et économique après des situations d’urgence pour faciliter la transition et permettre aux populations touchées de retrouver leurs moyens d’existence antérieurs ou d’en trouver de nouveaux au sortir d’une situation d’urgence (par exemple, conseils et traitements en vue d’aider à surmonter les traumatismes subis, programmes d’emploi).</narrative>
+            </description>
+            <category>730</category>
+        </codelist-item>
+        <codelist-item>
+            <code>74010</code>
+            <name>
+                <narrative>Disaster prevention and preparedness</narrative>
+                <narrative xml:lang="fr">Prévention des catastrophes et préparation à leur survenue</narrative>
+            </name>
+            <description>
+                <narrative>Disaster risk reduction activities (e.g. developing knowledge, natural risks cartography, legal norms for construction); early warning systems; emergency contingency stocks and contingency planning including preparations for forced displacement.</narrative>
+                <narrative xml:lang="fr">Activités visant à réduire les risques liés aux catastrophes (par exemple développement des connaissances, établissement d’une cartographie des risques naturels, de normes juridiques pour les constructions) ; systèmes d’alerte précoce, stocks d’urgence et planification d’urgence, y compris préparation à une évacuation.</narrative>
+            </description>
+            <category>740</category>
+        </codelist-item>
+        <codelist-item>
+            <code>91010</code>
+            <name>
+                <narrative>Administrative costs (non-sector allocable)</narrative>
+                <narrative xml:lang="fr">Frais administratifs (non alloués par secteur)</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>910</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>92010</code>
+            <name>
+                <narrative>Support to national NGOs</narrative>
+            </name>
+            <description>
+                <narrative>In the donor country.</narrative>
+            </description>
+            <category>920</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>92020</code>
+            <name>
+                <narrative>Support to international NGOs</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>920</category>
+        </codelist-item>
+        <codelist-item status="withdrawn">
+            <code>92030</code>
+            <name>
+                <narrative>Support to local and regional NGOs</narrative>
+            </name>
+            <description>
+                <narrative>In the recipient country or region.</narrative>
+            </description>
+            <category>920</category>
+        </codelist-item>
+        <codelist-item>
+            <code>93010</code>
+            <name>
+                <narrative>Refugees in donor countries (non-sector allocable)</narrative>
+                <narrative xml:lang="fr">Réfugiés dans le pays donneur (non alloués par secteur)</narrative>
+            </name>
+            <description>
+                <narrative/>
+            </description>
+            <category>930</category>
+        </codelist-item>
+        <codelist-item>
+            <code>99810</code>
+            <name>
+                <narrative>Sectors not specified</narrative>
+                <narrative xml:lang="fr">Secteur non spécifié</narrative>
+            </name>
+            <description>
+                <narrative>Contributions to general development of the recipient should be included under programme assistance (51010).</narrative>
+                <narrative xml:lang="fr">Les contributions au développement général du pays bénéficiaire devraient être incluses dans l’aide programme (51010).</narrative>
+            </description>
+            <category>998</category>
+        </codelist-item>
+        <codelist-item>
+            <code>99820</code>
+            <name>
+                <narrative>Promotion of development awareness (non-sector allocable)</narrative>
+                <narrative xml:lang="fr">Sensibilisation au développement (non alloués par secteur)</narrative>
+            </name>
+            <description>
+                <narrative>Spending in donor country for heightened awareness/interest in development co-operation (brochures, lectures, special research projects, etc.).</narrative>
+                <narrative xml:lang="fr">Dépenses dans le pays donneur afin de renforcer la sensibilisation et l’intérêt dans la coopération pour le développement (brochures, exposés, projets spéciaux de recherche, etc.).</narrative>
+            </description>
+            <category>998</category>
+        </codelist-item>
+    </codelist-items>
 </codelist>

--- a/xml/SectorCategory.xml
+++ b/xml/SectorCategory.xml
@@ -435,7 +435,7 @@
             <code>910</code>
             <name>
                 <narrative>ADMINISTRATIVE COSTS OF DONORS</narrative>
-                <narrative xml:lang="fr">Frais administratifs (non alloués par secteur)</narrative>
+                <narrative xml:lang="fr">ADMINISTRATIVE COSTS OF DONORS</narrative>
             </name>
             <description>
                 <narrative/>
@@ -454,7 +454,7 @@
             <code>930</code>
             <name>
                 <narrative>REFUGEES IN DONOR COUNTRIES</narrative>
-                <narrative xml:lang="fr">Réfugiés dans le pays donneur (non alloués par secteur)</narrative>
+                <narrative xml:lang="fr">REFUGIES DANS LE PAYS DONNEUR</narrative>
             </name>
             <description>
                 <narrative/>


### PR DESCRIPTION
Latest round of codelist updates from the DAC.

## Summary of changes:

### Channel Code

 * Add “Conservation International” (`21063`)
 * Add “National Red Cross and Red Crescent Societies” (`23501`)
 * Add “UN-led Country-based Pooled Funds” (`41503`)
 * Add “World Tourism Organization” (`41319`)
 * Add “Asian Infrastructure Investment Bank” (`46026`)
 * Add “Center of Excellence in Finance” (`47145`)

~~### Finance Type category~~

 * ~~Add “NON FLOW ITEMS” (`0`)~~

~~### Finance Type~~

 * ~~Add “GNI: Gross National Income” (`1`)~~
 * ~~Add “ODA % GNI (`2`)~~
 * ~~Add “Total flows % GNI” (`3`)~~
 * ~~Add “Population” (`4`)~~

[UPDATE: #16 suggests these finance type codes should not be part of this update, so I have removed them.]

…And other assorted typos and corrections.

---

One thing to note: Sector.xml previously used tabs instead of spaces. This fixes that, but unfortunately that messes up the PR diff.

You can use this sneaky “ignore whitespace changes” github feature:
https://github.com/IATI/IATI-Codelists-NonEmbedded/pull/171/commits/b0369dc0?w=1#diff-14f0f55b5d186317d078771305bd88ce

…or alternatively I could split the change into two commits if that’s easier.
