### PR TITLE
Add DisbursementChannel as a NE-Codelist

### DIFF
--- a/xml/DisbursementChannel.xml
+++ b/xml/DisbursementChannel.xml
@@ -1,0 +1,48 @@
+<codelist name="DisbursementChannel" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Disbursement Channel</narrative>
+        </name>
+        <description>
+            <narrative>Categories of information included in published documents</narrative>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Money is disbursed through central Ministry of Finance or Treasury</narrative>
+            </name>
+            <description>
+                <narrative>Money is disbursed through central Ministry of Finance or Treasury</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Money is disbursed directly to the implementing institution and managed through a separate bank account</narrative>
+            </name>
+            <description>
+                <narrative>Money is disbursed directly to the implementing institution and managed through a separate bank account</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Aid in kind: Donors utilise third party agencies, e.g. NGOs or management companies</narrative>
+            </name>
+            <description>
+                <narrative>Aid in kind: Donors utilise third party agencies, e.g. NGOs or management companies</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>4</code>
+            <name>
+                <narrative>Aid in kind: Donors manage funds themselves</narrative>
+            </name>
+            <description>
+                <narrative>Aid in kind: Donors manage funds themselves</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists