### PR TITLE
Add DescriptionType as a NE-Codelist

### DIFF
--- a/xml/DescriptionType.xml
+++ b/xml/DescriptionType.xml
@@ -1,0 +1,52 @@
+<codelist name="DescriptionType" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Description Type</narrative>
+        </name>
+        <description>
+            <narrative>Activity decription types. (General, objectives, etc)</narrative>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>General</narrative>
+                <narrative xml:lang="fr">Général</narrative>
+            </name>
+            <description>
+                <narrative>Unstructured, long description of the activity </narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Objectives</narrative>
+                <narrative xml:lang="fr">Objectifs</narrative>
+            </name>
+            <description>
+                <narrative>Specific objectives for the activity, e.g. taken from logical framework</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Target Groups</narrative>
+                <narrative xml:lang="fr">Groupes cibles</narrative>
+            </name>
+            <description>
+                <narrative>Details of groups that are intended to benefit from the activity</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>4</code>
+            <name>
+                <narrative>Other</narrative>
+                <narrative xml:lang="fr">Autre</narrative>
+            </name>
+            <description>
+                <narrative>For miscellaneous use. A further classification or breakdown may be included in the narrative</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists