### PR TITLE
Add SectorVocabulary as a NE-Codelist

### DIFF
--- a/xml/SectorVocabulary.xml
+++ b/xml/SectorVocabulary.xml
@@ -1,0 +1,135 @@
+<codelist name="SectorVocabulary" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Sector Vocabulary</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>OECD DAC CRS Purpose Codes (5 digit)</narrative>
+                <narrative xml:lang="fr">Codes-objet à cinq chiffres du Système de notification des pays créanciers du Comité d'aide au développement de l'OCDE</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to an OECD DAC CRS 5-digit purpose code</narrative>
+            </description>
+            <url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>OECD DAC CRS Purpose Codes (3 digit)</narrative>
+                <narrative xml:lang="fr">Codes-objet à trois chiffres du Système de notification des pays créanciers du Comité d’aide au développement de l'OCDE</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to an OECD DAC CRS 3-digit purpose code</narrative>
+            </description>
+            <url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Classification of the Functions of Government (UN)</narrative>
+                <narrative xml:lang="fr">Classification des fonctions des administrations publiques (ONU)</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to the UN Classification of the Functions of Government (CoFoG)</narrative>
+            </description>
+            <url>http://unstats.un.org/unsd/cr/registry/regcst.asp?Cl=4</url>
+        </codelist-item>
+        <codelist-item>
+            <code>4</code>
+            <name>
+                <narrative>Statistical classification of economic activities in the European Community</narrative>
+                <narrative xml:lang="fr">Nomenclature statistique des activités économiques dans la Communauté européenne</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to the statistical classifications of economic activities in the European Community</narrative>
+            </description>
+            <url>http://ec.europa.eu/eurostat/ramon/nomenclatures/index.cfm?TargetUrl=LST_NOM_DTL&amp;StrNom=NACE_REV2&amp;StrLanguageCode=EN</url>
+        </codelist-item>
+        <codelist-item>
+            <code>5</code>
+            <name>
+                <narrative>National Taxonomy for Exempt Entities (USA)</narrative>
+                <narrative xml:lang="fr">Taxonomie nationale des entités exonérées (É.-U.)</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to the National Taxonomy for Exempt Entities (NTEE) - USA</narrative>
+            </description>
+            <url>http://nccs.urban.org/classification/NTEE.cfm</url>
+        </codelist-item>
+        <codelist-item>
+            <code>6</code>
+            <name>
+                <narrative>AidData</narrative>
+                <narrative xml:lang="fr">AidData</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to AidData classifications</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>7</code>
+            <name>
+                <narrative>SDG Goal</narrative>
+            </name>
+            <description>
+                <narrative>A value from the top-level list of UN sustainable development goals (SDGs) (e.g. ‘1’)</narrative>
+            </description>
+            <url>https://sustainabledevelopment.un.org/?menu=1300</url>
+        </codelist-item>
+        <codelist-item>
+            <code>8</code>
+            <name>
+                <narrative>SDG Target</narrative>
+            </name>
+            <description>
+                <narrative>A value from the second-level list of UN sustainable development goals (SDGs) (e.g. ‘1.1’)</narrative>
+            </description>
+            <url>http://unstats.un.org/sdgs/indicators/indicators-list/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>9</code>
+            <name>
+                <narrative>SDG Indicator</narrative>
+            </name>
+            <description>
+                <narrative>A value from the second-level list of UN sustainable development (SDG) indicators</narrative>
+            </description>
+            <url>http://unstats.un.org/sdgs/indicators/indicators-list/</url>
+        </codelist-item>
+        <codelist-item>
+            <code>10</code>
+            <name>
+                <narrative>Humanitarian Global Clusters (Inter-Agency Standing Committee)</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to an Inter-Agency Standard Committee Humanitarian Global Cluster code</narrative>
+            </description>
+            <url>https://data.humdata.org/dataset/standard-cluster-names-and-codes/resource/24b50d16-897b-46f9-848b-7fce08ac599b</url>
+        </codelist-item>
+        <codelist-item>
+            <code>99</code>
+            <name>
+                <narrative>Reporting Organisation</narrative>
+                <narrative xml:lang="fr">Organisation déclarante</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to a sector vocabulary maintained by the reporting organisation for this activity</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>98</code>
+            <name>
+                <narrative>Reporting Organisation 2</narrative>
+                <narrative xml:lang="fr">Organisation déclarante 2</narrative>
+            </name>
+            <description>
+                <narrative>The sector reported corresponds to a sector vocabulary maintained by the reporting organisation for this activity (if they are referencing more than one)</narrative>
+                <narrative xml:lang="fr">Si plus d’un secteur est mentionné, le secteur indiqué correspond au vocabulaire utilisé par l’organisation déclarante en référence à cette activité</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists