### PR TITLE
Add PolicyMarker as a NE-Codelist

### DIFF
--- a/xml/PolicyMarker.xml
+++ b/xml/PolicyMarker.xml
@@ -1,0 +1,63 @@
+<codelist name="PolicyMarker" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Policy Marker</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>Gender Equality</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>Aid to Environment</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>3</code>
+            <name>
+                <narrative>Participatory Development/Good Governance</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>4</code>
+            <name>
+                <narrative>Trade Development</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>5</code>
+            <name>
+                <narrative>Aid Targeting the Objectives of the Convention on Biological Diversity</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>6</code>
+            <name>
+                <narrative>Aid Targeting the Objectives of the Framework Convention on Climate Change - Mitigation</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>7</code>
+            <name>
+                <narrative>Aid Targeting the Objectives of the Framework Convention on Climate Change - Adaptation</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>8</code>
+            <name>
+                <narrative>Aid Targeting the Objectives of the Convention to Combat Desertification</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item>
+            <code>9</code>
+            <name>
+                <narrative>Reproductive, Maternal, Newborn and Child Health (RMNCH)</narrative>
+            </name>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists