### PR TITLE
Add code 4 to AidTypeVocabulary codelist

### DIFF
--- a/xml/AidTypeVocabulary.xml
+++ b/xml/AidTypeVocabulary.xml
@@ -42,5 +42,15 @@
             </description>
             <url>https://reliefweb.int/sites/reliefweb.int/files/resources/Grand_Bargain_final_22_May_FINAL-2.pdf</url>
         </codelist-item>
+        <codelist-item>
+            <code>4</code>
+            <name>
+                <narrative>Cash and Voucher Modalities</narrative>
+            </name>
+            <description>
+                <narrative>This voacbulary has been created by IATI, following agreements and recommendations of the Tracking Cash and Voucher Assistance (CVA) Working Group.</narrative>
+            </description>
+            <url>http://reference.iatistandard.org/codelists/CashandVoucherModalities/</url>
+        </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/AidTypeVocabulary.xml
+++ b/xml/AidTypeVocabulary.xml
@@ -48,7 +48,7 @@
                 <narrative>Cash and Voucher Modalities</narrative>
             </name>
             <description>
-                <narrative>This voacbulary has been created by IATI, following agreements and recommendations of the Tracking Cash and Voucher Assistance (CVA) Working Group.</narrative>
+                <narrative>This vocabulary has been created by IATI, following agreements and recommendations of the Tracking Cash and Voucher Assistance (CVA) Working Group.</narrative>
             </description>
             <url>http://reference.iatistandard.org/codelists/CashandVoucherModalities/</url>
         </codelist-item>


### PR DESCRIPTION
Add new Aid Type vocabulary as per agreement on IATI discuss: https://discuss.iatistandard.org/t/approved-proposal-to-add-cash-transfer-and-voucher-codelist-under-aid-type-vocabulary/1793

@IATI/devs , please check if I have added the correct URL for code 4 as it needs to link to newly created codelist from pull request #309 .