### PR TITLE
Add GeographicVocabulary as a NE-Codelist

### DIFF
--- a/xml/GeographicVocabulary.xml
+++ b/xml/GeographicVocabulary.xml
@@ -1,0 +1,60 @@
+<codelist name="GeographicVocabulary" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Geographic Vocabulary</narrative>
+        </name>
+        <description>
+            <narrative/>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>A1</code>
+            <name>
+                <narrative>Global Admininistrative Unit Layers</narrative>
+            </name>
+            <url>http://www.fao.org/geonetwork/srv/en/metadata.show?id=12691</url>
+        </codelist-item>
+        <codelist-item>
+            <code>A2</code>
+            <name>
+                <narrative>UN Second Administrative Level Boundary Project</narrative>
+            </name>
+            <description>
+                <narrative>Note: the unsalb.org website is no longer accessible, and public access to the boundaries resources has been removed http://www.ungiwg.org/content/united-nations-international-and-administrative-boundaries-resources</narrative>
+            </description>
+            <url>http://www.unsalb.org/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>A3</code>
+            <name>
+                <narrative>Global Administrative Areas</narrative>
+            </name>
+            <url>http://www.gadm.org/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>A4</code>
+            <name>
+                <narrative>ISO Country (3166-1 alpha-2)</narrative>
+            </name>
+            <url>http://www.iso.org/iso/country_codes.htm</url>
+        </codelist-item>
+        <codelist-item>
+            <code>G1</code>
+            <name>
+                <narrative>Geonames</narrative>
+            </name>
+            <url>http://www.geonames.org/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>G2</code>
+            <name>
+                <narrative>OpenStreetMap</narrative>
+            </name>
+            <description>
+                <narrative>Note: the code should be formed by prefixing the relevant OpenStreetMap ID with node/ way/ or relation/ as appropriate, e.g. node/1234567</narrative>
+            </description>
+            <url>http://www.openstreetmap.org/</url>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists