### PR TITLE
Point replicated codelists in iati vocabs to iati urls

### DIFF
--- a/xml/AidTypeVocabulary.xml
+++ b/xml/AidTypeVocabulary.xml
@@ -20,7 +20,7 @@
             <description>
                 <narrative>List of codes provided by the OECD DAC used to distinguish types of aid</narrative>
             </description>
-            <url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
+            <url>http://reference.iatistandard.org/codelists/AidType/</url>
         </codelist-item>
         <codelist-item>
             <code>2</code>
@@ -30,7 +30,7 @@
             <description>
                 <narrative>This vocabulary has been created by IATI and is derived from the Grand Bargain Earmarking Modality codelist</narrative>
             </description>
-            <url>http://iatistandard.org/codelists/EarmarkingCategory</url>
+            <url>http://reference.iatistandard.org/codelists/EarmarkingCategory/</url>
         </codelist-item>
         <codelist-item>
             <code>3</code>

--- a/xml/GeographicVocabulary.xml
+++ b/xml/GeographicVocabulary.xml
@@ -45,7 +45,7 @@
                 <narrative>ISO Country (3166-1 alpha-2)</narrative>
                 <narrative xml:lang="fr">Pays ISO (3166-1 alpha-2)</narrative>
             </name>
-            <url>http://www.iso.org/iso/country_codes.htm</url>
+            <url>http://reference.iatistandard.org/codelists/Country/</url>
         </codelist-item>
         <codelist-item>
             <code>G1</code>

--- a/xml/PolicyMarkerVocabulary.xml
+++ b/xml/PolicyMarkerVocabulary.xml
@@ -18,6 +18,7 @@
                 <narrative>The policy marker is an OECD DAC CRS policy marker, Reported in columns 20-23, 28-31 and 54 of CRS++ reporting format.</narrative>
                 <narrative xml:lang="fr">Le marqueur de politique est un marqueur de politique OCDE CAD SNPC, indiqué dans les colonnes 20-23, 28-31 et 54 du format de préparation de déclaration SNPC++.</narrative>
             </description>
+            <url>http://reference.iatistandard.org/codelists/PolicyMarker/</url>
         </codelist-item>
         <codelist-item>
             <code>99</code>

--- a/xml/SectorVocabulary.xml
+++ b/xml/SectorVocabulary.xml
@@ -18,7 +18,7 @@
                 <narrative>The sector reported corresponds to an OECD DAC CRS 5-digit purpose code</narrative>
                 <narrative xml:lang="fr">Le secteur déclaré correspond à un code de secteur OCDE CAD SNPC à cinq chiffres</narrative>
             </description>
-            <url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
+            <url>http://reference.iatistandard.org/codelists/Sector/</url>
         </codelist-item>
         <codelist-item>
             <code>2</code>
@@ -30,7 +30,7 @@
                 <narrative>The sector reported corresponds to an OECD DAC CRS 3-digit purpose code</narrative>
                 <narrative xml:lang="fr">Le secteur déclaré correspond à un code de secteur OCDE CAD SNPC à trois chiffres</narrative>
             </description>
-            <url>http://www.oecd.org/dac/stats/dacandcrscodelists.htm</url>
+            <url>http://reference.iatistandard.org/codelists/SectorCategory/</url>
         </codelist-item>
         <codelist-item>
             <code>3</code>


### PR DESCRIPTION
This forms part of the work to update IATI's codelist management processes. This PR points links to replicated codelists to the IATI URL, rather than the external source.

See: 
- https://github.com/IATI/IATI-Codelists-NonEmbedded/issues/293 
- https://github.com/IATI/IATI-Extra-Documentation/pull/552 

This also encompasses: https://github.com/IATI/IATI-Codelists-NonEmbedded/issues/272 