### PR TITLE
Add RegionVocabulary as a NE-Codelist

### DIFF
--- a/xml/RegionVocabulary.xml
+++ b/xml/RegionVocabulary.xml
@@ -1,0 +1,36 @@
+<codelist name="RegionVocabulary" xml:lang="en" complete="1">
+    <metadata>
+        <name>
+            <narrative>Region Vocabulary</narrative>
+        </name>
+    </metadata>
+    <codelist-items>
+        <codelist-item>
+            <code>1</code>
+            <name>
+                <narrative>OECD DAC</narrative>
+            </name>
+            <description>
+                <narrative>Supra-national regions according to OECD DAC CRS recipient codes</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>2</code>
+            <name>
+                <narrative>UN</narrative>
+            </name>
+            <description>
+                <narrative>Supra-national regions maintained by UN Statistics Division</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item>
+            <code>99</code>
+            <name>
+                <narrative>Reporting Organisation</narrative>
+            </name>
+            <description>
+                <narrative>The region reported corresponds to a region vocabulary maintained by the reporting organisation for this activity.</narrative>
+            </description>
+        </codelist-item>
+    </codelist-items>
+</codelist>


### PR DESCRIPTION
This is a migration of the Codelist from Embedded to Non-Embedded.

IATI/IATI-Codelists#114
Version as per 387c04a1f2503a42db2b2a6f2e4cb534a6338b93 in IATI-Codelists