### PR TITLE
Updating Country Codes to match ISO Codelist

### DIFF
--- a/xml/Country.xml
+++ b/xml/Country.xml
@@ -180,7 +180,7 @@
         <codelist-item>
             <code>BQ</code>
             <name>
-                <narrative>BONAIRE, SAINT EUSTATIUS AND SABA</narrative>
+                <narrative>BONAIRE, SINT EUSTATIUS AND SABA</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -258,7 +258,7 @@
         <codelist-item>
             <code>CV</code>
             <name>
-                <narrative>CAPE VERDE</narrative>
+                <narrative>CABO VERDE</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -324,7 +324,7 @@
         <codelist-item>
             <code>CD</code>
             <name>
-                <narrative>CONGO, THE DEMOCRATIC REPUBLIC OF THE</narrative>
+                <narrative>CONGO (THE DEMOCRATIC REPUBLIC OF THE)</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -372,7 +372,7 @@
         <codelist-item>
             <code>CZ</code>
             <name>
-                <narrative>CZECH REPUBLIC (THE)</narrative>
+                <narrative>CZECHIA</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -720,13 +720,13 @@
         <codelist-item>
             <code>KP</code>
             <name>
-                <narrative>KOREA (DEMOCRATIC PEOPLE'S REPUBLIC OF)</narrative>
+                <narrative>KOREA (THE DEMOCRATIC PEOPLE'S REPUBLIC OF)</narrative>
             </name>
         </codelist-item>
         <codelist-item>
             <code>KR</code>
             <name>
-                <narrative>KOREA (REPUBLIC OF)</narrative>
+                <narrative>KOREA (THE REPUBLIC OF)</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -780,7 +780,7 @@
         <codelist-item>
             <code>LY</code>
             <name>
-                <narrative>LIBYAN ARAB JAMAHIRIYA</narrative>
+                <narrative>LIBYA</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -894,7 +894,7 @@
         <codelist-item>
             <code>MD</code>
             <name>
-                <narrative>MOLDOVA (REPUBLIC OF)</narrative>
+                <narrative>MOLDOVA (THE REPUBLIC OF)</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -1044,7 +1044,7 @@
         <codelist-item>
             <code>PS</code>
             <name>
-                <narrative>PALESTINIAN TERRITORY, OCCUPIED</narrative>
+                <narrative>PALESTINE, STATE OF</narrative>
             </name>
         </codelist-item>
         <codelist-item>
@@ -1110,7 +1110,7 @@
         <codelist-item>
             <code>RE</code>
             <name>
-                <narrative>REUNION</narrative>
+                <narrative>RÉUNION</narrative>
             </name>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
Updating Country Codes to match the 'short name' on ISO Codelist.
Including changes to Libya, Palestine, Czechia, and other small changes.