### PR TITLE
Add OtherIdentifierType as a NE-Codelist

### DIFF
--- a/xml/OtherIdentifierType.xml
+++ b/xml/OtherIdentifierType.xml
@@ -1,0 +1,56 @@
+<codelist name="OtherIdentifierType" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Other Identifier Type</narrative>
+            <narrative xml:lang="fr">Autre critère d’identification</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>A1</code>
+            <name>
+                <narrative>Reporting Organisation's internal activity identifier</narrative>
+                <narrative xml:lang="fr">Identifiant interne de l’activité dans l’organisation en charge de l’élaboration du rapport</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>A2</code>
+            <name>
+                <narrative>CRS Activity identifier</narrative>
+                <narrative xml:lang="fr">Identifiant de l’activité dans le Système de notification des pays créanciers</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>A3</code>
+            <name>
+                <narrative>Previous Activity Identifier</narrative>
+                <narrative xml:lang="fr">Identifiant précédent de l’activité</narrative>
+            </name>
+            <description>
+                <narrative>The standard insists that once an activity has been reported to IATI its identifier MUST NOT be changed, even if the reporting organisation changes its organisation identifier. There may be exceptional circumstances in which this rule cannot be followed, in which case the previous identifier should be reported using this code.</narrative>
+                <narrative xml:lang="fr">La norme insiste sur le fait qu’un identifiant d’activité transmis à l’IITA NE DOIT PAS être modifié, même si le notificateur modifie l’identifiant de l’organisation. Si des circonstances exceptionnelles empêchent le respect de cette règle, il convient de renseigner l’identifiant précédent à l’aide de ce code.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>A9</code>
+            <name>
+                <narrative>Other Activity Identifier</narrative>
+                <narrative xml:lang="fr">Autre identifiant de l’activité</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>B1</code>
+            <name>
+                <narrative>Previous Reporting Organisation Identifier</narrative>
+                <narrative xml:lang="fr">Identifiant précédent de l’organisation en charge de l’élaboration du rapport</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>B9</code>
+            <name>
+                <narrative>Other Organisation Identifier</narrative>
+                <narrative xml:lang="fr">Autre identifiant de l’organisation</narrative>
+            </name>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists