### PR TITLE
Add PublisherType as a NE-Codelist

### DIFF
--- a/xml/PublisherType.xml
+++ b/xml/PublisherType.xml
@@ -1,0 +1,39 @@
+<codelist name="PublisherType" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Publisher Type</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Aid Provider</narrative>
+                <narrative xml:lang="fr">Donateur</narrative>
+            </name>
+            <description>
+                <narrative>A government, organisation, agency or institution that provides aid funds.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Aid Recipient</narrative>
+                <narrative xml:lang="fr">Récipiendaire</narrative>
+            </name>
+            <description>
+                <narrative>A government, organisation, agency or institution that recieves aid funds.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Aggregator</narrative>
+                <narrative xml:lang="fr">Agrégateur</narrative>
+            </name>
+            <description>
+                <narrative>An organisation that collects and reproduces information from other providers or recipients</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists