### PR TITLE
Add IndicatorMeasure as a NE-Codelist

### DIFF
--- a/xml/IndicatorMeasure.xml
+++ b/xml/IndicatorMeasure.xml
@@ -1,0 +1,30 @@
+<codelist name="IndicatorMeasure" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Indicator Measure</narrative>
+        </name>
+        <description>
+            <narrative>To specify the language of titles, descriptions and documents</narrative>
+        </description>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Unit</narrative>
+            </name>
+            <description>
+                <narrative>The indicator is measured in units.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Percentage</narrative>
+            </name>
+            <description>
+                <narrative>The indicator is measured in percentages</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists