### PR TITLE
Add OrganisationType as a NE-Codelist

### DIFF
--- a/xml/OrganisationType.xml
+++ b/xml/OrganisationType.xml
@@ -1,0 +1,79 @@
+<codelist name="OrganisationType" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Organisation Type</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>10</code>
+            <name>
+                <narrative>Government</narrative>
+                <narrative xml:lang="fr">Gouvernement</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>15</code>
+            <name>
+                <narrative>Other Public Sector</narrative>
+                <narrative xml:lang="fr">Autre secteur public</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>21</code>
+            <name>
+                <narrative>International NGO</narrative>
+                <narrative xml:lang="fr">ONG internationale</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>22</code>
+            <name>
+                <narrative>National NGO</narrative>
+                <narrative xml:lang="fr">ONG nationale</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>23</code>
+            <name>
+                <narrative>Regional NGO</narrative>
+                <narrative xml:lang="fr">ONG regionale</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>30</code>
+            <name>
+                <narrative>Public Private Partnership</narrative>
+                <narrative xml:lang="fr">Partenariat public-privé</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>40</code>
+            <name>
+                <narrative>Multilateral</narrative>
+                <narrative xml:lang="fr">Multilatéral</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>60</code>
+            <name>
+                <narrative>Foundation</narrative>
+                <narrative xml:lang="fr">Fondation</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>70</code>
+            <name>
+                <narrative>Private Sector</narrative>
+                <narrative xml:lang="fr">Secteur privé</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>80</code>
+            <name>
+                <narrative>Academic, Training and Research</narrative>
+                <narrative xml:lang="fr">Universitaire, formation et recherche</narrative>
+            </name>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists