### PR TITLE
remove empty narratives

### DIFF
--- a/xml/AidType-category.xml
+++ b/xml/AidType-category.xml
@@ -62,10 +62,6 @@
                 <narrative>Scholarships and student costs in donor countries</narrative>
                 <narrative xml:lang="fr">Bourses et autres frais d’étude dans les pays donneurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>F</code>
@@ -73,10 +69,6 @@
                 <narrative>Debt relief</narrative>
                 <narrative xml:lang="fr">Allégement de la dette</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>G</code>
@@ -84,10 +76,6 @@
                 <narrative>Administrative costs not included elsewhere</narrative>
                 <narrative xml:lang="fr">Frais administratifs non inclus ailleurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>H</code>

--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -15,10 +15,6 @@
                 <narrative>Public Sector Institutions</narrative>
                 <narrative xml:lang="fr">Institutions du secteur public</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>11000</code>
@@ -26,10 +22,6 @@
                 <narrative>Donor Government</narrative>
                 <narrative xml:lang="fr">Gouvernement du donneur</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11001</code>
@@ -37,10 +29,6 @@
                 <narrative>Central Government</narrative>
                 <narrative xml:lang="fr">Gouvernment central</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>11000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -49,10 +37,6 @@
                 <narrative>Local Government</narrative>
                 <narrative xml:lang="fr">Gouvernment local</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>11000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -61,10 +45,6 @@
                 <narrative>Public corporations</narrative>
                 <narrative xml:lang="fr">Entreprise publique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>11000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -73,10 +53,6 @@
                 <narrative>Other public entities in donor country</narrative>
                 <narrative xml:lang="fr">Autres entité publique dans le pays donneur</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>11000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -85,10 +61,6 @@
                 <narrative>Recipient Government</narrative>
                 <narrative xml:lang="fr">Gouvernement du bénéficiaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12001</code>
@@ -96,10 +68,6 @@
                 <narrative>Central Government</narrative>
                 <narrative xml:lang="fr">Gouvernment central</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>12000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -108,10 +76,6 @@
                 <narrative>Local Government</narrative>
                 <narrative xml:lang="fr">Gouvernment local</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>12000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -120,10 +84,6 @@
                 <narrative>Public corporations</narrative>
                 <narrative xml:lang="fr">Entreprise publique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>12000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -132,10 +92,6 @@
                 <narrative>Other public entities in recipient country</narrative>
                 <narrative xml:lang="fr">Autres entité publique dans le pays bénéficiaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>12000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -144,10 +100,6 @@
                 <narrative>Third Country Government (Delegated co-operation)</narrative>
                 <narrative xml:lang="fr">Gouvernement tiers (coopération déléguée)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>20000</code>
@@ -155,10 +107,6 @@
                 <narrative>Non-Governmental Organisation (NGO) and Civil Society</narrative>
                 <narrative xml:lang="fr">Organisations non gouvernementales (ONG) et société civile</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>21000</code>
@@ -166,10 +114,6 @@
                 <narrative>International NGO</narrative>
                 <narrative xml:lang="fr">ONG internationales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>21001</code>
@@ -177,10 +121,6 @@
                 <narrative>Association of Geoscientists for International Development</narrative>
                 <narrative xml:lang="fr">Association de géoscientifiques pour le développement international</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -189,10 +129,6 @@
                 <narrative>Agency for International Trade Information and Co-operation</narrative>
                 <narrative xml:lang="fr">Agence de coopération et d'information pour le commerce international</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -201,10 +137,6 @@
                 <narrative>Latin American Council for Social Sciences</narrative>
                 <narrative xml:lang="fr">Conseil latino-américain des sciences sociales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -213,10 +145,6 @@
                 <narrative>Council for the Development of Economic and Social Research in Africa</narrative>
                 <narrative xml:lang="fr">Conseil pour le développement de la recherche en sciences sociales en Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
@@ -225,10 +153,6 @@
                 <narrative>Consumer Unity and Trust Society International</narrative>
                 <narrative xml:lang="fr">Consumer Unity and Trust Society International</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -237,10 +161,6 @@
                 <narrative>Development Gateway Foundation</narrative>
                 <narrative xml:lang="fr">Development Gateway Foundation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -249,10 +169,6 @@
                 <narrative>Environmental Liaison Centre International</narrative>
                 <narrative xml:lang="fr">Centre international de liaison pour l’environnement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -261,10 +177,6 @@
                 <narrative>Eurostep</narrative>
                 <narrative xml:lang="fr">Eurostep</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -273,10 +185,6 @@
                 <narrative>Forum for Agricultural Research in Africa</narrative>
                 <narrative xml:lang="fr">Forum pour la recherche agricole en Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -285,10 +193,6 @@
                 <narrative>Forum for African Women Educationalists</narrative>
                 <narrative xml:lang="fr">Forum des éducatrices africaines</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -297,10 +201,6 @@
                 <narrative>Global Campaign for Education</narrative>
                 <narrative xml:lang="fr">Campagne mondiale pour l’éducation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1999-01-01">
@@ -309,10 +209,6 @@
                 <narrative>Health Action International</narrative>
                 <narrative xml:lang="fr">Health Action International</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -321,10 +217,6 @@
                 <narrative>Human Rights Information and Documentation Systems</narrative>
                 <narrative xml:lang="fr">Systèmes d’Information et de Documentation sur les Droits de l’Homme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -333,10 +225,6 @@
                 <narrative>International Catholic Rural Association</narrative>
                 <narrative xml:lang="fr">Association internationale rurale catholique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -345,10 +233,6 @@
                 <narrative>International Committee of the Red Cross</narrative>
                 <narrative xml:lang="fr">Comité international de la Croix-Rouge</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -357,10 +241,6 @@
                 <narrative>International Centre for Trade and Sustainable Development</narrative>
                 <narrative xml:lang="fr">Centre international de commerce et de développement durable</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2000-01-01">
@@ -369,10 +249,6 @@
                 <narrative>International Federation of Red Cross and Red Crescent Societies</narrative>
                 <narrative xml:lang="fr">Fédération internationale des Sociétés de la Croix-Rouge et du Croissant-Rouge</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -381,10 +257,6 @@
                 <narrative>International Federation of Settlements and Neighbourhood Centres</narrative>
                 <narrative xml:lang="fr">Fédération internationale des centres sociaux et communautaires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -393,10 +265,6 @@
                 <narrative>International HIV/AIDS Alliance</narrative>
                 <narrative xml:lang="fr">International HIV/AIDS Alliance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -405,10 +273,6 @@
                 <narrative>International Institute for Environment and Development</narrative>
                 <narrative xml:lang="fr">Institut international pour l’environnement et le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -417,10 +281,6 @@
                 <narrative>International Network for Alternative Financial Institutions</narrative>
                 <narrative xml:lang="fr">Réseau international d’institutions financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -429,10 +289,6 @@
                 <narrative>International Planned Parenthood Federation</narrative>
                 <narrative xml:lang="fr">Fédération internationale pour le planning familial</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -441,10 +297,6 @@
                 <narrative>Inter Press Service, International Association</narrative>
                 <narrative xml:lang="fr">Inter Press Service, International Association</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -453,10 +305,6 @@
                 <narrative>International Seismological Centre</narrative>
                 <narrative xml:lang="fr">Centre séismologique international</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -465,10 +313,6 @@
                 <narrative>International Service for Human Rights</narrative>
                 <narrative xml:lang="fr">Service International pour les Droits de l’Homme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -477,10 +321,6 @@
                 <narrative>ITF Enhancing Human Security</narrative>
                 <narrative xml:lang="fr">ITF Améliorer la sécurité humaine</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -489,10 +329,6 @@
                 <narrative>International University Exchange Fund - IUEF Stip. in Africa and Latin America</narrative>
                 <narrative xml:lang="fr">Fonds international d’échanges universitaires - Échanges intéressant l’Afrique et l’Amérique latine</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2001-01-01">
@@ -501,10 +337,6 @@
                 <narrative>Doctors Without Borders</narrative>
                 <narrative xml:lang="fr">Médecins Sans Frontières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -513,10 +345,6 @@
                 <narrative>Pan African Institute for Development</narrative>
                 <narrative xml:lang="fr">Institut panafricain pour le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -525,10 +353,6 @@
                 <narrative>PANOS Institute</narrative>
                 <narrative xml:lang="fr">Institut PANOS</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -537,10 +361,6 @@
                 <narrative>Population Services International</narrative>
                 <narrative xml:lang="fr">Organisation internationale pour les services en matière de population</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -549,10 +369,6 @@
                 <narrative>Transparency International</narrative>
                 <narrative xml:lang="fr">Transparency International</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -561,10 +377,6 @@
                 <narrative>International Union Against Tuberculosis and Lung Disease</narrative>
                 <narrative xml:lang="fr">Union Internationale Contre la Tuberculose et les Maladies Respiratoires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -573,10 +385,6 @@
                 <narrative>World Organisation Against Torture</narrative>
                 <narrative xml:lang="fr">Organisation mondiale contre la torture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -585,10 +393,6 @@
                 <narrative>World University Service</narrative>
                 <narrative xml:lang="fr">Entraide universitaire mondiale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -597,10 +401,6 @@
                 <narrative>Women's World Banking</narrative>
                 <narrative xml:lang="fr">Banque mondiale des femmes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
@@ -609,10 +409,6 @@
                 <narrative>International Alert</narrative>
                 <narrative xml:lang="fr">International Alert</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -621,10 +417,6 @@
                 <narrative>International Institute for Sustainable Development</narrative>
                 <narrative xml:lang="fr">Institut international de développement durable</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -633,10 +425,6 @@
                 <narrative>International Women's Tribune Centre</narrative>
                 <narrative xml:lang="fr">Centre de la tribune internationale de la femme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
@@ -645,10 +433,6 @@
                 <narrative>Society for International Development</narrative>
                 <narrative xml:lang="fr">Société pour le développement international</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
@@ -657,10 +441,6 @@
                 <narrative>International Peacebuilding Alliance</narrative>
                 <narrative xml:lang="fr">Alliance internationale pour la consolidation de la paix</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -669,10 +449,6 @@
                 <narrative>European Parliamentarians for Africa</narrative>
                 <narrative xml:lang="fr">Association des parlementaires d’Europe pour l’Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -681,10 +457,6 @@
                 <narrative>International Council for the Control of Iodine Deficiency Disorders</narrative>
                 <narrative xml:lang="fr">Conseil international pour la lutte contre les troubles dus à une carence en iode</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -693,10 +465,6 @@
                 <narrative>African Medical and Research Foundation</narrative>
                 <narrative xml:lang="fr">Fondation africaine pour la médecine et la recherche</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -705,10 +473,6 @@
                 <narrative>Agency for Cooperation and Research in Development</narrative>
                 <narrative xml:lang="fr">Association de Coopération et de Recherche pour le Développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -717,10 +481,6 @@
                 <narrative>AgriCord</narrative>
                 <narrative xml:lang="fr">AgriCord</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -729,10 +489,6 @@
                 <narrative>Association of African Universities</narrative>
                 <narrative xml:lang="fr">Association des universités africaines</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -741,10 +497,6 @@
                 <narrative>European Centre for Development Policy Management</narrative>
                 <narrative xml:lang="fr">Centre européen de gestion de politiques de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -753,10 +505,6 @@
                 <narrative>Geneva Call</narrative>
                 <narrative xml:lang="fr">Appel de Genève</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -765,10 +513,6 @@
                 <narrative>Institut Supérieur Panafricaine d’Economie Coopérative</narrative>
                 <narrative xml:lang="fr">Institut supérieur panafricaine d’economie coopérative</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -777,10 +521,6 @@
                 <narrative>IPAS-Protecting Women’s Health, Advancing Women’s Reproductive Rights</narrative>
                 <narrative xml:lang="fr">IPAS-Protecting Women's Health, Advancing Women's Reproductive Rights</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -789,10 +529,6 @@
                 <narrative>Life and Peace Institute</narrative>
                 <narrative xml:lang="fr">Institut Vie et Paix</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -801,10 +537,6 @@
                 <narrative>Regional AIDS Training Network</narrative>
                 <narrative xml:lang="fr">Réseau régional de formation sur le SIDA</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -813,10 +545,6 @@
                 <narrative>Renewable Energy and Energy Efficiency Partnership</narrative>
                 <narrative xml:lang="fr">Partenariat pour les énergies renouvelables et l'efficience énergétique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -825,10 +553,6 @@
                 <narrative>International Centre for Transitional Justice</narrative>
                 <narrative xml:lang="fr">Centre International pour la Justice Transitionnelle</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -837,10 +561,6 @@
                 <narrative>International Crisis Group</narrative>
                 <narrative xml:lang="fr">International Crisis Group</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -849,10 +569,6 @@
                 <narrative>Africa Solidarity Fund</narrative>
                 <narrative xml:lang="fr">Fonds solidaire pour l'Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -861,10 +577,6 @@
                 <narrative>Association for the Prevention of Torture</narrative>
                 <narrative xml:lang="fr">Association pour la prévention de la torture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -873,10 +585,6 @@
                 <narrative>International Rehabilitation Council for Torture Victims</narrative>
                 <narrative xml:lang="fr">Conseil international de réhabilitation pour les victimes de torture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -885,10 +593,6 @@
                 <narrative>The Nature Conservancy</narrative>
                 <narrative xml:lang="fr">The Nature Conservancy</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -897,10 +601,6 @@
                 <narrative>Conservation International</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
@@ -909,10 +609,6 @@
                 <narrative>Clinton Health Access Initiative, Inc.</narrative>
                 <narrative xml:lang="fr">Initiative Clinton pour l'accès à la santé</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -921,10 +617,6 @@
                 <narrative>OXFAM International</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -933,10 +625,6 @@
                 <narrative>World Vision</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -945,10 +633,6 @@
                 <narrative>Family Health International 360</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -957,10 +641,6 @@
                 <narrative>International Relief and Development</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -969,10 +649,6 @@
                 <narrative>Save the Children</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -981,10 +657,6 @@
                 <narrative>International Rescue Committee</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -993,10 +665,6 @@
                 <narrative>Pact World</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1005,10 +673,6 @@
                 <narrative>Donor country-based NGO</narrative>
                 <narrative xml:lang="fr">ONG basée dans un pays donneur</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>22501</code>
@@ -1016,10 +680,6 @@
                 <narrative>OXFAM - provider country office</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -1028,10 +688,6 @@
                 <narrative>Save the Children - donor country office</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1040,10 +696,6 @@
                 <narrative>Developing country-based NGO</narrative>
                 <narrative xml:lang="fr">ONG basée dans un pays en développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>23501</code>
@@ -1051,10 +703,6 @@
                 <narrative>National Red Cross and Red Crescent Societies</narrative>
                 <narrative xml:lang="fr">Sociétés nationales de la Croix-Rouge et du Croissant-Rouge</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>23000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1063,10 +711,6 @@
                 <narrative>Public-Private Partnerships (PPP) and Networks</narrative>
                 <narrative xml:lang="fr">Partenariats public-privé (PPP) et réseaux</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30001</code>
@@ -1074,10 +718,6 @@
                 <narrative>Global Alliance for Improved Nutrition</narrative>
                 <narrative xml:lang="fr">Alliance mondiale pour une meilleure nutrition</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1086,10 +726,6 @@
                 <narrative>Global e-Schools and Communities Initiative</narrative>
                 <narrative xml:lang="fr">Initiative mondiale en faveur de l’informatique dans les écoles et dans les communautés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1098,10 +734,6 @@
                 <narrative>Global Water Partnership</narrative>
                 <narrative xml:lang="fr">Partenariat mondial pour l'eau</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1110,10 +742,6 @@
                 <narrative>International AIDS Vaccine Initiative</narrative>
                 <narrative xml:lang="fr">Initiative internationale pour un vaccin contre le SIDA</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1122,10 +750,6 @@
                 <narrative>International Partnership on Microbicides</narrative>
                 <narrative xml:lang="fr">Partenariat international pour des microbicides</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1134,10 +758,6 @@
                 <narrative>Global Alliance for ICT and Development</narrative>
                 <narrative xml:lang="fr">Alliance mondiale pour les TIC et le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1146,10 +766,6 @@
                 <narrative>Cities Alliance</narrative>
                 <narrative xml:lang="fr">Alliance pour les villes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1158,10 +774,6 @@
                 <narrative>Small Arms Survey</narrative>
                 <narrative xml:lang="fr">Small Arms Survey</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1170,10 +782,6 @@
                 <narrative>International drug purchase facility</narrative>
                 <narrative xml:lang="fr">Facilité internationale d'achat de médicaments</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1182,10 +790,6 @@
                 <narrative>International Union for the Conservation of Nature</narrative>
                 <narrative xml:lang="fr">Union internationale pour la conservation de la nature</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1194,10 +798,6 @@
                 <narrative>Global Climate Partnership Fund</narrative>
                 <narrative xml:lang="fr">Global Climate Partnership Fund</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1206,10 +806,6 @@
                 <narrative>Microfinance Enhancement Facility</narrative>
                 <narrative xml:lang="fr">Mécanisme de soutien au microfinancement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1218,10 +814,6 @@
                 <narrative>Regional Micro, Small and Medium Enterprise Investment Fund for Sub-Saharan Africa</narrative>
                 <narrative xml:lang="fr">Fonds régional d’investissement pour les très petites, petites et moyennes entreprises d’Afrique subsaharienne</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1230,10 +822,6 @@
                 <narrative>Global Energy Efficiency and Renewable Energy Fund</narrative>
                 <narrative xml:lang="fr">Fonds mondial pour la promotion de l'efficacité énergétique et des énergies renouvelables</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -1242,10 +830,6 @@
                 <narrative>European Fund for Southeast Europe</narrative>
                 <narrative xml:lang="fr">European Fund for Southeast Europe</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -1254,10 +838,6 @@
                 <narrative>SANAD Fund for Micro, Small and Medium Enterprises</narrative>
                 <narrative xml:lang="fr">SANAD Fund for Micro, Small and Medium Enterprises</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1266,10 +846,6 @@
                 <narrative>Public-Private Partnerships (PPP)</narrative>
                 <narrative xml:lang="fr">Partenariats public-privé (PPP)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>31001</code>
@@ -1277,10 +853,6 @@
                 <narrative>Global Development Network</narrative>
                 <narrative xml:lang="fr">Réseau de développement mondial</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1289,10 +861,6 @@
                 <narrative>Global Knowledge Partnership</narrative>
                 <narrative xml:lang="fr">Alliance mondiale pour le savoir</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1301,10 +869,6 @@
                 <narrative>International Land Coalition</narrative>
                 <narrative xml:lang="fr">Coalition internationale pour l'accès à la terre</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -1313,10 +877,6 @@
                 <narrative>Extractive Industries Transparency Initiative International Secretariat</narrative>
                 <narrative xml:lang="fr">Secrétariat de l'Initiative pour la transparence dans les industries extractives</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -1325,10 +885,6 @@
                 <narrative>Parliamentary Network on the World Bank</narrative>
                 <narrative xml:lang="fr">Réseau parlementaire sur la Banque mondaile</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -1337,10 +893,6 @@
                 <narrative>Coalition for Epidemic Preparedness Innovations</narrative>
                 <narrative xml:lang="fr">Coalition pour les innovations en matière de préparation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1349,10 +901,6 @@
                 <narrative>Networks</narrative>
                 <narrative xml:lang="fr">Réseaux</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>40000</code>
@@ -1360,10 +908,6 @@
                 <narrative>Multilateral Organisations</narrative>
                 <narrative xml:lang="fr">Organisations multilatérales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>41000</code>
@@ -1371,10 +915,6 @@
                 <narrative>United Nations (UN) agency, fund or commission</narrative>
                 <narrative xml:lang="fr">Agence, fonds ou commission des Nations Unies (ONU)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41100</code>
@@ -1382,10 +922,6 @@
                 <narrative>UN entities (core contributions reportable in full)</narrative>
                 <narrative xml:lang="fr">Entités des Nations Unies (contributions aux budgets reguliers à déclarer dans leur intégralité)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41101</code>
@@ -1393,10 +929,6 @@
                 <narrative>Convention to Combat Desertification</narrative>
                 <narrative xml:lang="fr">Convention sur la lutte contre la désertification</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1405,10 +937,6 @@
                 <narrative>Desert Locust Control Organisation for Eastern Africa</narrative>
                 <narrative xml:lang="fr">Organisation de lutte contre le criquet pèlerin dans l'Est Africain</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1417,10 +945,6 @@
                 <narrative>Economic Commission for Africa</narrative>
                 <narrative xml:lang="fr">Commission économique pour l'Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1429,10 +953,6 @@
                 <narrative>Economic Commission for Latin America and the Caribbean</narrative>
                 <narrative xml:lang="fr">Commission économique pour l'Amérique latine et les Caraïbes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1441,10 +961,6 @@
                 <narrative>Economic and Social Commission for Western Asia</narrative>
                 <narrative xml:lang="fr">Commission économique et sociale pour l'Asie occidentale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1453,10 +969,6 @@
                 <narrative>Economic and Social Commission for Asia and the Pacific</narrative>
                 <narrative xml:lang="fr">Commission économique et sociale pour l'Asie et le Pacifique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1465,10 +977,6 @@
                 <narrative>International Atomic Energy Agency (Contributions to Technical Cooperation Fund Only)</narrative>
                 <narrative xml:lang="fr">Agence internationale de l'énergie atomique (Contributions au Fonds de Coopération Technique uniquement)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1477,10 +985,6 @@
                 <narrative>International Fund for Agricultural Development</narrative>
                 <narrative xml:lang="fr">Fonds international de développement agricole</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -1489,10 +993,6 @@
                 <narrative>International Research and Training Institute for the Advancement of Women</narrative>
                 <narrative xml:lang="fr">International Research and Training Institute for the Advancement of Women</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1501,10 +1001,6 @@
                 <narrative>Joint United Nations Programme on HIV/AIDS</narrative>
                 <narrative xml:lang="fr">Programme commun des Nations Unies sur le VIH/SIDA</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1513,10 +1009,6 @@
                 <narrative>United Nations Capital Development Fund</narrative>
                 <narrative xml:lang="fr">Fonds d’équipement des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1525,10 +1017,6 @@
                 <narrative>United Nations Conference on Trade and Development</narrative>
                 <narrative xml:lang="fr">Conférence des Nations Unies sur le commerce et le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1537,10 +1025,6 @@
                 <narrative>United Nations Development Programme</narrative>
                 <narrative xml:lang="fr">Programme des Nations Unies pour le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1549,10 +1033,6 @@
                 <narrative>United Nations Environment Programme</narrative>
                 <narrative xml:lang="fr">Programme des Nations Unies pour l'environnement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1561,10 +1041,6 @@
                 <narrative>United Nations Population Fund</narrative>
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la population</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1573,10 +1049,6 @@
                 <narrative>United Nations Human Settlement Programme</narrative>
                 <narrative xml:lang="fr">Programme des Nations Unies pour les établissements humains</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1585,10 +1057,6 @@
                 <narrative>United Nations Office of the United Nations High Commissioner for Refugees</narrative>
                 <narrative xml:lang="fr">Haut Commissariat des Nations Unies pour les réfugiés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1597,10 +1065,6 @@
                 <narrative>United Nations Children’s Fund</narrative>
                 <narrative xml:lang="fr">Fonds des Nations Unies pour l'enfance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1609,10 +1073,6 @@
                 <narrative>United Nations Industrial Development Organisation</narrative>
                 <narrative xml:lang="fr">Organisation des Nations Unies pour le développement industriel</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -1621,10 +1081,6 @@
                 <narrative>United Nations Development Fund for Women</narrative>
                 <narrative xml:lang="fr">United Nations Development Fund for Women</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1633,10 +1089,6 @@
                 <narrative>United Nations Institute for Training and Research</narrative>
                 <narrative xml:lang="fr">Institut des Nations Unies pour la formation et la recherche</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1645,10 +1097,6 @@
                 <narrative>United Nations Mine Action Service</narrative>
                 <narrative xml:lang="fr">Service de l'action antimines des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1657,10 +1105,6 @@
                 <narrative>United Nations Office of Co-ordination of Humanitarian Affairs</narrative>
                 <narrative xml:lang="fr">Bureau des Nations Unies pour la coordination de l'assistance humanitaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1669,10 +1113,6 @@
                 <narrative>United Nations Office on Drugs and Crime</narrative>
                 <narrative xml:lang="fr">Office des Nations Unies contre la drogue et le crime</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1681,10 +1121,6 @@
                 <narrative>United Nations Research Institute for Social Development</narrative>
                 <narrative xml:lang="fr">Institut de recherche des Nations Unies pour le développement social</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1693,10 +1129,6 @@
                 <narrative>United Nations Relief and Works Agency for Palestine Refugees in the Near East</narrative>
                 <narrative xml:lang="fr">Office de secours et de travaux des Nations Unies pour les réfugiés de Palestine dans le Proche-Orient</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1705,10 +1137,6 @@
                 <narrative>United Nations System Staff College</narrative>
                 <narrative xml:lang="fr">Ecole des cadres du système des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1717,10 +1145,6 @@
                 <narrative>United Nations System Standing Committee on Nutrition</narrative>
                 <narrative xml:lang="fr">Comité permanent de la nutrition du système des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1729,10 +1153,6 @@
                 <narrative>United Nations Special Initiative on Africa</narrative>
                 <narrative xml:lang="fr">Initiative spéciale des Nations Unies pour l'Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1741,10 +1161,6 @@
                 <narrative>United Nations University (including Endowment Fund)</narrative>
                 <narrative xml:lang="fr">Université des Nations Unies (y compris le Fonds de dotation)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1753,10 +1169,6 @@
                 <narrative>United Nations Volunteers</narrative>
                 <narrative xml:lang="fr">Programme des volontaires des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1765,10 +1177,6 @@
                 <narrative>United Nations Voluntary Fund on Disability</narrative>
                 <narrative xml:lang="fr">Fonds de contributions voluntaires des Nations Unies pour les handicapés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1777,10 +1185,6 @@
                 <narrative>United Nations Voluntary Fund for Technical Co-operation in the Field of Human Rights</narrative>
                 <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour la coopération technique dans le domaine des droits de l'homme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1789,10 +1193,6 @@
                 <narrative>United Nations Voluntary Fund for Victims of Torture</narrative>
                 <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour les victimes de la torture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1801,10 +1201,6 @@
                 <narrative>World Food Programme</narrative>
                 <narrative xml:lang="fr">Programme alimentaire mondial</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1813,10 +1209,6 @@
                 <narrative>United Nations Peacebuilding Fund</narrative>
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41400</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1825,10 +1217,6 @@
                 <narrative>United Nations Democracy Fund</narrative>
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la démocratie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1837,10 +1225,6 @@
                 <narrative>World Health Organisation - core voluntary contributions account</narrative>
                 <narrative xml:lang="fr">Organisation mondiale de la santé - compte de contributions volontaires sans objet désigné</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1849,10 +1233,6 @@
                 <narrative>International Labour Organisation - Regular Budget Supplementary Account</narrative>
                 <narrative xml:lang="fr">Organisation internationale du Travail - Compte supplémentaire du budget ordinaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1861,10 +1241,6 @@
                 <narrative>International Maritime Organization - Technical Co-operation Fund</narrative>
                 <narrative xml:lang="fr">Organisation maritime internationale - Programme intégré de coopération technique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1873,10 +1249,6 @@
                 <narrative>United Nations Entity for Gender Equality and the Empowerment of Women</narrative>
                 <narrative xml:lang="fr">Entité des Nations Unies pour l'égalité des sexes et l'autonomisation de la femme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1885,10 +1257,6 @@
                 <narrative>Central Emergency Response Fund</narrative>
                 <narrative xml:lang="fr">Fonds central pour les interventions d'urgence</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41400</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1897,10 +1265,6 @@
                 <narrative>United Nations Department of Political Affairs, Trust Fund in Support of Political Affairs</narrative>
                 <narrative xml:lang="fr">Département des affaires politiques des Nations unies, fonds fiduciaire de soutien aux affaires politiques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41500</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1909,10 +1273,6 @@
                 <narrative>United Nations Development Coordination Office</narrative>
                 <narrative xml:lang="fr">Bureau de la coordination des activités de développement des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1921,10 +1281,6 @@
                 <narrative>United Nations Institute for Disarmament Research</narrative>
                 <narrative xml:lang="fr">Institut des Nations unies pour la recherche sur le désarmement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1933,10 +1289,6 @@
                 <narrative>International Agency for Research on Cancer</narrative>
                 <narrative xml:lang="fr">Centre international de recherche sur le cancer</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1945,10 +1297,6 @@
                 <narrative>Other UN (Core Contributions Reportable in Part)</narrative>
                 <narrative xml:lang="fr">Autres Nations Unies (contributions comptabilisables pour partie)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41301</code>
