### PR TITLE
Update SZ - Swaziland to Eswatini

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -1308,7 +1308,7 @@
         <codelist-item>
             <code>SZ</code>
             <name>
-                <narrative>SWAZILAND</narrative>
+                <narrative>ESWATINI</narrative>
             </name>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
Following the name change of Swaziland, ISO have updated the name of country code SZ to Eswatini.