### PR TITLE
Add BudgetIdentifierVocabulary as a NE-Codelist

### DIFF
--- a/xml/BudgetIdentifierVocabulary.xml
+++ b/xml/BudgetIdentifierVocabulary.xml
@@ -1,0 +1,54 @@
+<codelist name="BudgetIdentifierVocabulary" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Budget Identifier Vocabulary</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>IATI</narrative>
+            </name>
+            <description>
+                <narrative>The budget identifier reported uses IATI budget identifier categories</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Country Chart of Accounts</narrative>
+            </name>
+            <description>
+                <narrative>The budget identifier reported corresponds to the recipient country chart of accounts</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Other Country System</narrative>
+            </name>
+            <description>
+                <narrative>The budget identifier reported corresponds to a recipient country system other than the chart of accounts</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>4</code>
+            <name>
+                <narrative>Reporting Organisation</narrative>
+            </name>
+            <description>
+                <narrative>The budget identifier reported corresponds to categories that are specific to the reporting organisation</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>5</code>
+            <name>
+                <narrative>Other</narrative>
+            </name>
+            <description>
+                <narrative>The budget identifier reported uses a different vocabulary, not specified in the codelist </narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists