### PR TITLE
Update country CZ to Czechia

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -372,7 +372,7 @@
         <codelist-item>
             <code>CZ</code>
             <name>
-                <narrative>CZECH REPUBLIC (THE)</narrative>
+                <narrative>CZECHIA</narrative>
             </name>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
Following ISO change - the short name is now Czechia: https://www.iso.org/obp/ui/#iso:code:3166:CZ