@@ -1956,10 +1304,6 @@
                 <narrative>Food and Agricultural Organisation</narrative>
                 <narrative xml:lang="fr">Organisation des Nations Unies pour l'alimentation et l'agriculture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1968,10 +1312,6 @@
                 <narrative>International Labour Organisation - Assessed Contributions</narrative>
                 <narrative xml:lang="fr">Organisation internationale du travail - contributions obligatoires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1980,10 +1320,6 @@
                 <narrative>International Telecommunications Union</narrative>
                 <narrative xml:lang="fr">Union internationale des télécommunications</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -1992,10 +1328,6 @@
                 <narrative>United Nations Educational, Scientific and Cultural Organisation</narrative>
                 <narrative xml:lang="fr">Organisation des Nations Unies pour l’éducation, la science et la culture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2004,10 +1336,6 @@
                 <narrative>United Nations</narrative>
                 <narrative xml:lang="fr">Organisation des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2016,10 +1344,6 @@
                 <narrative>Universal Postal Union</narrative>
                 <narrative xml:lang="fr">Union postale universelle</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2028,10 +1352,6 @@
                 <narrative>World Health Organisation - assessed contributions</narrative>
                 <narrative xml:lang="fr">Organisation mondiale de la santé - contributions obligatoires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2040,10 +1360,6 @@
                 <narrative>World Intellectual Property Organisation</narrative>
                 <narrative xml:lang="fr">Organisation mondiale de la propriété intellectuelle</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2052,10 +1368,6 @@
                 <narrative>World Meteorological Organisation</narrative>
                 <narrative xml:lang="fr">Organisation météorologique mondiale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2064,10 +1376,6 @@
                 <narrative>United Nations Department of Peacekeeping Operations [only MINURSO, MINUSCA, MINUSMA, MINUJUSTH, MONUSCO, UNAMID, UNIFIL, UNISFA, UNMIK, UNMIL, UNMISS, UNOCI]. Report contributions mission by mission in CRS++.</narrative>
                 <narrative xml:lang="fr">Département des opérations de maintien de la paix des Nations unies [seulement MINURSO, MINUSCA, MINUSMA, MINUJUSTH, MONUSCO, MINUAD, FINUL, FISNUA, MINUK, MINUL, UNMISS, ONUCI]. Notifier les contributions mission par mission au format SNPC++.</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2019-12-31">
@@ -2076,10 +1384,6 @@
                 <narrative>United Nations Peacebuilding Fund (Window One:  Flexible Contributions Only)</narrative>
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix (Guichet un:  contributions sans conditions)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2088,10 +1392,6 @@
                 <narrative>International Atomic Energy Agency - assessed contributions</narrative>
                 <narrative xml:lang="fr">Agence internationale de l'énergie atomique - contributions obligatoires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2100,10 +1400,6 @@
                 <narrative>United Nations High Commissioner for Human Rights (extrabudgetary contributions only)</narrative>
                 <narrative xml:lang="fr">Haut-Commissariat des Nations unies aux droits de l'homme (contributions extrabudgétaires uniquement)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2112,10 +1408,6 @@
                 <narrative>United Nations Economic Commission for Europe (extrabudgetary contributions only)</narrative>
                 <narrative xml:lang="fr">Commission économique des Nations unies pour l'Europe (contributions extrabudgétaires uniquement)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2124,10 +1416,6 @@
                 <narrative>United Nations International Strategy for Disaster Reduction</narrative>
                 <narrative xml:lang="fr">Stratégie internationale des Nations Unies pour la prévention de catastrophes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2136,10 +1424,6 @@
                 <narrative>United Nations Framework Convention on Climate Change</narrative>
                 <narrative xml:lang="fr">Convention-cadre des Nations unies sur les changements climatiques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -2148,10 +1432,6 @@
                 <narrative>Green Climate Fund</narrative>
                 <narrative xml:lang="fr">Fonds vert pour le climat</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2160,10 +1440,6 @@
                 <narrative>Global Mechanism</narrative>
                 <narrative xml:lang="fr">Mécanisme mondial</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2172,10 +1448,6 @@
                 <narrative>World Tourism Organization</narrative>
                 <narrative xml:lang="fr">Organisation mondiale du tourisme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2184,10 +1456,6 @@
                 <narrative>Technology Bank for Least Developed Countries</narrative>
                 <narrative xml:lang="fr">Banque de Technologies en faveur des Pays les Moins Avancés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2196,10 +1464,6 @@
                 <narrative>UN inter-agency pooled funds</narrative>
                 <narrative xml:lang="fr">Fonds communs interinstitutions des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41401</code>
@@ -2207,10 +1471,6 @@
                 <narrative>UN-Multi Partner Trust Fund Office</narrative>
                 <narrative xml:lang="fr">UN-Multi Partner Trust Fund Office</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41400</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2219,10 +1479,6 @@
                 <narrative>UN single-agency thematic funds</narrative>
                 <narrative xml:lang="fr">Fonds thématiques uniques des Nations Unies</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41501</code>
@@ -2230,10 +1486,6 @@
                 <narrative>United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2242,10 +1494,6 @@
                 <narrative>United Nations Office for Project Services</narrative>
                 <narrative xml:lang="fr">Le Bureau des Nations Unies pour les services d'appui aux projets</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41300</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2254,10 +1502,6 @@
                 <narrative>UN-led Country-based Pooled Funds</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41400</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2277,10 +1521,6 @@
                 <narrative>European Union Institutions</narrative>
                 <narrative xml:lang="fr">Institutions de l'Union européenne</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>42001</code>
@@ -2288,10 +1528,6 @@
                 <narrative>European Commission - Development Share of Budget</narrative>
                 <narrative xml:lang="fr">Commission européenne - partie du budget affectée au développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>42000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2300,10 +1536,6 @@
                 <narrative>European Commission - European Development Fund</narrative>
                 <narrative xml:lang="fr">Commission européenne - Fonds européen de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>42000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2312,10 +1544,6 @@
                 <narrative>European Investment Bank</narrative>
                 <narrative xml:lang="fr">Banque européenne d'investissement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>42000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2004-01-01" withdrawal-date="2009-12-31">
@@ -2324,10 +1552,6 @@
                 <narrative>Facility for Euro-Mediterranean Investment and Partnership Trust Fund</narrative>
                 <narrative xml:lang="fr">Facility for Euro-Mediterranean Investment and Partnership Trust Fund</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>42000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2336,10 +1560,6 @@
                 <narrative>International Monetary Fund (IMF)</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international (FMI)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>43001</code>
@@ -2347,10 +1567,6 @@
                 <narrative>International Monetary Fund - Poverty Reduction and Growth Trust</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>43000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2359,10 +1575,6 @@
                 <narrative>International Monetary Fund - Poverty Reduction and Growth - Heavily Indebted Poor Countries Debt Relief Initiative Trust Fund [includes HIPC, Extended Credit Facility (ECF), and ECF-HIPC sub-accounts]</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international – Réduction de la pauvreté et croissance – Initiative d’allègement de la dette en faveur des pays pauvres très endettés [y compris Initiative PPTE, Facilité élargie de crédit (FEC) et sous-comptes (FEC-PPTE)]</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>43000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
@@ -2371,10 +1583,6 @@
                 <narrative>International Monetary Fund - Subsidization of Emergency Post Conflict Assistance/Emergency Assistance for Natural Disasters for PRGT-eligible members</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international – Aide d’urgence après un conflit (EPCA) et aide d’urgence à la suite de catastrophes naturelles (ENDA) pour les membres pouvant bénéficier de la FRPC</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>43000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -2383,10 +1591,6 @@
                 <narrative>International Monetary Fund - Poverty Reduction and Growth - Multilateral Debt Relief Initiative Trust</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance – Initiative d’allègement de la dette multilatérale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>43000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -2395,10 +1599,6 @@
                 <narrative>International Monetary Fund - Post-Catastrophe Debt Relief Trust</narrative>
                 <narrative xml:lang="fr">Fonds monétaire international  - Fonds fiduciaire pour l'allégement de la dette après une catastrophe</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>43000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -2407,10 +1607,6 @@
                 <narrative>Catastrophe Containment and Relief Trust</narrative>
                 <narrative xml:lang="fr">Fonds fiduciaire d’assistance et de riposte aux catastrophes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>43000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2419,10 +1615,6 @@
                 <narrative>World Bank Group (WB)</narrative>
                 <narrative xml:lang="fr">Groupe de la Banque mondiale (BM)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>44001</code>
@@ -2430,10 +1622,6 @@
                 <narrative>International Bank for Reconstruction and Development</narrative>
                 <narrative xml:lang="fr">Banque internationale pour la reconstruction et le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2442,10 +1630,6 @@
                 <narrative>International Development Association</narrative>
                 <narrative xml:lang="fr">Association internationale de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2454,10 +1638,6 @@
                 <narrative>International Development Association - Heavily Indebted Poor Countries Debt Initiative Trust Fund</narrative>
                 <narrative xml:lang="fr">Association internationale de développement - Fonds fiduciaire de l'IDA en faveur des pays pauvres très endettés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2466,10 +1646,6 @@
                 <narrative>International Finance Corporation</narrative>
                 <narrative xml:lang="fr">Société financière internationale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2478,10 +1654,6 @@
                 <narrative>Multilateral Investment Guarantee Agency</narrative>
                 <narrative xml:lang="fr">Agence multilatérale de garantie des investissements</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
@@ -2490,10 +1662,6 @@
                 <narrative>Advance Market Commitments</narrative>
                 <narrative xml:lang="fr">Garanties de marché</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -2502,10 +1670,6 @@
                 <narrative>International Development Association - Multilateral Debt Relief Initiative</narrative>
                 <narrative xml:lang="fr">Association internationale de développement - Initiative d’allégement de la dette multilatérale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>44000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2514,10 +1678,6 @@
                 <narrative>World Trade Organisation (WTO)</narrative>
                 <narrative xml:lang="fr">Organisation mondiale du commerce (OMC)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>45001</code>
@@ -2525,10 +1685,6 @@
                 <narrative>World Trade Organisation - International Trade Centre</narrative>
                 <narrative xml:lang="fr">Centre du commerce international de l'Organisation mondiale du commerce</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2537,10 +1693,6 @@
                 <narrative>World Trade Organisation - Advisory Centre on WTO Law</narrative>
                 <narrative xml:lang="fr">Centre consultatif sur la législation de l'Organisation mondiale du commerce</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -2549,10 +1701,6 @@
                 <narrative>World Trade Organisation - Doha Development Agenda Global Trust Fund</narrative>
                 <narrative xml:lang="fr">Organisation mondiale du commerce - Fonds global d'affectation spéciale pour le Programme de Doha pour le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2561,10 +1709,6 @@
                 <narrative>Regional Development Banks</narrative>
                 <narrative xml:lang="fr">Banques régionales de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46002</code>
@@ -2572,10 +1716,6 @@
                 <narrative>African Development Bank</narrative>
                 <narrative xml:lang="fr">Banque africaine de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2584,10 +1724,6 @@
                 <narrative>African Development Fund</narrative>
                 <narrative xml:lang="fr">Fonds africain de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2596,10 +1732,6 @@
                 <narrative>Asian Development Bank</narrative>
                 <narrative xml:lang="fr">Banque asiatique de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2608,10 +1740,6 @@
                 <narrative>Asian Development Fund</narrative>
                 <narrative xml:lang="fr">Fonds asiatique de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2008-01-01">
