### PR TITLE
Adding SDG goals, targets, indicators to the TagVocabulary codelist

### DIFF
--- a/xml/TagVocabulary.xml
+++ b/xml/TagVocabulary.xml
@@ -19,6 +19,36 @@
       <url>http://artemide.art.uniroma2.it:8081/agrovoc/agrovoc/en/</url>
     </codelist-item>
     <codelist-item>
+      <code>2</code>
+      <name>
+        <narrative>SDG Goal</narrative>
+      </name>
+      <description>
+        <narrative>A value from the top-level list of UN sustainable development goals (SDGs) (e.g. ‘1’).</narrative>
+      </description>
+      <url>https://sustainabledevelopment.un.org/?menu=1300</url>
+    </codelist-item>
+    <codelist-item>
+      <code>3</code>
+      <name>
+        <narrative>SDG Target</narrative>
+      </name>
+      <description>
+        <narrative>A value from the second-level list of UN sustainable development goals (SDGs) (e.g. ‘1.1’).</narrative>
+      </description>
+      <url>http://unstats.un.org/sdgs/indicators/indicators-list/</url>
+    </codelist-item>
+    <codelist-item>
+      <code>4</code>
+      <name>
+        <narrative>SDG Indicator</narrative>
+      </name>
+      <description>
+        <narrative>A value from the list of UN sustainable development (SDG) indicators (e.g. ‘1.1.1’).</narrative>
+      </description>
+      <url>http://unstats.un.org/sdgs/indicators/indicators-list/</url>
+    </codelist-item>
+    <codelist-item>
       <code>99</code>
       <name>
         <narrative>Reporting Organisation</narrative>


### PR DESCRIPTION
Proposal to add SDG goals, targets and indicators to the non-embedded codelist tag vocabulary: https://discuss.iatistandard.org/t/add-sdg-goals-and-targets-to-the-tagvocabulary-codelist/1562

 No objection so far.  Changes to be reviewed and merged by 4th of December.