### PR TITLE
Add GeographicLocationReach as a NE-Codelist

### DIFF
--- a/xml/GeographicLocationReach.xml
+++ b/xml/GeographicLocationReach.xml
@@ -1,0 +1,35 @@
+<codelist name="GeographicLocationReach" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Geographic Location Reach</narrative>
+            <narrative xml:lang="fr">Caractéristiques du lieu</narrative>
+        </name>
+        <description>
+            <narrative/>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Activity</narrative>
+                <narrative xml:lang="fr">Activité</narrative>
+            </name>
+            <description>
+                <narrative>The location specifies where the activity is carried out</narrative>
+                <narrative xml:lang="fr">La désignation géographique correspond au lieu où l’activité est mise en œuvre.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Intended Beneficiaries</narrative>
+                <narrative xml:lang="fr">Bénéficiaires visés</narrative>
+            </name>
+            <description>
+                <narrative>The location specifies where the intended beneficiaries of the activity live</narrative>
+                <narrative xml:lang="fr">La désignation géographique correspond au lieu d’habitation des bénéficiaires visés.</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists