### PR TITLE
Add DocumentCategory-category as a NE-Codelist

### DIFF
--- a/xml/DocumentCategory-category.xml
+++ b/xml/DocumentCategory-category.xml
@@ -1,0 +1,30 @@
+<codelist name="DocumentCategory-category" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Document Category (category)</narrative>
+        </name>
+        <description>
+            <narrative>This codelists exists to group the Document Category codelist into categories. It is not used as a codelist in its own right.</narrative>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>A</code>
+            <name>
+                <narrative>Activity Level</narrative>
+            </name>
+            <description>
+                <narrative>The document is relevant to a specific activity</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>B</code>
+            <name>
+                <narrative>Organisation Level</narrative>
+            </name>
+            <description>
+                <narrative>The document is relevant to the organisation as a whole</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists