### PR TITLE
Add missing space in EarmarkingCategory name

### DIFF
--- a/xml/EarmarkingCategory.xml
+++ b/xml/EarmarkingCategory.xml
@@ -1,7 +1,7 @@
 <codelist name="EarmarkingCategory" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
-            <narrative>EarmarkingCategory</narrative>
+            <narrative>Earmarking Category</narrative>
         </name>
         <description>
             <narrative>This codelist has been created by IATI and is derived from the Grand Bargain Earmarking Modality codelist.</narrative>


### PR DESCRIPTION
This is the only camel-cased codelist name, so I guess this is a typo.

![Screenshot 2019-10-29 at 13 57 51](https://user-images.githubusercontent.com/464193/67773794-2e26c380-fa54-11e9-99af-b15daa5e1606.png)