@@ -2620,10 +1748,6 @@
                 <narrative>Black Sea Trade and Development Bank</narrative>
                 <narrative xml:lang="fr">Black Sea Trade and Development Bank</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2632,10 +1756,6 @@
                 <narrative>Central American Bank for Economic Integration</narrative>
                 <narrative xml:lang="fr">Banque centroaméricaine d'intégration économique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2644,10 +1764,6 @@
                 <narrative>Development Bank of Latin America</narrative>
                 <narrative xml:lang="fr">Banque de développement de l'Amérique latine</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2656,10 +1772,6 @@
                 <narrative>Caribbean Development Bank</narrative>
                 <narrative xml:lang="fr">Banque de développement des Caraïbes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2668,10 +1780,6 @@
                 <narrative>Inter-American Development Bank, Inter-American Investment Corporation and Multilateral Investment Fund</narrative>
                 <narrative xml:lang="fr">Banque interaméricaine de développement, Société interaméricaine d'investissements, Fonds multilatéral d'investissements</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2680,10 +1788,6 @@
                 <narrative>Inter-American Development Bank, Fund for Special Operations</narrative>
                 <narrative xml:lang="fr">Banque interaméricaine de développement, Fonds opérations spécial</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -2692,10 +1796,6 @@
                 <narrative>European Bank for Reconstruction and Development</narrative>
                 <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -2704,10 +1804,6 @@
                 <narrative>European Bank for Reconstruction and Development – technical co-operation and special funds (ODA-eligible countries only)</narrative>
                 <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (pays éligibles à l'APD)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -2716,10 +1812,6 @@
                 <narrative>European Bank for Reconstruction and Development – technical co-operation and special funds (all EBRD countries of operations)</narrative>
                 <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (tous pays)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -2728,10 +1820,6 @@
                 <narrative>European Bank for Reconstruction and Development - Early Transition Countries Fund</narrative>
                 <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Initiative en faveur des pays en transition précoce</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -2740,10 +1828,6 @@
                 <narrative>European Bank for Reconstruction and Development - Western Balkans Joint Trust Fund</narrative>
                 <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Fonds spécial pour les Balkans occidentaux</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -2752,10 +1836,6 @@
                 <narrative>Central African States Development Bank</narrative>
                 <narrative xml:lang="fr">Banque de développement des États de l'Afrique Centrale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -2764,10 +1844,6 @@
                 <narrative>West African Development Bank</narrative>
                 <narrative xml:lang="fr">Banque ouest-africaine de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
@@ -2776,10 +1852,6 @@
                 <narrative>African Export Import Bank</narrative>
                 <narrative xml:lang="fr">Banque Africaine d'Import-Export</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
@@ -2788,10 +1860,6 @@
                 <narrative>Eastern and Southern African Trade and Development Bank</narrative>
                 <narrative xml:lang="fr">Banque de l’Afrique de l’Est et de l’Afrique Australe pour le Commerce et le Développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
@@ -2800,10 +1868,6 @@
                 <narrative>Council of Europe Development Bank</narrative>
                 <narrative xml:lang="fr">Banque de Développement du Conseil de l'Europe</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
@@ -2812,10 +1876,6 @@
                 <narrative>Islamic Development Bank</narrative>
                 <narrative xml:lang="fr">Banque Islamique de Développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -2824,10 +1884,6 @@
                 <narrative>Asian Infrastructure Investment Bank</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
@@ -2836,10 +1892,6 @@
                 <narrative>Financial Fund for the Development of the River Plate Basin</narrative>
                 <narrative xml:lang="fr">Fonds financier pour le développement du bassin fluvial de la Plata</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>46000</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2848,10 +1900,6 @@
                 <narrative>Other multilateral institutions</narrative>
                 <narrative xml:lang="fr">Autres institutions multilatérales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2000-01-01">
             <code>47001</code>
@@ -2859,10 +1907,6 @@
                 <narrative>African Capacity Building Foundation</narrative>
                 <narrative xml:lang="fr">Fondation pour le renforcement des capacités en Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2871,10 +1915,6 @@
                 <narrative>Asian Productivity Organisation</narrative>
                 <narrative xml:lang="fr">Organisation asiatique de productivité</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2883,10 +1923,6 @@
                 <narrative>Association of South East Asian Nations: Economic Co-operation</narrative>
                 <narrative xml:lang="fr">Association des nations de l'Asie du Sud-Est - coopération économique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -2895,10 +1931,6 @@
                 <narrative>ASEAN Cultural Fund</narrative>
                 <narrative xml:lang="fr">ASEAN Cultural Fund</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2907,10 +1939,6 @@
                 <narrative>African Union (excluding peacekeeping facilities)</narrative>
                 <narrative xml:lang="fr">Union Africaine (à l'exclusion de la Facilité de soutien à la paix)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -2919,10 +1947,6 @@
                 <narrative>World Vegetable Centre</narrative>
                 <narrative xml:lang="fr">Centre international de cultures maraîchères</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2931,10 +1955,6 @@
                 <narrative>African and Malagasy Council for Higher Education</narrative>
                 <narrative xml:lang="fr">Conseil africain et malgache pour l'enseignement supérieur</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -2943,10 +1963,6 @@
                 <narrative>Commonwealth Agency for Public Administration and Management</narrative>
                 <narrative xml:lang="fr">Agence du Commonwealth pour l'administration et la gestion publiques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
@@ -2955,10 +1971,6 @@
                 <narrative>Caribbean Community Secretariat</narrative>
                 <narrative xml:lang="fr">Secrétariat de la Communauté des Caraïbes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2967,10 +1979,6 @@
                 <narrative>Caribbean Epidemiology Centre</narrative>
                 <narrative xml:lang="fr">Centre épidémiologique des Caraïbes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -2979,10 +1987,6 @@
                 <narrative>Commonwealth Foundation</narrative>
                 <narrative xml:lang="fr">Fondation du Commonwealth</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -2991,10 +1995,6 @@
                 <narrative>Commonwealth Fund for Technical Co-operation</narrative>
                 <narrative xml:lang="fr">Commonwealth Fund for Technical Co-operation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3003,10 +2003,6 @@
                 <narrative>CGIAR Fund</narrative>
                 <narrative xml:lang="fr">CGIAR Fund</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2009-12-31">
@@ -3015,10 +2011,6 @@
                 <narrative>Commonwealth Institute</narrative>
                 <narrative xml:lang="fr">Commonwealth Institute</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3027,10 +2019,6 @@
                 <narrative>International Centre for Tropical Agriculture</narrative>
                 <narrative xml:lang="fr">Centre international d'agriculture tropicale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3039,10 +2027,6 @@
                 <narrative>Centre for International Forestry Research</narrative>
                 <narrative xml:lang="fr">Centre de recherche forestière internationale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3051,10 +2035,6 @@
                 <narrative>International Centre for Advanced Mediterranean Agronomic Studies</narrative>
                 <narrative xml:lang="fr">Centre international de hautes études agronomique méditerranéennes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3063,10 +2043,6 @@
                 <narrative>International Maize and Wheat Improvement Centre</narrative>
                 <narrative xml:lang="fr">Centre international d’amélioration du maïs et du blé</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3075,10 +2051,6 @@
                 <narrative>International Potato Centre</narrative>
                 <narrative xml:lang="fr">Centre international de la pomme de terre</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3087,10 +2059,6 @@
                 <narrative>Convention on International Trade in Endangered Species of Wild Flora and Fauna</narrative>
                 <narrative xml:lang="fr">Convention sur le commerce international des espèces de faune et de flore sauvages menacées d'extinction</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3099,10 +2067,6 @@
                 <narrative>Commonwealth Legal Advisory Service</narrative>
                 <narrative xml:lang="fr">Commonwealth Legal Advisory Service</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3111,10 +2075,6 @@
                 <narrative>Commonwealth Media Development Fund</narrative>
                 <narrative xml:lang="fr">Commonwealth Media Development Fund</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3123,10 +2083,6 @@
                 <narrative>Commonwealth of Learning</narrative>
                 <narrative xml:lang="fr">Commonwealth of Learning</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
@@ -3135,10 +2091,6 @@
                 <narrative>Community of Portuguese Speaking Countries</narrative>
                 <narrative xml:lang="fr">Communauté des pays de langue portugaise</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3147,10 +2099,6 @@
                 <narrative>Colombo Plan</narrative>
                 <narrative xml:lang="fr">Plan de Colombo</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3159,10 +2107,6 @@
                 <narrative>Commonwealth Partnership for Technical Management</narrative>
                 <narrative xml:lang="fr">Partenariat pour la gestion technique (Commonwealth)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>32000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3171,10 +2115,6 @@
                 <narrative>Sahel and West Africa Club</narrative>
                 <narrative xml:lang="fr">Club du Sahel et de l’Afrique de l’Ouest</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2009-12-31">
@@ -3183,10 +2123,6 @@
                 <narrative>Commonwealth Scientific Council</narrative>
                 <narrative xml:lang="fr">Commonwealth Scientific Council</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3195,10 +2131,6 @@
                 <narrative>Commonwealth Small States Office</narrative>
                 <narrative xml:lang="fr">Commonwealth Small States Office</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2009-12-31">
@@ -3207,10 +2139,6 @@
                 <narrative>Commonwealth Trade and Investment Access Facility</narrative>
                 <narrative xml:lang="fr">Commonwealth Trade and Investment Access Facility</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3219,10 +2147,6 @@
                 <narrative>Commonwealth Youth Programme</narrative>
                 <narrative xml:lang="fr">Commonwealth Youth Programme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -3231,10 +2155,6 @@
                 <narrative>Economic Community of West African States</narrative>
                 <narrative xml:lang="fr">Communauté économique des Etats de l’Afrique de l’Ouest</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3243,10 +2163,6 @@
                 <narrative>Environmental Development Action in the Third World</narrative>
                 <narrative xml:lang="fr">Environnement et développement du Tiers-monde</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>21000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3255,10 +2171,6 @@
                 <narrative>European and Mediterranean Plant Protection Organisation</narrative>
                 <narrative xml:lang="fr">Organisation Européenne et Méditerranéenne pour la Protection des Plantes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3267,10 +2179,6 @@
                 <narrative>Eastern-Regional Organisation of Public Administration</narrative>
                 <narrative xml:lang="fr">Organisation régionale de l'Orient pour l'administration publique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3279,10 +2187,6 @@
                 <narrative>INTERPOL Fund for Aid and Technical Assistance to Developing Countries</narrative>
                 <narrative xml:lang="fr">INTERPOL Fund for Aid and Technical Assistance to Developing Countries</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3291,10 +2195,6 @@
                 <narrative>Forum Fisheries Agency</narrative>
                 <narrative xml:lang="fr">Agence des pêches</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3303,10 +2203,6 @@
                 <narrative>Food and Fertilizer Technology Centre</narrative>
                 <narrative xml:lang="fr">Centre des techniques de l'alimentation et des engrais</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3315,10 +2211,6 @@
                 <narrative>Foundation for International Training</narrative>
                 <narrative xml:lang="fr">Fondation pour la formation internationale dans les pays du tiers monde</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>22000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3327,10 +2219,6 @@
                 <narrative>Global Crop Diversity Trust</narrative>
                 <narrative xml:lang="fr">Global Crop Diversity Trust</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>31000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -3339,10 +2227,6 @@
                 <narrative>Global Environment Facility Trust Fund</narrative>
                 <narrative xml:lang="fr">Fonds pour l'environnement mondial - fonds fiduciaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -3351,10 +2235,6 @@
                 <narrative>Global Fund to Fight AIDS, Tuberculosis and Malaria</narrative>
                 <narrative xml:lang="fr">Fonds mondial de lutte contre le SIDA, la tuberculose et la paludisme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3363,10 +2243,6 @@
                 <narrative>International Organisation of the Francophonie</narrative>
                 <narrative xml:lang="fr">Organisation internationale de la Francophonie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3375,10 +2251,6 @@
                 <narrative>International African Institute</narrative>
                 <narrative xml:lang="fr">Institut international africain</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3387,10 +2259,6 @@
                 <narrative>Inter-American Indian Institute</narrative>
                 <narrative xml:lang="fr">Inter-American Indian Institute</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3399,10 +2267,6 @@
                 <narrative>International Bureau of Education - International Educational Reporting System (IERS)</narrative>
                 <narrative xml:lang="fr">International Bureau of Education - International Educational Reporting System (IERS)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3411,10 +2275,6 @@
                 <narrative>International Cotton Advisory Committee</narrative>
                 <narrative xml:lang="fr">Comité consultatif international du coton</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3423,10 +2283,6 @@
                 <narrative>International Centre for Agricultural Research in Dry Areas</narrative>
                 <narrative xml:lang="fr">Centre international de recherche agricole dans les zones arides</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3435,10 +2291,6 @@
                 <narrative>International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
                 <narrative xml:lang="fr">International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3447,10 +2299,6 @@
                 <narrative>International Centre of Insect Physiology and Ecology</narrative>
                 <narrative xml:lang="fr">Centre international sur la physiologie et l’écologie des insectes</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3459,10 +2307,6 @@
                 <narrative>International Centre for Development Oriented Research in Agriculture</narrative>
                 <narrative xml:lang="fr">Centre International pour la Recherche Agricole orientée vers le développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3471,10 +2315,6 @@
                 <narrative>World AgroForestry Centre</narrative>
                 <narrative xml:lang="fr">Centre mondial de l’agroforesterie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3483,10 +2323,6 @@
                 <narrative>International Crop Research for Semi-Arid Tropics</narrative>
                 <narrative xml:lang="fr">Institut international de recherche sur les cultures des zones tropicales semi-arides</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -3495,10 +2331,6 @@
                 <narrative>International Institute for Democracy and Electoral Assistance</narrative>
                 <narrative xml:lang="fr">International Institute for Democracy and Electoral Assistance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3507,10 +2339,6 @@
                 <narrative>International Development Law Organisation</narrative>
                 <narrative xml:lang="fr">Organisation internationale de droit du développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3519,10 +2347,6 @@
                 <narrative>International Institute for Cotton</narrative>
                 <narrative xml:lang="fr">International Institute for Cotton</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3531,10 +2355,6 @@
                 <narrative>Inter-American Institute for Co-operation on Agriculture</narrative>
                 <narrative xml:lang="fr">Institut interaméricain de coopération pour l’agriculture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3543,10 +2363,6 @@
                 <narrative>International Institute of Tropical Agriculture</narrative>
                 <narrative xml:lang="fr">Institut international d’agriculture tropicale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3555,10 +2371,6 @@
                 <narrative>International Livestock Research Institute</narrative>
                 <narrative xml:lang="fr">International Livestock Research Institute</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
@@ -3567,10 +2379,6 @@
                 <narrative>International Network for Bamboo and Rattan</narrative>
                 <narrative xml:lang="fr">Réseau International sur le bambou et le rotin</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -3579,10 +2387,6 @@
                 <narrative>Intergovernmental Oceanographic Commission</narrative>
                 <narrative xml:lang="fr">Commission océanographique intergouvernementale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -3591,10 +2395,6 @@
                 <narrative>International Organisation for Migration</narrative>
                 <narrative xml:lang="fr">Organisation internationale des migrations</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3603,10 +2403,6 @@
                 <narrative>Intergovernmental Panel on Climate Change</narrative>
                 <narrative xml:lang="fr">Groupe d’experts intergouvernemental sur l’évolution du climat</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3615,10 +2411,6 @@
                 <narrative>Asia-Pacific Fishery Commission</narrative>
                 <narrative xml:lang="fr">Commission Asie-Pacifique des pêches</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3627,10 +2419,6 @@
                 <narrative>Bioversity International</narrative>
                 <narrative xml:lang="fr">Bioversity International</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3639,10 +2427,6 @@
                 <narrative>International Rice Research Institute</narrative>
                 <narrative xml:lang="fr">Institut international de recherche sur le riz</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3651,10 +2435,6 @@
                 <narrative>International Seed Testing Association</narrative>
                 <narrative xml:lang="fr">Association internationale d’essais de semences</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2001-01-01">
@@ -3663,10 +2443,6 @@
                 <narrative>International Tropical Timber Organisation</narrative>
                 <narrative xml:lang="fr">Organisation Internationale des Bois Tropicaux</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3675,10 +2451,6 @@
                 <narrative>International Vaccine Institute</narrative>
                 <narrative xml:lang="fr">Institut international de vaccins</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3687,10 +2459,6 @@
                 <narrative>International Water Management Institute</narrative>
                 <narrative xml:lang="fr">Institut international de gestion des ressources en eau</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
@@ -3699,10 +2467,6 @@
                 <narrative>Justice Studies Centre of the Americas</narrative>
                 <narrative xml:lang="fr">Centre d’études sur la justice dans les Amériques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -3711,10 +2475,6 @@
                 <narrative>Mekong River Commission</narrative>
                 <narrative xml:lang="fr">Commission du Mékong</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -3723,10 +2483,6 @@
                 <narrative>Multilateral Fund for the Implementation of the Montreal Protocol</narrative>
                 <narrative xml:lang="fr">Fonds multilatéral pour l’application du Protocole de Montréal</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3735,10 +2491,6 @@
                 <narrative>Organisation of American States</narrative>
                 <narrative xml:lang="fr">Organisation des États américains</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3747,10 +2499,6 @@
                 <narrative>Organisation for Economic Co-operation and Development (Contributions to special funds for Technical Co-operation Activities Only)</narrative>
                 <narrative xml:lang="fr">Organisation de Coopération et de développement économiques (contributions aux fonds spéciaux pour les activités de coopération technique uniquement)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
@@ -3759,10 +2507,6 @@
                 <narrative>OECD Development Centre</narrative>
                 <narrative xml:lang="fr">OCDE Centre de développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
@@ -3771,10 +2515,6 @@
                 <narrative>Organisation of Eastern Caribbean States</narrative>
                 <narrative xml:lang="fr">Organisation des États des Caraïbes orientales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
@@ -3783,10 +2523,6 @@
                 <narrative>Pan-American Health Organisation</narrative>
                 <narrative xml:lang="fr">Organisation panaméricaine de la santé</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41100</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3795,10 +2531,6 @@
                 <narrative>Pan-American Institute of Geography and History</narrative>
                 <narrative xml:lang="fr">Institut panaméricain de géographie et d’histoire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3807,10 +2539,6 @@
                 <narrative>Pan-American Railway Congress Association</narrative>
                 <narrative xml:lang="fr">Pan-American Railway Congress Association</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -3819,10 +2547,6 @@
                 <narrative>Private Infrastructure Development Group</narrative>
                 <narrative xml:lang="fr">Private Infrastructure Development Group</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3831,10 +2555,6 @@
                 <narrative>Pacific Islands Forum Secretariat</narrative>
                 <narrative xml:lang="fr">Secrétariat du Forum des Iles du Pacifique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3843,10 +2563,6 @@
                 <narrative>Relief Net</narrative>
                 <narrative xml:lang="fr">Relief Net</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -3855,10 +2571,6 @@
                 <narrative>Southern African Development Community</narrative>
                 <narrative xml:lang="fr">Communauté pour le développement de l’Afrique australe</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3867,10 +2579,6 @@
                 <narrative>Southern African Transport and Communications Commission</narrative>
                 <narrative xml:lang="fr">Southern African Transport and Communications Commission</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
@@ -3879,10 +2587,6 @@
                 <narrative>(Colombo Plan) Special Commonwealth African Assistance Programme</narrative>
                 <narrative xml:lang="fr">(Colombo Plan) Special Commonwealth African Assistance Programme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3891,10 +2595,6 @@
                 <narrative>South East Asian Fisheries Development Centre</narrative>
                 <narrative xml:lang="fr">Centre de développement des pêches de l’Asie du Sud-Est</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3903,10 +2603,6 @@
                 <narrative>South East Asian Ministers of Education</narrative>
                 <narrative xml:lang="fr">Organisation des Ministres de l’éducation de l’Asie du Sud-Est</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2000-01-01" withdrawal-date="2010-12-31">
@@ -3915,10 +2611,6 @@
                 <narrative>South Pacific Applied Geoscience Commission</narrative>
                 <narrative xml:lang="fr">South Pacific Applied Geoscience Commission</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2000-01-01">
@@ -3927,10 +2619,6 @@
                 <narrative>South Pacific Board for Educational Assessment</narrative>
                 <narrative xml:lang="fr">Conseil d’évaluation du Pacifique Sud pour l'éducation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3939,10 +2627,6 @@
                 <narrative>Secretariat of the Pacific Community</narrative>
                 <narrative xml:lang="fr">Secrétariat Général de la Communauté du Pacifique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3951,10 +2635,6 @@
                 <narrative>Pacific Regional Environment Programme</narrative>
                 <narrative xml:lang="fr">Programme régional océanien de l’environnement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
@@ -3963,10 +2643,6 @@
                 <narrative>Unrepresented Nations and Peoples’ Organisation</narrative>
                 <narrative xml:lang="fr">Organisation des peuples et des nations non représentés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3975,10 +2651,6 @@
                 <narrative>University of the South Pacific</narrative>
                 <narrative xml:lang="fr">Université du Pacifique Sud</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
@@ -3987,10 +2659,6 @@
                 <narrative>West African Monetary Union</narrative>
                 <narrative xml:lang="fr">Union monétaire ouest-africaine</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -3999,10 +2667,6 @@
                 <narrative>Africa Rice Centre</narrative>
                 <narrative xml:lang="fr">Centre du riz pour l’Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2000-01-01" withdrawal-date="2012-12-31">
@@ -4011,10 +2675,6 @@
                 <narrative>World Customs Organisation Fellowship Programme</narrative>
                 <narrative xml:lang="fr">Organisation mondiale des douanes, programme de bourses</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -4023,10 +2683,6 @@
                 <narrative>World Maritime University</narrative>
                 <narrative xml:lang="fr">Université maritime mondiale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -4035,10 +2691,6 @@
                 <narrative>WorldFish Centre</narrative>
                 <narrative xml:lang="fr">Centre international pour l’aménagement des ressources bioaquatiques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2001-01-01">
@@ -4047,10 +2699,6 @@
                 <narrative>Common Fund for Commodities</narrative>
                 <narrative xml:lang="fr">Fonds commun pour les produits de base</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
@@ -4059,10 +2707,6 @@
                 <narrative>Geneva Centre for the Democratic Control of Armed Forces</narrative>
                 <narrative xml:lang="fr">Centre de contrôle démocratique des forces armées - Genève</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
@@ -4071,10 +2715,6 @@
                 <narrative>International Finance Facility for Immunisation</narrative>
                 <narrative xml:lang="fr">Facilité internationale de financement pour la vaccination</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2006-01-01" withdrawal-date="2010-12-31">
@@ -4083,10 +2723,6 @@
                 <narrative>Multi-Country Demobilisation and Reintegration Program</narrative>
                 <narrative xml:lang="fr">Multi-Country Demobilisation and Reintegration Program</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
@@ -4095,10 +2731,6 @@
                 <narrative>Asia-Pacific Economic Cooperation Support Fund (except contributions tied to counter-terrorism activities)</narrative>
                 <narrative xml:lang="fr">Fonds de soutien de la coopération économique Asie-Pacifique (hors lutte contre le terrorisme)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
@@ -4107,10 +2739,6 @@
                 <narrative>Organisation of the Black Sea Economic Cooperation</narrative>
                 <narrative xml:lang="fr">Organisation de coopération économique de la mer Noire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4119,10 +2747,6 @@
                 <narrative>Adaptation Fund</narrative>
                 <narrative xml:lang="fr">Fonds pour l’adaptation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4131,10 +2755,6 @@
                 <narrative>Central European Initiative - Special Fund for Climate and Environmental Protection</narrative>
                 <narrative xml:lang="fr">Initiative de l’Europe centrale - Fonds Spécial pour la protection climatique et environnementale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4143,10 +2763,6 @@
                 <narrative>Economic and Monetary Community of Central Africa</narrative>
                 <narrative xml:lang="fr">Communauté économique et monétaire de l’Afrique Centrale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4155,10 +2771,6 @@
                 <narrative>Integrated Framework for Trade-Related Technical Assistance to Least Developed Countries</narrative>
                 <narrative xml:lang="fr">Cadre intégré pour l'assistance technique liée au commerce en faveur des pays les moins avancés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4167,10 +2779,6 @@
                 <narrative>New Partnership for Africa's Development</narrative>
                 <narrative xml:lang="fr">Nouveau Partenariat pour le développement de l’Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4179,10 +2787,6 @@
                 <narrative>Regional Organisation for the Strengthening of Supreme Audit Institutions of Francophone Sub-Saharan Countries</narrative>
                 <narrative xml:lang="fr">Conseil Régional de Formation des Institutions Supérieures de Contrôle des Finances Publiques d’Afrique Francophone Subsaharienne</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4191,10 +2795,6 @@
                 <narrative>Sahara and Sahel Observatory</narrative>
                 <narrative xml:lang="fr">Observatoire du Sahara et du Sahel</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4203,10 +2803,6 @@
                 <narrative>South Asian Association for Regional Cooperation</narrative>
                 <narrative xml:lang="fr">Association de l'Asie du Sud pour la coopération régionale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4215,10 +2811,6 @@
                 <narrative>United Cities and Local Governments of Africa</narrative>
                 <narrative xml:lang="fr">Cités et gouvernements locaux unis d’Afrique</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
@@ -4227,10 +2819,6 @@
                 <narrative>Global Alliance for Vaccines and Immunization</narrative>
                 <narrative xml:lang="fr">Alliance mondiale pour la vaccination et l’immunisation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
@@ -4239,10 +2827,6 @@
                 <narrative>Geneva International Centre for Humanitarian Demining</narrative>
                 <narrative xml:lang="fr">Centre International de Déminage Humanitaire Genève</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2008-01-01">
@@ -4251,10 +2835,6 @@
                 <narrative>Latin-American Energy Organisation</narrative>
                 <narrative xml:lang="fr">Organisation latino-américaine de l'énergie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -4263,10 +2843,6 @@
                 <narrative>Nordic Development Fund</narrative>
                 <narrative xml:lang="fr">Nordic Development Fund</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -4275,10 +2851,6 @@
                 <narrative>Global Environment Facility - Least Developed Countries Fund</narrative>
                 <narrative xml:lang="fr">FEM Fonds pour les pays les moins avancés</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
@@ -4287,10 +2859,6 @@
                 <narrative>Global Environment Facility - Special Climate Change Fund</narrative>
                 <narrative xml:lang="fr">FEM Fonds spécial pour les changements climatiques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
@@ -4299,10 +2867,6 @@
                 <narrative>Organization for Security and Co-operation in Europe</narrative>
                 <narrative xml:lang="fr">Organisation pour la sécurité et la oopération en Europe</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
@@ -4311,10 +2875,6 @@
                 <narrative>Commonwealth Secretariat (ODA-eligible contributions only)</narrative>
                 <narrative xml:lang="fr">Secrétariat du Commonwealth (seulement les contributions éligibles à l'APD)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
@@ -4323,10 +2883,6 @@
                 <narrative>Clean Technology Fund</narrative>
                 <narrative xml:lang="fr">Fonds pour les technologies propres</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
@@ -4335,10 +2891,6 @@
                 <narrative>Strategic Climate Fund</narrative>
                 <narrative xml:lang="fr">Fonds stratégique pour le climat</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
@@ -4347,10 +2899,6 @@
                 <narrative>Global Green Growth Institute</narrative>
                 <narrative xml:lang="fr">Institut mondial de la croissance verte</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
@@ -4359,10 +2907,6 @@
                 <narrative>African Risk Capacity Group</narrative>
                 <narrative xml:lang="fr">Mutuelle panafricaine de gestion des risques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
@@ -4371,10 +2915,6 @@
                 <narrative>Council of Europe</narrative>
                 <narrative xml:lang="fr">Conseil de l’Europe</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
@@ -4383,10 +2923,6 @@
                 <narrative>World Customs Organization Customs Co-operation Fund</narrative>
                 <narrative xml:lang="fr">Organisation Mondiale des Douanes Fonds de coopération douanière</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
@@ -4395,10 +2931,6 @@
                 <narrative>Organisation of Ibero-American States for Education, Science and Culture</narrative>
                 <narrative xml:lang="fr">Organisation des états ibéro-américains pour l'éducation, la science et la culture (OEI)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -4407,10 +2939,6 @@
                 <narrative>African Tax Administration Forum</narrative>
                 <narrative xml:lang="fr">Forum sur l’Administration Fiscale Africaine</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -4419,10 +2947,6 @@
                 <narrative>OPEC Fund for International Development</narrative>
                 <narrative xml:lang="fr">Le Fonds OPEP pour le développement international</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -4431,10 +2955,6 @@
                 <narrative>Global Community Engagement and Resilience Fund</narrative>
                 <narrative xml:lang="fr">Fonds mondial pour l’engagement de la communauté et la résilience</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
@@ -4443,10 +2963,6 @@
                 <narrative>International Renewable Energy Agency</narrative>
                 <narrative xml:lang="fr">Agence internationale pour les energies renouvelables</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4455,10 +2971,6 @@
                 <narrative>Center of Excellence in Finance</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
@@ -4467,10 +2979,6 @@
                 <narrative>International Investment Bank</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
@@ -4479,10 +2987,6 @@
                 <narrative>International Finance Facility for Education</narrative>
                 <narrative xml:lang="fr">Facilité internationale de financement pour l'éducation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
@@ -4491,10 +2995,6 @@
                 <narrative>World Organisation for Animal Health</narrative>
                 <narrative xml:lang="fr">Organisation mondiale de la santé animale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4503,10 +3003,6 @@
                 <narrative>European Space Agency (ESA) programme 'Space in support of International Development Aid'</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -4515,10 +3011,6 @@
                 <narrative>Global Partnership for Education</narrative>
                 <narrative xml:lang="fr">Partenariat Mondial pour l'Education</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -4527,10 +3019,6 @@
                 <narrative>Global Fund for Disaster Risk Reduction</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -4539,10 +3027,6 @@
                 <narrative>Global Agriculture and Food Security Program</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
@@ -4551,10 +3035,6 @@
                 <narrative>Forest Carbon Partnership Facility</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>47000</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -4563,10 +3043,6 @@
                 <narrative>Others</narrative>
                 <narrative xml:lang="fr">Autres</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>51000</code>
@@ -4574,10 +3050,6 @@
                 <narrative>University, college or other teaching institution, research institute or think-tank</narrative>
                 <narrative xml:lang="fr">Université, collège ou autre établissement d'enseignement, institut de recherche ou de réflexion</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>51001</code>
@@ -4585,10 +3057,6 @@
                 <narrative>International Food Policy Research Institute</narrative>
                 <narrative xml:lang="fr">Institut International de Recherche sur les Politiques Alimentaires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>51000</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -4597,10 +3065,6 @@
                 <narrative>Other</narrative>
                 <narrative xml:lang="fr">Autre</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>60000</code>
@@ -4608,10 +3072,6 @@
                 <narrative>Private Sector Institutions</narrative>
                 <narrative xml:lang="fr">Institutions du secteur privé</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61000</code>
@@ -4619,10 +3079,6 @@
                 <narrative>Private sector in provider country</narrative>
                 <narrative xml:lang="fr">Secteur privé du pays donneur</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61001</code>
@@ -4630,10 +3086,6 @@
                 <narrative>Banks (deposit taking corporations)</narrative>
                 <narrative xml:lang="fr">Banques (institutions de dépôts)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2016-01-01">
@@ -4642,10 +3094,6 @@
                 <narrative>Private exporter in provider country</narrative>
                 <narrative xml:lang="fr">Exportateur privé dans le pays donneur</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4654,10 +3102,6 @@
                 <narrative>Investment funds and other collective investment institutions</narrative>
                 <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4666,10 +3110,6 @@
                 <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4678,10 +3118,6 @@
                 <narrative>Insurance Corporations</narrative>
                 <narrative xml:lang="fr">Sociétés d’assurance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4690,10 +3126,6 @@
                 <narrative>Pension Funds</narrative>
                 <narrative xml:lang="fr">Fonds de pension</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4702,10 +3134,6 @@
                 <narrative>Other financial corporations</narrative>
                 <narrative xml:lang="fr">Autres sociétés financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4714,10 +3142,6 @@
                 <narrative>Exporters</narrative>
                 <narrative xml:lang="fr">Exportateurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4726,10 +3150,6 @@
                 <narrative>Other non-financial corporations</narrative>
                 <narrative xml:lang="fr">Autres sociétés non financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4738,10 +3158,6 @@
                 <narrative>Retail investors</narrative>
                 <narrative xml:lang="fr">Investisseurs individuels</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4750,10 +3166,6 @@
                 <narrative>Private sector in recipient country</narrative>
                 <narrative xml:lang="fr">Secteur privé du pays bénéficiaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62001</code>
@@ -4761,10 +3173,6 @@
                 <narrative>Banks (deposit taking corporations except Micro Finance Institutions)</narrative>
                 <narrative xml:lang="fr">Banques (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4773,10 +3181,6 @@
                 <narrative>Micro Finance Institutions (deposit and non-deposit)</narrative>
                 <narrative xml:lang="fr">Institutions de microfinancement (collectant ou pas des dépôts)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4785,10 +3189,6 @@
                 <narrative>Investment funds and other collective investment institutions</narrative>
                 <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4797,10 +3197,6 @@
                 <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4809,10 +3205,6 @@
                 <narrative>Insurance Corporations</narrative>
                 <narrative xml:lang="fr">Sociétés d’assurance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4821,10 +3213,6 @@
                 <narrative>Pension Funds</narrative>
                 <narrative xml:lang="fr">Fonds de pension</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4833,10 +3221,6 @@
                 <narrative>Other financial corporations</narrative>
                 <narrative xml:lang="fr">Autres sociétés financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4845,10 +3229,6 @@
                 <narrative>Importers/Exporters</narrative>
                 <narrative xml:lang="fr">Importateurs / Exportateurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4857,10 +3237,6 @@
                 <narrative>Other non-financial corporations</narrative>
                 <narrative xml:lang="fr">Autres sociétés non financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4869,10 +3245,6 @@
                 <narrative>Retail investors</narrative>
                 <narrative xml:lang="fr">Investisseurs individuels</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4881,10 +3253,6 @@
                 <narrative>Private sector in third country</narrative>
                 <narrative xml:lang="fr">Secteur privé d'un pays tiers</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>63001</code>
@@ -4892,10 +3260,6 @@
                 <narrative>Banks (deposit taking corporations except Micro Finance Institutions)</narrative>
                 <narrative xml:lang="fr">Banques (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -4904,10 +3268,6 @@
                 <narrative>Micro Finance Institutions (deposit and non-deposit)</narrative>
                 <narrative xml:lang="fr">Institutions de microfinancement (collectant ou pas des dépôts)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4916,10 +3276,6 @@
                 <narrative>Investment funds and other collective investment institutions</narrative>
                 <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4928,10 +3284,6 @@
                 <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4940,10 +3292,6 @@
                 <narrative>Insurance Corporations</narrative>
                 <narrative xml:lang="fr">Sociétés d’assurance</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4952,10 +3300,6 @@
                 <narrative>Pension Funds</narrative>
                 <narrative xml:lang="fr">Fonds de pension</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4964,10 +3308,6 @@
                 <narrative>Other financial corporations</narrative>
                 <narrative xml:lang="fr">Autres sociétés financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4976,10 +3316,6 @@
                 <narrative>Exporters</narrative>
                 <narrative xml:lang="fr">Exportateurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -4988,10 +3324,6 @@
                 <narrative>Other non-financial corporations</narrative>
                 <narrative xml:lang="fr">Autres sociétés non financières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
@@ -5000,10 +3332,6 @@
                 <narrative>Retail investors</narrative>
                 <narrative xml:lang="fr">Investisseurs individuels</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -5012,10 +3340,6 @@
                 <narrative>Other</narrative>
                 <narrative xml:lang="fr">Autre</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/CollaborationType.xml
+++ b/xml/CollaborationType.xml
@@ -18,10 +18,6 @@
                 <narrative>Bilateral</narrative>
                 <narrative xml:lang="fr">Bilatéral</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>2</code>
@@ -29,10 +25,6 @@
                 <narrative>Multilateral (inflows)</narrative>
                 <narrative xml:lang="fr">Multilatéral (contributions des donneurs du CAD)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>3</code>
@@ -40,10 +32,6 @@
                 <narrative>Bilateral, core contributions to NGOs and other private bodies / PPPs</narrative>
                 <narrative xml:lang="fr">Contributions bilatérales au budget général d'organisations non gouvernementales, d'autres organisations de la société civile, de partenariats publics-privés et d'instituts de recherches</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>4</code>
@@ -51,10 +39,6 @@
                 <narrative>Multilateral outflows</narrative>
                 <narrative xml:lang="fr">Apports des institutions multilatérales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>6</code>
@@ -62,10 +46,6 @@
                 <narrative>Private Sector Outflows</narrative>
                 <narrative xml:lang="fr">Apports du secteur privé</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>7</code>
@@ -73,10 +53,6 @@
                 <narrative>Bilateral, ex-post reporting on NGOs’ activities funded through core contributions</narrative>
                 <narrative xml:lang="fr">Contributions bilatérales, notification ex post des activités des ONG financées par des contributions des donneurs au budget général de l'ONG.</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>8</code>

--- a/xml/FinanceType-category.xml
+++ b/xml/FinanceType-category.xml
@@ -29,10 +29,6 @@
                 <narrative>GRANTS</narrative>
                 <narrative xml:lang="fr">DONS</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>1000</code>
@@ -40,10 +36,6 @@
                 <narrative>GUARANTEES AND OTHER UNFUNDED CONTINGENT LIABILITIES</narrative>
                 <narrative xml:lang="fr">GARANTIES ET AUTRES ENGAGEMENTS CONDITIONNELS NON PROVISIONNÉS</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>200</code>
@@ -84,10 +76,6 @@
                 <narrative>DEBT INSTRUMENTS</narrative>
                 <narrative xml:lang="fr">INSTRUMENTS DE DETTE</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>430</code>
@@ -95,10 +83,6 @@
                 <narrative>MEZZANINE FINANCE INSTRUMENTS</narrative>
                 <narrative xml:lang="fr">INSTRUMENTS DE DETTE</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>500</code>
@@ -106,10 +90,6 @@
                 <narrative>EQUITY  AND SHARES IN COLLECTIVE INVESTMENT VEHICLES</narrative>
                 <narrative xml:lang="fr">ACTIONS ET  PARTS DANS DES VEHICULES COLLECTIFS D'INVESTISSEMENT</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="active">
             <code>600</code>
@@ -150,10 +130,6 @@
                 <narrative>OTHER SECURITIES/CLAIMS</narrative>
                 <narrative xml:lang="fr">AUTRES TITRES/CREANCES</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/FinanceType.xml
+++ b/xml/FinanceType.xml
@@ -18,10 +18,6 @@
                 <narrative>GNI: Gross National Income</narrative>
                 <narrative xml:lang="fr">RNB : Revenu national brut</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>0</category>
         </codelist-item>
         <codelist-item status="active">
@@ -42,10 +38,6 @@
                 <narrative>Guarantees/insurance</narrative>
                 <narrative xml:lang="fr">Garanties/assurances</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>1000</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -54,10 +46,6 @@
                 <narrative>Subsidies to national private investors</narrative>
                 <narrative xml:lang="fr">Don hors réorganisation de la dette (y compris quasi-dons)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>100</category>
         </codelist-item>
         <codelist-item status="active">
@@ -66,10 +54,6 @@
                 <narrative>ODA % GNI</narrative>
                 <narrative xml:lang="fr">APD en % du RNB</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>0</category>
         </codelist-item>
         <codelist-item status="active">
@@ -90,10 +74,6 @@
                 <narrative>Interest subsidy to national private exporters</narrative>
                 <narrative xml:lang="fr">Bonification d’intérêt octroyée aux exportateurs privés nationaux</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>100</category>
         </codelist-item>
         <codelist-item status="active">
@@ -102,10 +82,6 @@
                 <narrative>Total Flows % GNI</narrative>
                 <narrative xml:lang="fr">Apports totaux en % du RNB</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>0</category>
         </codelist-item>
         <codelist-item status="active">
@@ -138,10 +114,6 @@
                 <narrative>Population</narrative>
                 <narrative xml:lang="fr">Population</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>0</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -150,10 +122,6 @@
                 <narrative>Aid loan excluding debt reorganisation</narrative>
                 <narrative xml:lang="fr">Prêt d’aide hors réorganisation de la dette</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -162,10 +130,6 @@
                 <narrative>Investment-related loan to developing countries</narrative>
                 <narrative xml:lang="fr">Prêt lié à un investissement dans les pays en développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -174,10 +138,6 @@
                 <narrative>Loan in a joint venture with the recipient</narrative>
                 <narrative xml:lang="fr">Prêt dans une coentreprise avec le pays bénéficiaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -186,10 +146,6 @@
                 <narrative>Loan to national private investor</narrative>
                 <narrative xml:lang="fr">Prêt à un investisseur privé national</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -198,10 +154,6 @@
                 <narrative>Loan to national private exporter</narrative>
                 <narrative xml:lang="fr">Prêt à un exportateur privé national</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -258,10 +210,6 @@
                 <narrative>Other debt securities</narrative>
                 <narrative xml:lang="fr">Autres actifs de dette</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>420</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -306,10 +254,6 @@
                 <narrative>Non-banks guaranteed export credits</narrative>
                 <narrative xml:lang="fr">Crédits à l'exportation garantis du secteur non bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>450</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -318,10 +262,6 @@
                 <narrative>Non-banks non-guaranteed portions of guaranteed export credits</narrative>
                 <narrative xml:lang="fr">Fraction non garantie des crédits à l'exportation garantis du secteur bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -330,10 +270,6 @@
                 <narrative>Bank export credits</narrative>
                 <narrative xml:lang="fr">Crédits à l'exportation du secteur bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>400</category>
         </codelist-item>
         <codelist-item status="active">
@@ -354,10 +290,6 @@
                 <narrative>Acquisition of equity not part of joint venture in developing countries</narrative>
                 <narrative xml:lang="fr">Acquisition de prises de participation en dehors des coentreprises avec les pays en développement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>500</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -366,10 +298,6 @@
                 <narrative>Other acquisition of equity</narrative>
                 <narrative xml:lang="fr">Autre acquisition de prises de participation</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>500</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -402,10 +330,6 @@
                 <narrative>Debt forgiveness:  ODA claims (P)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance APD (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -414,10 +338,6 @@
                 <narrative>Debt forgiveness: ODA claims (I)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance APD (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -426,10 +346,6 @@
                 <narrative>Debt forgiveness: OOF claims (P)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance AASP (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -438,10 +354,6 @@
                 <narrative>Debt forgiveness: OOF claims (I)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance AASP (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -450,10 +362,6 @@
                 <narrative>Debt forgiveness:  Private claims (P)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance du secteur privé (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -462,10 +370,6 @@
                 <narrative>Debt forgiveness:  Private claims (I)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance du secteur privé (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -474,10 +378,6 @@
                 <narrative>Debt forgiveness: OOF claims (DSR)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance AASP (DSR)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -486,10 +386,6 @@
                 <narrative>Debt forgiveness:  Private claims (DSR)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance du secteur privé (DSR)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -498,10 +394,6 @@
                 <narrative>Debt forgiveness: Other</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : autre</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -510,10 +402,6 @@
                 <narrative>Debt rescheduling: ODA claims (P)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance APD (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -522,10 +410,6 @@
                 <narrative>Debt rescheduling: ODA claims (I)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance APD (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -534,10 +418,6 @@
                 <narrative>Debt rescheduling: OOF claims (P)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -546,10 +426,6 @@
                 <narrative>Debt rescheduling: OOF claims (I)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -558,10 +434,6 @@
                 <narrative>Debt rescheduling:  Private claims (P)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -570,10 +442,6 @@
                 <narrative>Debt rescheduling:  Private claims (I)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -582,10 +450,6 @@
                 <narrative>Debt rescheduling: OOF claims (DSR)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (RSD)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -594,10 +458,6 @@
                 <narrative>Debt rescheduling:  Private claims (DSR)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (RSD)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -606,10 +466,6 @@
                 <narrative>Debt rescheduling: OOF claim (DSR – original loan principal)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (RSD – principal du prêt d’origine)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -618,10 +474,6 @@
                 <narrative>Debt rescheduling: OOF claim (DSR – original loan interest)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (RSD – intérêts du prêt d’origine)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -630,10 +482,6 @@
                 <narrative>Debt rescheduling: Private claim (DSR – original loan principal)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (RSD – principal du prêt d’origine)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -642,10 +490,6 @@
                 <narrative>Debt forgiveness/conversion: export credit claims (P)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance de crédit à l'exportation (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -654,10 +498,6 @@
                 <narrative>Debt forgiveness/conversion:  export credit claims (I)</narrative>
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance de crédit à l'exportation (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -666,10 +506,6 @@
                 <narrative>Debt forgiveness:  export credit claims (DSR)</narrative>
                 <narrative xml:lang="fr">Annulation de la dette : créance de crédit à l'exportation (DSR)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -678,10 +514,6 @@
                 <narrative>Debt rescheduling:  export credit claims (P)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (P)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -690,10 +522,6 @@
                 <narrative>Debt rescheduling:  export credit claims (I)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (I)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -702,10 +530,6 @@
                 <narrative>Debt rescheduling:  export credit claims (DSR)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (DSR)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
@@ -714,10 +538,6 @@
                 <narrative>Debt rescheduling:  export credit claim (DSR – original loan principal)</narrative>
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (DSR - principal du prêt originel)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -726,10 +546,6 @@
                 <narrative>Foreign direct investment, new capital outflow (includes reinvested earnings if separate identification not available)</narrative>
                 <narrative xml:lang="fr">Investissement direct international</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>700</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -738,10 +554,6 @@
                 <narrative>Other foreign direct investment, including reinvested earnings</narrative>
                 <narrative xml:lang="fr">Autre investissement direct international , y compris les bénéfices réinvestis</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>700</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -750,10 +562,6 @@
                 <narrative>Foreign direct investment, reinvested earnings</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>700</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -762,10 +570,6 @@
                 <narrative>Bank bonds</narrative>
                 <narrative xml:lang="fr">Obligations du secteur bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>800</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -774,10 +578,6 @@
                 <narrative>Non-bank  bonds</narrative>
                 <narrative xml:lang="fr">Obligations du secteur non bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>800</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -786,10 +586,6 @@
                 <narrative>Other bank securities/claims</narrative>
                 <narrative xml:lang="fr">Autres titres/créances du secteur bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>900</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -798,10 +594,6 @@
                 <narrative>Other non-bank securities/claims</narrative>
                 <narrative xml:lang="fr">Autres titres/créances du secteur non bancaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>900</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -810,10 +602,6 @@
                 <narrative>Purchase of securities from issuing agencies</narrative>
                 <narrative xml:lang="fr">Titres et autres instruments émis par les agences multilatérales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>900</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -822,10 +610,6 @@
                 <narrative>Securities and other instruments originally issued by multilateral agencies</narrative>
                 <narrative xml:lang="fr"/>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>900</category>
         </codelist-item>
     </codelist-items>

--- a/xml/Sector.xml
+++ b/xml/Sector.xml
@@ -973,10 +973,6 @@
                 <narrative>Prisons</narrative>
                 <narrative xml:lang="fr">Prisons</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>151</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
@@ -1091,10 +1087,6 @@
                 <narrative>Tax policy and administration support</narrative>
                 <narrative xml:lang="fr">Politique et administration fiscales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>151</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1467,10 +1459,6 @@
                 <narrative>Recreation and sport</narrative>
                 <narrative xml:lang="fr">Récréation et sport</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>160</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1479,10 +1467,6 @@
                 <narrative>Culture</narrative>
                 <narrative xml:lang="fr">Culture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>160</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
@@ -1671,10 +1655,6 @@
                 <narrative>Education and training in transport and storage</narrative>
                 <narrative xml:lang="fr">Education/formation dans les transports et le stockage</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>210</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1695,10 +1675,6 @@
                 <narrative>Communications policy, planning and administration</narrative>
                 <narrative xml:lang="fr">Politiques, planification et administration des communications</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>220</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1826,9 +1802,6 @@
             <name>
                 <narrative>Gas-fired power plants</narrative>
             </name>
-            <description>
-                <narrative/>
-            </description>
             <category>230</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
@@ -1836,9 +1809,6 @@
             <name>
                 <narrative>Coal-fired power plants</narrative>
             </name>
-            <description>
-                <narrative/>
-            </description>
             <category>230</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
@@ -1866,9 +1836,6 @@
             <name>
                 <narrative>Geothermal energy</narrative>
             </name>
-            <description>
-                <narrative/>
-            </description>
             <category>230</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
@@ -1949,10 +1916,6 @@
                 <narrative>Energy sector policy, planning and administration</narrative>
                 <narrative xml:lang="fr">Politiques, planification et administration du secteur de l'énergie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>231</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2273,10 +2236,6 @@
                 <narrative>Retail distribution of liquid or solid fossil fuels</narrative>
                 <narrative xml:lang="fr">Distribution au détail de carburants fossiles liquide ou solides</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>236</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
@@ -2357,10 +2316,6 @@
                 <narrative>Education/training in banking and financial services</narrative>
                 <narrative xml:lang="fr">Education/formation bancaire et dans les services financiers</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>240</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2549,10 +2504,6 @@
                 <narrative>Agricultural education/training</narrative>
                 <narrative xml:lang="fr">Education et formation dans le domaine agricole</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>311</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2669,10 +2620,6 @@
                 <narrative>Forestry education/training</narrative>
                 <narrative xml:lang="fr">Education et formation en sylviculture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>312</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2693,10 +2640,6 @@
                 <narrative>Forestry services</narrative>
                 <narrative xml:lang="fr">Services sylvicoles</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>312</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2729,10 +2672,6 @@
                 <narrative>Fishery education/training</narrative>
                 <narrative xml:lang="fr">Education et formation dans le domaine de la pêche</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>313</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2777,10 +2716,6 @@
                 <narrative>Industrial development</narrative>
                 <narrative xml:lang="fr">Développement industriel</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>321</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2801,10 +2736,6 @@
                 <narrative>Cottage industries and handicraft</narrative>
                 <narrative xml:lang="fr">Artisanat</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>321</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2861,10 +2792,6 @@
                 <narrative>Fertilizer plants</narrative>
                 <narrative xml:lang="fr">Production d'engrais chimiques</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>321</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2873,10 +2800,6 @@
                 <narrative>Cement/lime/plaster</narrative>
                 <narrative xml:lang="fr">Ciment, chaux et plâtre</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>321</category>
         </codelist-item>
         <codelist-item status="active">
@@ -2921,10 +2844,6 @@
                 <narrative>Non-ferrous metal industries</narrative>
                 <narrative xml:lang="fr">Industries des métaux non ferreux</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>321</category>
         </codelist-item>
         <codelist-item status="active">
@@ -3197,10 +3116,6 @@
                 <narrative>Tourism policy and administrative management</narrative>
                 <narrative xml:lang="fr">Politique du tourisme et gestion administrative</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>332</category>
         </codelist-item>
         <codelist-item status="active">
@@ -3269,10 +3184,6 @@
                 <narrative>Environmental education/training</narrative>
                 <narrative xml:lang="fr">Education et formation environnementales</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>410</category>
         </codelist-item>
         <codelist-item status="active">
@@ -3293,10 +3204,6 @@
                 <narrative>Multisector aid</narrative>
                 <narrative xml:lang="fr">Aide plurisectorielle</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>430</category>
         </codelist-item>
         <codelist-item status="active">
@@ -3521,10 +3428,6 @@
                 <narrative>Debt forgiveness</narrative>
                 <narrative xml:lang="fr">Annulation de la dette</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -3545,10 +3448,6 @@
                 <narrative>Rescheduling and refinancing</narrative>
                 <narrative xml:lang="fr">Rééchelonnement d'échéances et refinancement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>600</category>
         </codelist-item>
         <codelist-item status="active">
@@ -3689,10 +3588,6 @@
                 <narrative>Administrative costs (non-sector allocable)</narrative>
                 <narrative xml:lang="fr">Frais administratifs (non alloués par secteur)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>910</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
@@ -3710,9 +3605,6 @@
             <name>
                 <narrative>Support to international NGOs</narrative>
             </name>
-            <description>
-                <narrative/>
-            </description>
             <category>920</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">

--- a/xml/SectorCategory.xml
+++ b/xml/SectorCategory.xml
@@ -26,10 +26,6 @@
                 <narrative>Basic Education</narrative>
                 <narrative xml:lang="fr">Education de Base</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>113</code>
@@ -37,10 +33,6 @@
                 <narrative>Secondary Education</narrative>
                 <narrative xml:lang="fr">Education Secondaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>114</code>
@@ -48,10 +40,6 @@
                 <narrative>Post-Secondary Education</narrative>
                 <narrative xml:lang="fr">Education Post Secondaire</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>121</code>
@@ -59,10 +47,6 @@
                 <narrative>Health, General</narrative>
                 <narrative xml:lang="fr">Santé, Général</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>122</code>
@@ -70,10 +54,6 @@
                 <narrative>Basic Health</narrative>
                 <narrative xml:lang="fr">Santé de Base</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>123</code>
@@ -81,10 +61,6 @@
                 <narrative>Non-communicable diseases (NCDs)</narrative>
                 <narrative xml:lang="fr">Maladies non-transmissibles (MNT)</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>130</code>
@@ -92,10 +68,6 @@
                 <narrative>Population Policies/Programmes &amp; Reproductive Health</narrative>
                 <narrative xml:lang="fr">Politique en Matière de Population/Santé&amp;Fertilité</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>140</code>
@@ -103,10 +75,6 @@
                 <narrative>Water Supply &amp; Sanitation</narrative>
                 <narrative xml:lang="fr">Distribution d'Eau et Assainissement</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>151</code>
@@ -136,10 +104,6 @@
                 <narrative>Other Social Infrastructure &amp; Services</narrative>
                 <narrative xml:lang="fr">Infrastructure et Services Sociaux Divers</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>210</code>
@@ -158,10 +122,6 @@
                 <narrative>Communications</narrative>
                 <narrative xml:lang="fr">Communications</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>230</code>
@@ -178,10 +138,6 @@
                 <narrative>Energy Policy</narrative>
                 <narrative xml:lang="fr">Politique de l'énergie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>232</code>
@@ -189,10 +145,6 @@
                 <narrative>Energy generation, renewable sources</narrative>
                 <narrative xml:lang="fr">Production d'électricité, sources renouvelables</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>233</code>
@@ -200,10 +152,6 @@
                 <narrative>Energy generation, non-renewable sources</narrative>
                 <narrative xml:lang="fr">Production d'électricité, sources non renouvelables</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>234</code>
@@ -211,10 +159,6 @@
                 <narrative>Hybrid energy plants</narrative>
                 <narrative xml:lang="fr">Centrales hybrides</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>235</code>
@@ -222,10 +166,6 @@
                 <narrative>Nuclear energy plants</narrative>
                 <narrative xml:lang="fr">Centrales nucléaires</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>236</code>
@@ -233,10 +173,6 @@
                 <narrative>Energy distribution</narrative>
                 <narrative xml:lang="fr">Distribution de l'énergie</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>240</code>
@@ -244,10 +180,6 @@
                 <narrative>Banking &amp; Financial Services</narrative>
                 <narrative xml:lang="fr">Banques et Services Financiers</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>250</code>
@@ -255,10 +187,6 @@
                 <narrative>Business &amp; Other Services</narrative>
                 <narrative xml:lang="fr">Entreprises et Autres Services</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>311</code>
@@ -266,10 +194,6 @@
                 <narrative>Agriculture</narrative>
                 <narrative xml:lang="fr">Agriculture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>312</code>
@@ -277,10 +201,6 @@
                 <narrative>Forestry</narrative>
                 <narrative xml:lang="fr">Sylviculture</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>313</code>
@@ -288,10 +208,6 @@
                 <narrative>Fishing</narrative>
                 <narrative xml:lang="fr">Pêche</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>321</code>
@@ -299,10 +215,6 @@
                 <narrative>Industry</narrative>
                 <narrative xml:lang="fr">Industries Manufacturières</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>322</code>
@@ -310,10 +222,6 @@
                 <narrative>Mineral Resources &amp; Mining</narrative>
                 <narrative xml:lang="fr">Industries Extractives</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>323</code>
@@ -321,10 +229,6 @@
                 <narrative>Construction</narrative>
                 <narrative xml:lang="fr">Construction</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>331</code>
@@ -332,10 +236,6 @@
                 <narrative>Trade Policies &amp; Regulations</narrative>
                 <narrative xml:lang="fr">Politique Commerciale et Réglementations</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>332</code>
@@ -343,10 +243,6 @@
                 <narrative>Tourism</narrative>
                 <narrative xml:lang="fr">Tourisme</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>410</code>
@@ -365,10 +261,6 @@
                 <narrative>Other Multisector</narrative>
                 <narrative xml:lang="fr">Autres Multisecteurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>510</code>
@@ -387,10 +279,6 @@
                 <narrative>Development Food Assistance</narrative>
                 <narrative xml:lang="fr">Aide Alimentaire Dévelopmentale</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>530</code>
@@ -409,10 +297,6 @@
                 <narrative>Action Relating to Debt</narrative>
                 <narrative xml:lang="fr">Actions se Rapportant a la Dette</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>720</code>
@@ -453,10 +337,6 @@
                 <narrative>Administrative Costs of Donors</narrative>
                 <narrative xml:lang="fr">Frais Administratifs des Donneurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>920</code>
@@ -473,10 +353,6 @@
                 <narrative>Refugees in Donor Countries</narrative>
                 <narrative xml:lang="fr">Refugiés dans les Pays Donneurs</narrative>
             </name>
-            <description>
-                <narrative/>
-                <narrative xml:lang="fr"/>
-            </description>
         </codelist-item>
         <codelist-item>
             <code>998</code>


### PR DESCRIPTION
At one point we had commented out the code that removed empty narratives to reduce the noise in the GitHub diff. My guess is that this was being done at the same time as a DAC Codelist update and that work took prescendence.

Now we've just completed a DAC Codelist update so the only change here will be removing the empty narrative elements. So next time we do a DAC codelist update we can leave the empty narratives out.﻿
