### PR TITLE
Add ResultType as a NE-Codelist

### DIFF
--- a/xml/ResultType.xml
+++ b/xml/ResultType.xml
@@ -1,0 +1,49 @@
+<codelist name="ResultType" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Result Type</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Output</narrative>
+                <narrative xml:lang="fr">Donateur</narrative>
+            </name>
+            <description>
+                <narrative>Results of the activity that came about as a direct effect of your work and specific, what is done, and what communities are reached. For example, X number of individuals.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Outcome</narrative>
+                <narrative xml:lang="fr">Effet</narrative>
+            </name>
+            <description>
+                <narrative>Results of the activity that produce an effect on the overall communities or issues you serve. For example lower rate of infection after a vaccination programme.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Impact</narrative>
+                <narrative xml:lang="fr">Impact</narrative>
+            </name>
+            <description>
+                <narrative>The long term effects of the outcomes, that lead to larger, over arching results, such as improved life-expectancy.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>9</code>
+            <name>
+                <narrative>Other</narrative>
+                <narrative xml:lang="fr">Autre</narrative>
+            </name>
+            <description>
+                <narrative>Another type of result, not specified above.</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists