### PR TITLE
Adding the correct description for code 2- Voucher

### DIFF
--- a/xml/CashandVoucherModalities.xml
+++ b/xml/CashandVoucherModalities.xml
@@ -26,7 +26,7 @@
                 <narrative>Voucher</narrative>
             </name>
             <description>
-                <narrative>The activity scope is a supranational region</narrative>
+                <narrative>A paper, token or e-voucher that can be exchanged for a set quantity or value of goods or services, denominated either as a cash value (e.g. $15) or predetermined commodities (e.g. 5 kg maize) or specific services (e.g. milling of 5 kg of maize), or a combination of value and commodities. Vouchers are restricted by default, although the degree of restriction will vary based on the programme design and type of voucher. They are redeemable with preselected vendors or in ‘fairs’ created by the implementing agency. The terms vouchers, stamps, or coupons might be used interchangeably.</narrative>
             </description>
         </codelist-item>
    </codelist-items>


### PR DESCRIPTION
As per IATI Discuss: https://discuss.iatistandard.org/t/approved-proposal-to-add-cash-transfer-and-voucher-codelist-under-aid-type-vocabulary/1793

My mistake for pasting wrong description first time round.