### PR TITLE
Translate UNSDG goal 8

### DIFF
--- a/xml/UNSDG-Goals.xml
+++ b/xml/UNSDG-Goals.xml
@@ -65,7 +65,7 @@
             <code>8</code>
             <name>
                 <narrative>Goal 8. Promote sustained, inclusive and sustainable economic growth, full and productive employment and decent work for all</narrative>
-                <narrative xml:lang="fr">Objectif 7. Garantir l’accès de tous à des services énergétiques fiables, durables et modernes, à un coût abordable</narrative>
+                <narrative xml:lang="fr">Objectif 8. Promouvoir une croissance économique soutenue, partagée et durable, le plein emploi productif et un travail décent pour tous</narrative>
             </name>
         </codelist-item>
         <codelist-item>


### PR DESCRIPTION
This pull request includes a correction to the French translation of Goal 8 in the `xml/UNSDG-Goals.xml` file. The narrative now accurately reflects the content of Goal 8. 

* [`xml/UNSDG-Goals.xml`](diffhunk://#diff-158ca9060b70611c4a60412435ad643609dc6a0857c5149e30f6b5e42d8afc53L68-R68): Updated the French narrative for Goal 8 to correctly describe "Promouvoir une croissance économique soutenue, partagée et durable, le plein emploi productif et un travail décent pour tous" instead of incorrectly referencing Goal 7.