### PR TITLE
Add LoanRepaymentType as a NE-Codelist

### DIFF
--- a/xml/LoanRepaymentType.xml
+++ b/xml/LoanRepaymentType.xml
@@ -1,0 +1,48 @@
+<codelist name="LoanRepaymentType" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Loan Repayment Type</narrative>
+        </name>
+        <description>
+            <narrative>used in additional CRS elements</narrative>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Equal Principal Payments (EPP)</narrative>
+            </name>
+            <description>
+                <narrative>As required and defined by CRS++ reporting format Column 44</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Annuity</narrative>
+            </name>
+            <description>
+                <narrative>As required and defined by CRS++ reporting format Column 44</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Lump sum</narrative>
+            </name>
+            <description>
+                <narrative>As required and defined by CRS++ reporting format Column 44</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>5</code>
+            <name>
+                <narrative>Other</narrative>
+            </name>
+            <description>
+                <narrative>As required and defined by CRS++ reporting format Column 44</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists