### PR TITLE
Update OECD DAC Codelists with 2026-04-02 changes

### DIFF
--- a/extras_namespace.md
+++ b/extras_namespace.md
@@ -1,0 +1,5 @@
+# "extras" namespace within IATI-Codelists-NonEmbedded
+
+We have a namespace named `extras` with a URI of https://namespaces.iatistandard.org/codelist_extras
+
+This exists to add extra fields, without needing to change the codelist xsd in the main IATI-Codelists repository, as this is more likely to break things for people.

--- a/xml/AidType-category.xml
+++ b/xml/AidType-category.xml
@@ -12,7 +12,7 @@
         </category>
     </metadata>
     <codelist-items>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>A</code>
             <name>
                 <narrative>Budget support</narrative>
@@ -23,18 +23,18 @@
                 <narrative xml:lang="fr">Pour les contributions relevant de cette catégorie, le donneur renonce au contrôle exclusif des fonds qu’il octroie en partageant cette responsabilité avec le bénéficiaire.</narrative>
             </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>B</code>
             <name>
                 <narrative>Core contributions and pooled programmes and funds</narrative>
                 <narrative xml:lang="fr">Contributions aux budgets réguliers des organisations, programmes et financements groupés</narrative>
             </name>
             <description>
-                <narrative>For contributions under this category, the donor relinquishes the exclusive control of its funds by sharing the responsibility with other stakeholders (other donors, NGOs, multilateral institutions, Public Private Partnerships). The category covers both core contributions (B01 and B02), and pooled contributions with a specific earmarking (B03 and B04).</narrative>
-                <narrative xml:lang="fr">Pour les contributions relevant de cette catégorie, le donneur renonce au contrôle exclusif des fonds qu’il octroie en partageant cette responsabilité avec d’autres acteurs (autres donneurs, ONG, institutions multilatérales, partenariats public-privé). La catégorie couvre à la fois les contributions aux budgets réguliers des organisations (B01 et B02) et les contributions groupées préaffectées à un objectif spécifique (B03 et B04).</narrative>
+                <narrative>For contributions under this category, the donor relinquishes the exclusive control of its funds by sharing the responsibility with other stakeholders (other donors, NGOs, multilateral institutions, Public Private Partnerships or PSI vehicles). The category covers both core contributions (B01 and B02), pooled contributions with a specific earmarking (B03 and B04) and PSI intra-governmental transfers (B05).</narrative>
+                <narrative xml:lang="fr">Pour les contributions relevant de cette catégorie, le donneur renonce au contrôle exclusif des fonds qu’il octroie en partageant cette responsabilité avec d’autres acteurs (autres donneurs, ONG, institutions multilatérales, partenariats public-privé ou véhicules PSI). La catégorie couvre à la fois les contributions aux budgets réguliers des organisations (B01 et B02) et les contributions groupées préaffectées à un objectif spécifique (B03 et B04) et les transferts intra-gouvernementaux d’ISP (B05).</narrative>
             </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>C</code>
             <name>
                 <narrative>Project-type interventions</narrative>
@@ -45,7 +45,7 @@
                 <narrative xml:lang="fr">N.B.  Dans cette catégorie, les membres qui le peuvent notifieront dans le tableau CAD1 le montant total dédié au financement d’experts/consultants du pays donneur.1Lorsque l’activité consiste uniquement en des frais d’experts, notifier sous la catégorie D.</narrative>
             </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>D</code>
             <name>
                 <narrative>Experts and other technical assistance</narrative>
@@ -56,28 +56,28 @@
                 <narrative xml:lang="fr">Cette catégorie couvre l’apport, en dehors de projets tels qu’ils sont définis dans la catégorie C01, de savoir-faire sous forme de personnel, de formation et d’activités de recherche.</narrative>
             </description>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>E</code>
             <name>
                 <narrative>Scholarships and student costs in donor countries</narrative>
                 <narrative xml:lang="fr">Bourses et autres frais d’étude dans les pays donneurs</narrative>
             </name>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>F</code>
             <name>
                 <narrative>Debt relief</narrative>
                 <narrative xml:lang="fr">Allégement de la dette</narrative>
             </name>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>G</code>
             <name>
                 <narrative>Administrative costs not included elsewhere</narrative>
                 <narrative xml:lang="fr">Frais administratifs non inclus ailleurs</narrative>
             </name>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>H</code>
             <name>
                 <narrative>Other in-donor expenditures</narrative>
@@ -87,6 +87,38 @@
                 <narrative>Groups a number of contributions that do not give rise to a cross-border flow.</narrative>
                 <narrative xml:lang="fr">Regroupe diverses contributions qui n’entraînent pas de mouvement de fonds transnationaux.</narrative>
             </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>I</code>
+            <name>
+                <narrative>Support to refugees / protected persons</narrative>
+                <narrative xml:lang="fr">Support to refugees / protected persons</narrative>
+            </name>
+            <description>
+                <narrative>Covers expenses on the temporary sustenance of refugees and protected persons in refugee-like situations in the provider country as well as financial, material or technical support to refugees in other host countries. Also includes support to refugees returning to their countries of origin.</narrative>
+                <narrative xml:lang="fr">Covers expenses on the temporary sustenance of refugees and protected persons in refugee-like situations in the provider country as well as financial, material or technical support to refugees in other host countries. Also includes support to refugees returning to their countries of origin.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>J</code>
+            <name>
+                <narrative>In-kind donations</narrative>
+                <narrative xml:lang="fr">Dons en nature</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>K</code>
+            <name>
+                <narrative>Research and development</narrative>
+                <narrative xml:lang="fr">Research and development</narrative>
+            </name>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>L</code>
+            <name>
+                <narrative>Direct cash transfers to developing countries</narrative>
+                <narrative xml:lang="fr">Direct cash transfers to developing countries</narrative>
+            </name>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/AidType-category.xml
+++ b/xml/AidType-category.xml
@@ -1,4 +1,4 @@
-<codelist name="AidType-category" xml:lang="en" complete="1" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="AidType-category" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
             <narrative>Aid Type (category)</narrative>
@@ -22,6 +22,8 @@
                 <narrative>For contributions under this category, the donor relinquishes the exclusive control of its funds by sharing the responsibility with the recipient.</narrative>
                 <narrative xml:lang="fr">Pour les contributions relevant de cette catégorie, le donneur renonce au contrôle exclusif des fonds qu’il octroie en partageant cette responsabilité avec le bénéficiaire.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>B</code>
@@ -33,6 +35,8 @@
                 <narrative>For contributions under this category, the donor relinquishes the exclusive control of its funds by sharing the responsibility with other stakeholders (other donors, NGOs, multilateral institutions, Public Private Partnerships or PSI vehicles). The category covers both core contributions (B01 and B02), pooled contributions with a specific earmarking (B03 and B04) and PSI intra-governmental transfers (B05).</narrative>
                 <narrative xml:lang="fr">Pour les contributions relevant de cette catégorie, le donneur renonce au contrôle exclusif des fonds qu’il octroie en partageant cette responsabilité avec d’autres acteurs (autres donneurs, ONG, institutions multilatérales, partenariats public-privé ou véhicules PSI). La catégorie couvre à la fois les contributions aux budgets réguliers des organisations (B01 et B02) et les contributions groupées préaffectées à un objectif spécifique (B03 et B04) et les transferts intra-gouvernementaux d’ISP (B05).</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>C</code>
@@ -44,6 +48,8 @@
                 <narrative>N.B.  Within this category, members able to do so are requested to report the aggregate amount used for financing donor experts/consultants on Table DAC11. Where the activity consists solely of experts’ costs, report under category D.</narrative>
                 <narrative xml:lang="fr">N.B.  Dans cette catégorie, les membres qui le peuvent notifieront dans le tableau CAD1 le montant total dédié au financement d’experts/consultants du pays donneur.1Lorsque l’activité consiste uniquement en des frais d’experts, notifier sous la catégorie D.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>D</code>
@@ -55,6 +61,8 @@
                 <narrative>This category covers the provision, outside projects as described in category C, of know-how in the form of personnel, training and research.</narrative>
                 <narrative xml:lang="fr">Cette catégorie couvre l’apport, en dehors de projets tels qu’ils sont définis dans la catégorie C01, de savoir-faire sous forme de personnel, de formation et d’activités de recherche.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>E</code>
@@ -62,6 +70,8 @@
                 <narrative>Scholarships and student costs in donor countries</narrative>
                 <narrative xml:lang="fr">Bourses et autres frais d’étude dans les pays donneurs</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>F</code>
@@ -69,6 +79,8 @@
                 <narrative>Debt relief</narrative>
                 <narrative xml:lang="fr">Allégement de la dette</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>G</code>
@@ -76,6 +88,8 @@
                 <narrative>Administrative costs not included elsewhere</narrative>
                 <narrative xml:lang="fr">Frais administratifs non inclus ailleurs</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>H</code>
@@ -87,6 +101,8 @@
                 <narrative>Groups a number of contributions that do not give rise to a cross-border flow.</narrative>
                 <narrative xml:lang="fr">Regroupe diverses contributions qui n’entraînent pas de mouvement de fonds transnationaux.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>I</code>
@@ -98,6 +114,8 @@
                 <narrative>Covers expenses on the temporary sustenance of refugees and protected persons in refugee-like situations in the provider country as well as financial, material or technical support to refugees in other host countries. Also includes support to refugees returning to their countries of origin.</narrative>
                 <narrative xml:lang="fr">Covers expenses on the temporary sustenance of refugees and protected persons in refugee-like situations in the provider country as well as financial, material or technical support to refugees in other host countries. Also includes support to refugees returning to their countries of origin.</narrative>
             </description>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>J</code>
@@ -105,6 +123,8 @@
                 <narrative>In-kind donations</narrative>
                 <narrative xml:lang="fr">Dons en nature</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>K</code>
@@ -112,6 +132,8 @@
                 <narrative>Research and development</narrative>
                 <narrative xml:lang="fr">Research and development</narrative>
             </name>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>L</code>
@@ -119,6 +141,8 @@
                 <narrative>Direct cash transfers to developing countries</narrative>
                 <narrative xml:lang="fr">Direct cash transfers to developing countries</narrative>
             </name>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/AidType-category.xml
+++ b/xml/AidType-category.xml
@@ -71,7 +71,7 @@
                 <narrative xml:lang="fr">Bourses et autres frais d’étude dans les pays donneurs</narrative>
             </name>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>F</code>

--- a/xml/AidType.xml
+++ b/xml/AidType.xml
@@ -1,4 +1,4 @@
-<codelist name="AidType" xml:lang="en" complete="1" category-codelist="AidType-category" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="AidType" xml:lang="en" complete="1" category-codelist="AidType-category" embedded="0">
     <metadata>
         <name>
             <narrative>Aid Type</narrative>
@@ -20,6 +20,8 @@
                 <narrative xml:lang="fr">Identifies contributions from the provider to the government budget of a recipient country, which has exclusive responsibility for the use of and accountability for the funds. Budget support can be generic (not sector allocated) or sectoral (e.g. energy, agriculture).</narrative>
             </description>
             <category>A</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>A01</code>
@@ -32,6 +34,8 @@
                 <narrative xml:lang="fr">Contributions au budget du gouvernement non préaffectées y compris le soutien à la mise en œuvre de réformes macroéconomiques (programmes d’ajustement structurel, stratégies de lutte contre la pauvreté). Le soutien budgétaire se définit comme une méthode de financement du budget d’un pays bénéficiaire via un transfert de ressources d’un organisme de financement externe au Trésor public du gouvernement bénéficiaire. Les fonds ainsi transférés sont gérés conformément aux procédures budgétaires du bénéficiaire. Cette définition n’englobe donc pas les fonds transférés au Trésor public pour le financement de programmes ou de projets gérés selon des procédures budgétaires différentes de celles du pays bénéficiaire, dans l’intention d’affecter ces ressources à des usages spécifiques.</narrative>
             </description>
             <category>A</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>A02</code>
@@ -44,6 +48,8 @@
                 <narrative xml:lang="fr">Le soutien budgétaire sectoriel, comme le soutien budgétaire général, est une contribution financière au budget du gouvernement du pays bénéficiaire. Cependant, dans le cas du soutien budgétaire sectoriel, le dialogue entre les donneurs et les gouvernements partenaires se concentre sur les préoccupations spécifiques à un secteur plutôt que sur les priorités de la politique globale et les priorités budgétaires.</narrative>
             </description>
             <category>A</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>B01</code>
@@ -56,6 +62,8 @@
                 <narrative xml:lang="fr">Fonds versés à des PPP, réseaux, instituts de recherche et organismes privés à but non lucratif – ONG basées dans des pays en développement, dans des pays donneurs ou ONG internationales et autres organisations de la société civile par exemple les fondations philanthropiques – qui sont utilisés à la discrétion de ces organisations, et qui contribuent au financement de programmes et activités que ces organisations ont mis au point elles-mêmes et qu’elles mettent en œuvre sous leur propre autorité et responsabilité.La Liste des organisations internationales éligible en APD (voir l’annexe 2) fournit une liste d’ONGI, de PPP et de réseaux en faveur desquels les contributions aux budgets réguliers peuvent être notifiées sous B01. Cette liste n’est pas exhaustive.</narrative>
             </description>
             <category>B</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>B02</code>
@@ -68,6 +76,8 @@
                 <narrative xml:lang="fr">Ces fonds sont classés comme multilatéraux (toutes les autres catégories sont bilatérales). L'institution multilatérale bénéficiaire met en commun les contributions de sorte qu'elles perdent leur identité et deviennent partie intégrante de ses actifs ou passifs financiers. Comprend également les fonds d'intermédiation financière (FEM, FIC) dont la Banque mondiale est l'administrateur, ainsi que certains fonds communs inter-institutions des Nations unies, tels que le CERF et le Fonds des Nations unies pour la consolidation de la paix. Voir l'annexe 2 des Directives pour une liste complète des agences dont les contributions de base peuvent être rapportées sous B02 et ses sous-catégories. (Section I. Institutions multilatérales). Nota bene : les contributions aux organisations multilatérales de développement hors de l'annexe 2 ne sont pas à déclarer dans les statistiques du CAD. Les composantes non-APD du soutien de base aux organisations multilatérales incluses dans l'annexe 2 ne sont pas non plus à déclarer.</narrative>
             </description>
             <category>B</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B021</code>
@@ -80,6 +90,8 @@
                 <narrative xml:lang="fr">Les contributions de cette catégorie sont mises en commun par l'institution multilatérale bénéficiaire et deviennent partie intégrante de ses actifs ou passifs financiers.</narrative>
             </description>
             <category>B02</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B022</code>
@@ -92,6 +104,8 @@
                 <narrative xml:lang="fr">Contributions à des fonds mondiaux classés comme multilatéraux, y compris les fonds d'intermédiation financière dont la Banque mondiale est l'administrateur et qui sont passés par le processus de l'annexe 2 (FEM, FIC), ainsi que certains fonds communs inter-institutions des Nations unies, par exemple le CERF et le Fonds de consolidation de la paix des Nations unies.</narrative>
             </description>
             <category>B02</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B02a</code>
@@ -104,6 +118,8 @@
                 <narrative xml:lang="fr">Fixed contributions calculated based on agreed formula that members of multilateral institutions commit to when joining an institution.</narrative>
             </description>
             <category>B02</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B02b</code>
@@ -116,6 +132,8 @@
                 <narrative xml:lang="fr">Voluntary unearmarked contributions to the general budgets of multilateral institutions.</narrative>
             </description>
             <category>B02</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>B03</code>
@@ -128,6 +146,8 @@
                 <narrative xml:lang="fr">Outre leurs opérations de base, les organisations internationales – agences multilatérales, ONG, PPP et réseaux – tant dans les pays fournisseurs que dans les pays tiers, mettent en place des programmes ou fonds qui visent des objectifs sectoriels, thématiques ou géographiques spécifiques. Les contributions bilatérales des donneurs à ce type de programmes et fonds entrent dans cette catégorie. Utilisez les catégories B031 et B032 pour les fonds d'affectation spéciale gérés par l'ONU (tous conçus comme multidonateurs) à moins que les contributions ne soient affectées à un lieu géographique ou à une fenêtre de financement spécifique.</narrative>
             </description>
             <category>B</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B031</code>
@@ -140,6 +160,8 @@
                 <narrative xml:lang="fr">Contributions à des mécanismes de financement (programmes et fonds à finalité spécifique) qui mettent en commun les ressources de plusieurs fournisseurs et à partir desquels plusieurs agences multilatérales –  agences multilatérales, ONG, PPP et réseaux – peuvent se voir allouer des fonds pour la mise en œuvre ; contributions à des fonds communs par pays des Nations unies et à des fonds de développement au niveau des pays. Ne comprend pas les contributions aux fonds mondiaux classés comme multilatéraux (voir B022). Comprend les fonds intermédiaires financiers dont la Banque mondiale est l'administrateur et qui ne sont pas passés par le processus de l'annexe 2.</narrative>
             </description>
             <category>B03</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B032</code>
@@ -152,6 +174,8 @@
                 <narrative xml:lang="fr">Contributions à des mécanismes de financement multi-donateurs (programmes et fonds à but spécial) gérés par une seule organisation multilatérale  –  agences multilatérales, ONG, PPP et réseaux – , par exemple, les fonds thématiques d'une seule agence des Nations Unies ; les fonds fiduciaires de la Banque mondiale ou d'autres BMD. Classer la contribution sous B032 même si un seul donateur contribue initialement au fonds.</narrative>
             </description>
             <category>B03</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>B033</code>
@@ -164,6 +188,8 @@
                 <narrative xml:lang="fr">Contributions aux mécanismes de financement (programmes et fonds à but spécifique) où le donateur a une influence significative sur l'allocation des fonds. Cela comprend les contributions à des fonds d'affectation spéciale à donateur unique et les contributions affectées à des pays/emplacements géographiques spécifiques ou à des guichets de financement au sein de fonds d'affectation spéciale à donateur multiple. Lorsque le donateur conçoit l'activité mais la fait transiter par une organisation internationale, l'activité doit être classée en C01.</narrative>
             </description>
             <category>B03</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>B04</code>
@@ -176,6 +202,8 @@
                 <narrative xml:lang="fr">Le donneur dépose des fonds sur un compte autonome, géré conjointement avec d’autres donneurs et/ou le bénéficiaire. Sont associés à ce compte des objectifs, des modalités de versement, des mécanismes de reddition de comptes spécifiques, et un horizon temporel précis.La mise en commun de fonds suppose des documents de projet communs, des contrats de financement communs et des procédures de notification/audit communes à tous les donneurs.Les contributions des donneurs à des fonds gérés par des organisations internationales sont notifiées sous B03.</narrative>
             </description>
             <category>B</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>B05</code>
@@ -188,6 +216,8 @@
                 <narrative xml:lang="fr">Augmentation ou baisse de de capital de véhicules pour ISP et dividendes versés au gouvernement.</narrative>
             </description>
             <category>B</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>C01</code>
@@ -200,6 +230,8 @@
                 <narrative xml:lang="fr">Un projet est un ensemble d’éléments, d’activités et de produits, convenus avec le pays partenaire*, en vue d’atteindre des objectifs/résultats spécifiques dans un laps de temps et une zone géographique prédéfinis au moyen d’un budget fixé à l’avance. Les projets peuvent différer considérablement par leurs objectifs, leur complexité, les montants en jeu et leur durée. Si les petits projets ne mettent en jeu que des ressources financières modestes et ne durent souvent que quelques mois, les grands projets peuvent porter sur des montants substantiels, devoir être mis en œuvre par tranches et durer plusieurs années. Lorsqu’un grand projet se subdivise en plusieurs composantes, il est parfois appelé programme, mais doit néanmoins être comptabilisé dans la présente rubrique. Sont inclues les études de faisabilité, ainsi que les évaluations préalables ou rétrospectives (lorsqu’elles sont conçues comme un volet du projet/programme ou qu’elles font l’objet de modalités de financement dédiées). Le suivi, l'audit et les analyses de situation des projets et programmes sont également inclus. Les études universitaires, la recherche et le développement, les formations, les bourses et autres activités d'assistance technique non directement liées aux projets/programmes de développement doivent plutôt être enregistrées sous D02. L’aide acheminée par l’intermédiaire d’ONG ou d’organisations multilatérales est également notifiée ici. Cela comprend les paiements effectués aux ONG et aux organisations multilatérales pour qu’elles mettent en œuvre les projets et programmes des donneurs, ainsi que le financement de projets spécifiques des ONG. En revanche, les contributions de caractère général aux ONG et aux organisations multilatérales ainsi que les contributions aux fonds à objectif spécifique sont notifiées sous B. * Dans le cas d’investissements sous forme de prises de participation, d’une aide humanitaire ou d’une aide par l’intermédiaire d’ONG, les projets sont notifiés ici même s’ils ne font pas l’objet d’un accord direct avec le pays partenaire. Les contributions aux fonds d'affectation spéciale à donateur unique et les contributions aux fonds d'affectation spéciale destinés à un guichet de financement et/ou à un pays spécifiques sont enregistrées sous B033.</narrative>
             </description>
             <category>C</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>D01</code>
@@ -212,6 +244,8 @@
                 <narrative xml:lang="fr">Experts, consultants, enseignants, universitaires, chercheurs, stagiaires et volontaires, ainsi que contributions à des organismes publics et privés pour l’envoi d’experts dans les pays en développement.</narrative>
             </description>
             <category>D</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>D011</code>
@@ -224,6 +258,8 @@
                 <narrative xml:lang="fr">Expenses related to hiring specialists, technical hours of government officials and opportunity costs, directly associated with the technical co-operation activity.</narrative>
             </description>
             <category>D01</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>D012</code>
@@ -236,6 +272,8 @@
                 <narrative xml:lang="fr">Expenses related to per diems, daily allowances and airfares, that are directly associated with the technical co-operation activity. Also includes expenditures for travel-related costs of volunteers.</narrative>
             </description>
             <category>D01</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>D013</code>
@@ -248,6 +286,8 @@
                 <narrative xml:lang="fr">Expenses regarding the acquisition of services, materials, equipment and supplies that are needed to deliver technical co-operation activities/projects between developing countries.</narrative>
             </description>
             <category>D01</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>D02</code>
@@ -260,6 +300,8 @@
                 <narrative xml:lang="fr">Cette catégorie couvre l’apport de savoir-faire en dehors de projets tels qu’ils sont définis dans la catégorie C01 (sauf l’assistance technique fournie par des experts des pays donneurs couverte sous D01, et les bourses/formations dans le pays donneur couvertes sous E01.) Sont inclues les activités de formation et de recherche, les formations linguistiques, les études Sud-Sud, les études pour la recherche, les activités de recherche impliquant une collaboration entre des universités ou organismes du pays donneur et du pays bénéficiaire, les bourses locales, et les programmes sociaux et culturels à des fins de développement. La catégorie couvre également les contributions ponctuelles telles les conférences, séminaires et ateliers, échanges, publications, etc.</narrative>
             </description>
             <category>D</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>D021</code>
@@ -272,6 +314,8 @@
                 <narrative xml:lang="fr">Includes the provision of training using internationally or locally recruited experts. This category also covers various capacity building activities such as conferences, seminars, workshops, exchange visits.</narrative>
             </description>
             <category>D02</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>E01</code>
@@ -284,6 +328,8 @@
                 <narrative xml:lang="fr">Bourses octroyées à des étudiants et contributions aux frais associés à des stages.</narrative>
             </description>
             <category>E</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>E02</code>
@@ -296,6 +342,8 @@
                 <narrative xml:lang="fr">Coûts indirects (“imputés”) correspondant aux frais de scolarité dans le pays donneur.</narrative>
             </description>
             <category>E</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>F01</code>
@@ -308,6 +356,8 @@
                 <narrative xml:lang="fr">Regroupe toutes les actions se rapportant à la dette (annulation, conversion, échange, rachat, rééchelonnement, refinancement).</narrative>
             </description>
             <category>F</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>F02</code>
@@ -320,6 +370,8 @@
                 <narrative xml:lang="fr">Principal component of a debt relief operation, in cases where the loans concerned were not previously recorded in TOSSD (private claims or official claims not previously recorded in TOSSD).</narrative>
             </description>
             <category>F</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>F03</code>
@@ -332,6 +384,8 @@
                 <narrative xml:lang="fr">Interest component of a debt relief operation (interests in arrears and late interests).</narrative>
             </description>
             <category>F</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>G01</code>
@@ -344,6 +398,8 @@
                 <narrative xml:lang="fr">Frais d'administration des programmes d'aide au développement qui ne sont pas déjà inclus dans d'autres rubriques comme partie intégrante du coût de l’acheminement ou de la mise en œuvre de l’aide fournie. Cette catégorie comprend les analyses de situation et les activités d’audit.En ce qui concerne la composante salariale des frais administratifs, elle se rapporte uniquement au personnel et contractuels de l’agence ; les coûts associés aux experts/consultants du pays donneur sont à notifier sous les catégories C ou D01.</narrative>
             </description>
             <category>G</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>H00</code>
@@ -356,6 +412,8 @@
                 <narrative xml:lang="fr">Expenditures in the provider country not included elsewhere.</narrative>
             </description>
             <category>H</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>H01</code>
@@ -368,6 +426,8 @@
                 <narrative xml:lang="fr">Financement d’activités visant à accroître le soutien du public dans le pays donneur pour les efforts de coopération pour le développement et à rendre la population plus consciente des besoins et problèmes du développement.</narrative>
             </description>
             <category>H</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>H02</code>
@@ -380,6 +440,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l’aide de base apportée aux demandeurs d’asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu’à 12 mois, quand les coûts ne peuvent pas être désagrégés. Voir section II.6 et Annexe 17.</narrative>
             </description>
             <category>H</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>H03</code>
@@ -392,6 +454,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l’aide de base apportée aux demandeurs d’asile lorsque ceux-ci sont finalement acceptés. Cette catégorie couvre uniquement les coûts encourus avant la reconnaissance de statut.</narrative>
             </description>
             <category>H</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>H04</code>
@@ -404,6 +468,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l’aide de base apportée aux demandeurs d’asile lorsque ceux-ci sont finalement déboutés. Cette catégorie couvre uniquement les coûts encourus avant le rejet de la demande. Dans les cas où il est probable que la décision définitive relative au statut ne surviendra qu’après douze mois et afin de parvenir à une estimation prudente, les membres peuvent établir leur notification en fonction de la date du rejet en première instance. Pour plus d’instructions sur la façon de calculer les coûts relatifs aux demandeurs d’asile finalement déboutés, voir la Clarification 5, troisième point dans la section II.6 des Directives.</narrative>
             </description>
             <category>H</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>H05</code>
@@ -416,6 +482,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l’aide de base apportée aux personnes auxquelles le statut de réfugié a été accordé. Cette catégorie couvre uniquement les coûts postérieurs à la reconnaissance (ou à la date d’entrée dans un pays dans le cadre d’un programme de réinstallation).</narrative>
             </description>
             <category>H</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2022-01-01">
             <code>H06</code>
@@ -428,6 +496,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans d'autres pays fournisseurs non éligibles à l'APD pour l'assistance de base aux demandeurs d'asile et aux réfugiés des pays en développement, jusqu'à 12 mois. Le pays d'accueil et d'origine des réfugiés/demandeurs d'asile doit être précisé dans l'un des champs descriptifs du SNPC (champs 14 ou 19).</narrative>
             </description>
             <category>H</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>I01</code>
@@ -440,6 +510,8 @@
                 <narrative xml:lang="fr">Costs incurred in provider countries for basic assistance to asylum seekers, refugees and protected persons from TOSSD-eligible countries, up to 12 months. Reportable under Pillar II.</narrative>
             </description>
             <category>I</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>I02</code>
@@ -452,6 +524,8 @@
                 <narrative xml:lang="fr">Costs incurred in provider countries for basic assistance to asylum seekers, refugees and protected persons from TOSSD-eligible countries, beyond the 12-month period, to the extent that the individual is not recognised by the competent authorities of the country in which he/she has sought asylum as having the rights and obligations which are attached to the possession of residency or nationality of that country. Reportable under Pillar II.</narrative>
             </description>
             <category>I</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2019-01-01" withdrawal-date="2021-12-31">
             <code>I03</code>
@@ -464,6 +538,8 @@
                 <narrative xml:lang="fr">Financial, material or technical support to asylum seekers, refugees and protected persons in other host countries. Reportable under Pillar I.</narrative>
             </description>
             <category>I</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2019-01-01" withdrawal-date="2021-12-31">
             <code>I04</code>
@@ -476,6 +552,8 @@
                 <narrative xml:lang="fr">Support to refugees, asylum seekers and protected persons voluntarily returning to their countries of origin, nationality or last habitual residence.  Excluding pre-departure assistance. Reportable under Pillar I.</narrative>
             </description>
             <category>I</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>I05</code>
@@ -488,6 +566,8 @@
                 <narrative xml:lang="fr">Costs incurred in provider countries for promoting the integration in their economy of asylum seekers, refugees, protected persons and migrants from TOSSD-eligible countries. Covers activities that promote the integration in the economy and culture of the provider country (including language training, vocational training, social protection schemes, employment programmes, awareness on national culture), up to the first 5 years of stay. Temporary sustenance/basic assistance is covered under modalities I01 and I02. Reportable under Pillar II.</narrative>
             </description>
             <category>I</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>J01</code>
@@ -500,6 +580,8 @@
                 <narrative xml:lang="fr">Dons de biens et de matériel. Cela comprend des denrées alimentaires, de l'équipement (y compris du matériel médical), des matériaux et des véhicules motorisés.</narrative>
             </description>
             <category>J</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>K01</code>
@@ -512,6 +594,8 @@
                 <narrative xml:lang="fr">Disbursements for joint research projects between two or more developing countries, covering the working time and opportunity costs of scientists/specialists and other research personnel from the reporting country as well as expenses for scientific-related infrastructure and services (labs, equipment, materials, supplies) directly associated with the research activity.</narrative>
             </description>
             <category>K</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>K011</code>
@@ -524,6 +608,8 @@
                 <narrative xml:lang="fr">Laboratories, equipment and supplies directly associated with research and development activities.</narrative>
             </description>
             <category>K01</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>K012</code>
@@ -536,6 +622,8 @@
                 <narrative xml:lang="fr">Covers working hours and opportunity costs of scientists/specialists and other research personnel from the reporting country.</narrative>
             </description>
             <category>K01</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2022-01-01">
             <code>K02</code>
@@ -548,6 +636,8 @@
                 <narrative xml:lang="fr">Research and experimental development comprising creative and systematic work undertaken in order to increase the stock of knowledge – including knowledge of humankind, culture and society – and to devise new applications of available knowledge.</narrative>
             </description>
             <category>K</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>L01</code>
@@ -560,6 +650,8 @@
                 <narrative xml:lang="fr">Direct cash transfers expenditure benefiting individuals, in the context of public programmes of sustainable development in partner countries (with the consent and support of the partner country).</narrative>
             </description>
             <category>L</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/AidType.xml
+++ b/xml/AidType.xml
@@ -1,4 +1,4 @@
-<codelist name="AidType" xml:lang="en" category-codelist="AidType-category" complete="1" embedded="0">
+<codelist name="AidType" xml:lang="en" complete="1" category-codelist="AidType-category" embedded="0">
     <metadata>
         <name>
             <narrative>Aid Type</narrative>
@@ -9,7 +9,19 @@
         </category>
     </metadata>
     <codelist-items>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>A00</code>
+            <name>
+                <narrative>Budget support</narrative>
+                <narrative xml:lang="fr">Budget support</narrative>
+            </name>
+            <description>
+                <narrative>Identifies contributions from the provider to the government budget of a recipient country, which has exclusive responsibility for the use of and accountability for the funds. Budget support can be generic (not sector allocated) or sectoral (e.g. energy, agriculture).</narrative>
+                <narrative xml:lang="fr">Identifies contributions from the provider to the government budget of a recipient country, which has exclusive responsibility for the use of and accountability for the funds. Budget support can be generic (not sector allocated) or sectoral (e.g. energy, agriculture).</narrative>
+            </description>
+            <category>A</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>A01</code>
             <name>
                 <narrative>General budget support</narrative>
@@ -21,7 +33,7 @@
             </description>
             <category>A</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>A02</code>
             <name>
                 <narrative>Sector budget support</narrative>
@@ -33,7 +45,7 @@
             </description>
             <category>A</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>B01</code>
             <name>
                 <narrative>Core support to NGOs, other private bodies, PPPs and research institutes</narrative>
@@ -45,7 +57,7 @@
             </description>
             <category>B</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>B02</code>
             <name>
                 <narrative>Core contributions to multilateral institutions and global funds</narrative>
@@ -57,7 +69,7 @@
             </description>
             <category>B</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2022-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
             <code>B021</code>
             <name>
                 <narrative>Core contributions to multilateral institutions</narrative>
@@ -69,7 +81,7 @@
             </description>
             <category>B02</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2022-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
             <code>B022</code>
             <name>
                 <narrative>Core contributions to global funds</narrative>
@@ -81,7 +93,31 @@
             </description>
             <category>B02</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>B02a</code>
+            <name>
+                <narrative>Assessed contributions to multilateral institutions</narrative>
+                <narrative xml:lang="fr">Assessed contributions to multilateral institutions</narrative>
+            </name>
+            <description>
+                <narrative>Fixed contributions calculated based on agreed formula that members of multilateral institutions commit to when joining an institution.</narrative>
+                <narrative xml:lang="fr">Fixed contributions calculated based on agreed formula that members of multilateral institutions commit to when joining an institution.</narrative>
+            </description>
+            <category>B02</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>B02b</code>
+            <name>
+                <narrative>Voluntary core contributions to multilateral institutions</narrative>
+                <narrative xml:lang="fr">Voluntary core contributions to multilateral institutions</narrative>
+            </name>
+            <description>
+                <narrative>Voluntary unearmarked contributions to the general budgets of multilateral institutions.</narrative>
+                <narrative xml:lang="fr">Voluntary unearmarked contributions to the general budgets of multilateral institutions.</narrative>
+            </description>
+            <category>B02</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>B03</code>
             <name>
                 <narrative>Contributions to specific-purpose programmes and funds managed by implementing partners</narrative>
@@ -93,7 +129,7 @@
             </description>
             <category>B</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2022-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
             <code>B031</code>
             <name>
                 <narrative>Contributions to multi-donor/multi-entity funding mechanisms</narrative>
@@ -105,7 +141,7 @@
             </description>
             <category>B03</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2022-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
             <code>B032</code>
             <name>
                 <narrative>Contributions to multi-donor/single-entity funding mechanisms</narrative>
@@ -117,7 +153,7 @@
             </description>
             <category>B03</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2022-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
             <code>B033</code>
             <name>
                 <narrative>Contributions to single-donor funding mechanisms and contributions earmarked for a specific funding window or geographical location</narrative>
@@ -129,7 +165,7 @@
             </description>
             <category>B03</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>B04</code>
             <name>
                 <narrative>Basket funds/pooled funding</narrative>
@@ -141,19 +177,31 @@
             </description>
             <category>B</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>B05</code>
+            <name>
+                <narrative>PSI intra-governmental transfers</narrative>
+                <narrative xml:lang="fr">Transfert intra-gouvernemental pour ISP</narrative>
+            </name>
+            <description>
+                <narrative>Capital increases of PSI vehicles, decapitalisations and dividends paid to the government.</narrative>
+                <narrative xml:lang="fr">Augmentation ou baisse de de capital de véhicules pour ISP et dividendes versés au gouvernement.</narrative>
+            </description>
+            <category>B</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>C01</code>
             <name>
                 <narrative>Project-type interventions</narrative>
                 <narrative xml:lang="fr">Interventions de type projet</narrative>
             </name>
             <description>
-                <narrative>A project is a set of inputs, activities and outputs, agreed with the partner country*, to reach specific objectives/outcomes within a defined time frame, with a defined budget and a  defined geographical area. Projects can vary significantly in terms of objectives, complexity, amounts involved and duration. There are smaller projects that might involve modest financial resources and last only a few months, whereas large projects might involve more significant amounts, entail successive phases and last for many years. A large project with a number of different components is sometimes referred to as a programme, but should nevertheless be recorded here. Feasibility studies, appraisals and evaluations are included (whether designed as part of projects/programmes or dedicated funding arrangements). Academic studies, research and development, trainings, scholarships, and other technical assistance activities not directly linked to development projects/programmes should instead be recorded under D02. Aid channelled through NGOs or multilaterals is also recorded here. This includes payments for NGOs and multilaterals to implement donors’ projects and programmes, and funding of specified NGOs projects. By contrast, core funding of NGOs and multilaterals as well as contributions to specific-purpose funds are recorded under B.* In the cases of equity investments, humanitarian aid or aid channelled through NGOs, projects are recorded here even if there was no direct agreement between the donor and the partner country. Contributions to single-donor trust funds and contributions to trust funds earmarked for a specific funding window and/or country are recorded under B033.</narrative>
-                <narrative xml:lang="fr">Un projet est un ensemble d’éléments, d’activités et de produits, convenus avec le pays partenaire*, en vue d’atteindre des objectifs/résultats spécifiques dans un laps de temps et une zone géographique prédéfinis au moyen d’un budget fixé à l’avance. Les projets peuvent différer considérablement par leurs objectifs, leur complexité, les montants en jeu et leur durée. Si les petits projets ne mettent en jeu que des ressources financières modestes et ne durent souvent que quelques mois, les grands projets peuvent porter sur des montants substantiels, devoir être mis en œuvre par tranches et durer plusieurs années. Lorsqu’un grand projet se subdivise en plusieurs composantes, il est parfois appelé programme, mais doit néanmoins être comptabilisé dans la présente rubrique. Sont inclues les études de faisabilité, ainsi que les évaluations préalables ou rétrospectives (qu’elles soient conçues comme un volet du projet/programme ou qu’elles fassent l’objet de modalités de financement dédiées). Les études universitaires, la recherche et le développement, les formations, les bourses et autres activités d'assistance technique non directement liées aux projets/programmes de développement doivent plutôt être enregistrées sous D02. L’aide acheminée par l’intermédiaire d’ONG ou d’organisations multilatérales est également notifiée ici. Cela comprend les paiements effectués aux ONG et aux organisations multilatérales pour qu’elles mettent en œuvre les projets et programmes des donneurs, ainsi que le financement de projets spécifiques des ONG. En revanche, les contributions de caractère général aux ONG et aux organisations multilatérales ainsi que les contributions aux fonds à objectif spécifique sont notifiées sous B. * Dans le cas d’investissements sous forme de prises de participation, d’une aide humanitaire ou d’une aide par l’intermédiaire d’ONG, les projets sont notifiés ici même s’ils ne font pas l’objet d’un accord direct avec le pays partenaire. Les contributions aux fonds d'affectation spéciale à donateur unique et les contributions aux fonds d'affectation spéciale destinés à un guichet de financement et/ou à un pays spécifiques sont enregistrées sous B033.</narrative>
+                <narrative>A project is a set of inputs, activities and outputs, agreed with the partner country*, to reach specific objectives/outcomes within a defined time frame, with a defined budget and a  defined geographical area. Projects can vary significantly in terms of objectives, complexity, amounts involved and duration. There are smaller projects that might involve modest financial resources and last only a few months, whereas large projects might involve more significant amounts, entail successive phases and last for many years. A large project with a number of different components is sometimes referred to as a programme, but should nevertheless be recorded here. Feasibility studies, appraisals and evaluations are included (when designed as part of projects/programmes or dedicated funding arrangements). Monitoring, auditing and situation analyses of projects and programmes are also included. Academic studies, research and development, trainings, scholarships, and other technical assistance activities not directly linked to development projects/programmes should instead be recorded under D02. Aid channelled through NGOs or multilaterals is also recorded here. This includes payments for NGOs and multilaterals to implement donors’ projects and programmes, and funding of specified NGOs projects. By contrast, core funding of NGOs and multilaterals as well as contributions to specific-purpose funds are recorded under B.* In the cases of equity investments, humanitarian aid or aid channelled through NGOs, projects are recorded here even if there was no direct agreement between the donor and the partner country. Contributions to single-donor trust funds and contributions to trust funds earmarked for a specific funding window and/or country are recorded under B033.</narrative>
+                <narrative xml:lang="fr">Un projet est un ensemble d’éléments, d’activités et de produits, convenus avec le pays partenaire*, en vue d’atteindre des objectifs/résultats spécifiques dans un laps de temps et une zone géographique prédéfinis au moyen d’un budget fixé à l’avance. Les projets peuvent différer considérablement par leurs objectifs, leur complexité, les montants en jeu et leur durée. Si les petits projets ne mettent en jeu que des ressources financières modestes et ne durent souvent que quelques mois, les grands projets peuvent porter sur des montants substantiels, devoir être mis en œuvre par tranches et durer plusieurs années. Lorsqu’un grand projet se subdivise en plusieurs composantes, il est parfois appelé programme, mais doit néanmoins être comptabilisé dans la présente rubrique. Sont inclues les études de faisabilité, ainsi que les évaluations préalables ou rétrospectives (lorsqu’elles sont conçues comme un volet du projet/programme ou qu’elles font l’objet de modalités de financement dédiées). Le suivi, l'audit et les analyses de situation des projets et programmes sont également inclus. Les études universitaires, la recherche et le développement, les formations, les bourses et autres activités d'assistance technique non directement liées aux projets/programmes de développement doivent plutôt être enregistrées sous D02. L’aide acheminée par l’intermédiaire d’ONG ou d’organisations multilatérales est également notifiée ici. Cela comprend les paiements effectués aux ONG et aux organisations multilatérales pour qu’elles mettent en œuvre les projets et programmes des donneurs, ainsi que le financement de projets spécifiques des ONG. En revanche, les contributions de caractère général aux ONG et aux organisations multilatérales ainsi que les contributions aux fonds à objectif spécifique sont notifiées sous B. * Dans le cas d’investissements sous forme de prises de participation, d’une aide humanitaire ou d’une aide par l’intermédiaire d’ONG, les projets sont notifiés ici même s’ils ne font pas l’objet d’un accord direct avec le pays partenaire. Les contributions aux fonds d'affectation spéciale à donateur unique et les contributions aux fonds d'affectation spéciale destinés à un guichet de financement et/ou à un pays spécifiques sont enregistrées sous B033.</narrative>
             </description>
             <category>C</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>D01</code>
             <name>
                 <narrative>Donor country personnel</narrative>
@@ -165,7 +213,43 @@
             </description>
             <category>D</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>D011</code>
+            <name>
+                <narrative>(for SSC providers only) In-kind technical cooperation. Experts costs</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) In-kind technical cooperation. Experts costs</narrative>
+            </name>
+            <description>
+                <narrative>Expenses related to hiring specialists, technical hours of government officials and opportunity costs, directly associated with the technical co-operation activity.</narrative>
+                <narrative xml:lang="fr">Expenses related to hiring specialists, technical hours of government officials and opportunity costs, directly associated with the technical co-operation activity.</narrative>
+            </description>
+            <category>D01</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>D012</code>
+            <name>
+                <narrative>(for SSC providers only) In-kind technical cooperation experts. Travel related costs</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) In-kind technical cooperation experts. Travel related costs</narrative>
+            </name>
+            <description>
+                <narrative>Expenses related to per diems, daily allowances and airfares, that are directly associated with the technical co-operation activity. Also includes expenditures for travel-related costs of volunteers.</narrative>
+                <narrative xml:lang="fr">Expenses related to per diems, daily allowances and airfares, that are directly associated with the technical co-operation activity. Also includes expenditures for travel-related costs of volunteers.</narrative>
+            </description>
+            <category>D01</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>D013</code>
+            <name>
+                <narrative>(for SSC providers only) In-kind technical cooperation. Services, materials, equipment and supplies.</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) In-kind technical cooperation. Services, materials, equipment and supplies.</narrative>
+            </name>
+            <description>
+                <narrative>Expenses regarding the acquisition of services, materials, equipment and supplies that are needed to deliver technical co-operation activities/projects between developing countries.</narrative>
+                <narrative xml:lang="fr">Expenses regarding the acquisition of services, materials, equipment and supplies that are needed to deliver technical co-operation activities/projects between developing countries.</narrative>
+            </description>
+            <category>D01</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>D02</code>
             <name>
                 <narrative>Other technical assistance</narrative>
@@ -177,7 +261,19 @@
             </description>
             <category>D</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>D021</code>
+            <name>
+                <narrative>(for SSC providers only) Training</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) Training</narrative>
+            </name>
+            <description>
+                <narrative>Includes the provision of training using internationally or locally recruited experts. This category also covers various capacity building activities such as conferences, seminars, workshops, exchange visits.</narrative>
+                <narrative xml:lang="fr">Includes the provision of training using internationally or locally recruited experts. This category also covers various capacity building activities such as conferences, seminars, workshops, exchange visits.</narrative>
+            </description>
+            <category>D02</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>E01</code>
             <name>
                 <narrative>Scholarships/training in donor country</narrative>
@@ -189,7 +285,7 @@
             </description>
             <category>E</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>E02</code>
             <name>
                 <narrative>Imputed student costs</narrative>
@@ -201,7 +297,7 @@
             </description>
             <category>E</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active">
             <code>F01</code>
             <name>
                 <narrative>Debt relief</narrative>
@@ -213,7 +309,31 @@
             </description>
             <category>F</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>F02</code>
+            <name>
+                <narrative>Debt relief - principal (original loan not recorded in TOSSD)</narrative>
+                <narrative xml:lang="fr">Debt relief - principal (original loan not recorded in TOSSD)</narrative>
+            </name>
+            <description>
+                <narrative>Principal component of a debt relief operation, in cases where the loans concerned were not previously recorded in TOSSD (private claims or official claims not previously recorded in TOSSD).</narrative>
+                <narrative xml:lang="fr">Principal component of a debt relief operation, in cases where the loans concerned were not previously recorded in TOSSD (private claims or official claims not previously recorded in TOSSD).</narrative>
+            </description>
+            <category>F</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>F03</code>
+            <name>
+                <narrative>Debt relief - interest</narrative>
+                <narrative xml:lang="fr">Debt relief - interest</narrative>
+            </name>
+            <description>
+                <narrative>Interest component of a debt relief operation (interests in arrears and late interests).</narrative>
+                <narrative xml:lang="fr">Interest component of a debt relief operation (interests in arrears and late interests).</narrative>
+            </description>
+            <category>F</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>G01</code>
             <name>
                 <narrative>Administrative costs not included elsewhere</narrative>
@@ -225,7 +345,19 @@
             </description>
             <category>G</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>H00</code>
+            <name>
+                <narrative>Expenditures in the provider country</narrative>
+                <narrative xml:lang="fr">Expenditures in the provider country</narrative>
+            </name>
+            <description>
+                <narrative>Expenditures in the provider country not included elsewhere.</narrative>
+                <narrative xml:lang="fr">Expenditures in the provider country not included elsewhere.</narrative>
+            </description>
+            <category>H</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>H01</code>
             <name>
                 <narrative>Development awareness</narrative>
@@ -237,7 +369,7 @@
             </description>
             <category>H</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="active" activation-date="2018-01-01">
             <code>H02</code>
             <name>
                 <narrative>Refugees/asylum seekers in donor countries</narrative>
@@ -249,7 +381,7 @@
             </description>
             <category>H</category>
         </codelist-item>
-        <codelist-item status="active">
+        <codelist-item status="active" activation-date="2018-01-01">
             <code>H03</code>
             <name>
                 <narrative>Asylum-seekers ultimately accepted</narrative>
@@ -261,7 +393,7 @@
             </description>
             <category>H</category>
         </codelist-item>
-        <codelist-item status="active">
+        <codelist-item status="active" activation-date="2018-01-01">
             <code>H04</code>
             <name>
                 <narrative>Asylum-seekers ultimately rejected</narrative>
@@ -273,7 +405,7 @@
             </description>
             <category>H</category>
         </codelist-item>
-        <codelist-item status="active">
+        <codelist-item status="active" activation-date="2018-01-01">
             <code>H05</code>
             <name>
                 <narrative>Recognised refugees</narrative>
@@ -285,7 +417,7 @@
             </description>
             <category>H</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2023-01-01">
+        <codelist-item status="active" activation-date="2022-01-01">
             <code>H06</code>
             <name>
                 <narrative>Refugees and asylum seekers in other provider countries</narrative>
@@ -296,6 +428,138 @@
                 <narrative xml:lang="fr">Coûts encourus dans d'autres pays fournisseurs non éligibles à l'APD pour l'assistance de base aux demandeurs d'asile et aux réfugiés des pays en développement, jusqu'à 12 mois. Le pays d'accueil et d'origine des réfugiés/demandeurs d'asile doit être précisé dans l'un des champs descriptifs du SNPC (champs 14 ou 19).</narrative>
             </description>
             <category>H</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>I01</code>
+            <name>
+                <narrative>Support to refugees/protected persons in the provider country (up to 12 months of their stay)</narrative>
+                <narrative xml:lang="fr">Support to refugees/protected persons in the provider country (up to 12 months of their stay)</narrative>
+            </name>
+            <description>
+                <narrative>Costs incurred in provider countries for basic assistance to asylum seekers, refugees and protected persons from TOSSD-eligible countries, up to 12 months. Reportable under Pillar II.</narrative>
+                <narrative xml:lang="fr">Costs incurred in provider countries for basic assistance to asylum seekers, refugees and protected persons from TOSSD-eligible countries, up to 12 months. Reportable under Pillar II.</narrative>
+            </description>
+            <category>I</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>I02</code>
+            <name>
+                <narrative>Support to refugees/protected persons in the provider country (beyond the 12-month period)</narrative>
+                <narrative xml:lang="fr">Support to refugees/protected persons in the provider country (beyond the 12-month period)</narrative>
+            </name>
+            <description>
+                <narrative>Costs incurred in provider countries for basic assistance to asylum seekers, refugees and protected persons from TOSSD-eligible countries, beyond the 12-month period, to the extent that the individual is not recognised by the competent authorities of the country in which he/she has sought asylum as having the rights and obligations which are attached to the possession of residency or nationality of that country. Reportable under Pillar II.</narrative>
+                <narrative xml:lang="fr">Costs incurred in provider countries for basic assistance to asylum seekers, refugees and protected persons from TOSSD-eligible countries, beyond the 12-month period, to the extent that the individual is not recognised by the competent authorities of the country in which he/she has sought asylum as having the rights and obligations which are attached to the possession of residency or nationality of that country. Reportable under Pillar II.</narrative>
+            </description>
+            <category>I</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2019-01-01" withdrawal-date="2021-12-31">
+            <code>I03</code>
+            <name>
+                <narrative>Support to refugees/protected persons - in other countries of asylum</narrative>
+                <narrative xml:lang="fr">Support to refugees/protected persons - in other countries of asylum</narrative>
+            </name>
+            <description>
+                <narrative>Financial, material or technical support to asylum seekers, refugees and protected persons in other host countries. Reportable under Pillar I.</narrative>
+                <narrative xml:lang="fr">Financial, material or technical support to asylum seekers, refugees and protected persons in other host countries. Reportable under Pillar I.</narrative>
+            </description>
+            <category>I</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" activation-date="2019-01-01" withdrawal-date="2021-12-31">
+            <code>I04</code>
+            <name>
+                <narrative>Support to refugees/protected persons - voluntary returns</narrative>
+                <narrative xml:lang="fr">Support to refugees/protected persons - voluntary returns</narrative>
+            </name>
+            <description>
+                <narrative>Support to refugees, asylum seekers and protected persons voluntarily returning to their countries of origin, nationality or last habitual residence.  Excluding pre-departure assistance. Reportable under Pillar I.</narrative>
+                <narrative xml:lang="fr">Support to refugees, asylum seekers and protected persons voluntarily returning to their countries of origin, nationality or last habitual residence.  Excluding pre-departure assistance. Reportable under Pillar I.</narrative>
+            </description>
+            <category>I</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>I05</code>
+            <name>
+                <narrative>Support to refugees/protected persons/migrants for their integration in the economy of provider countries</narrative>
+                <narrative xml:lang="fr">Support to refugees/protected persons/migrants for their integration in the economy of provider countries</narrative>
+            </name>
+            <description>
+                <narrative>Costs incurred in provider countries for promoting the integration in their economy of asylum seekers, refugees, protected persons and migrants from TOSSD-eligible countries. Covers activities that promote the integration in the economy and culture of the provider country (including language training, vocational training, social protection schemes, employment programmes, awareness on national culture), up to the first 5 years of stay. Temporary sustenance/basic assistance is covered under modalities I01 and I02. Reportable under Pillar II.</narrative>
+                <narrative xml:lang="fr">Costs incurred in provider countries for promoting the integration in their economy of asylum seekers, refugees, protected persons and migrants from TOSSD-eligible countries. Covers activities that promote the integration in the economy and culture of the provider country (including language training, vocational training, social protection schemes, employment programmes, awareness on national culture), up to the first 5 years of stay. Temporary sustenance/basic assistance is covered under modalities I01 and I02. Reportable under Pillar II.</narrative>
+            </description>
+            <category>I</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>J01</code>
+            <name>
+                <narrative>In-kind donations of goods</narrative>
+                <narrative xml:lang="fr">Dons en nature de biens</narrative>
+            </name>
+            <description>
+                <narrative>Donation of goods and materials. Includes food, equipment (including medical equipment), materials, and motor vehicles.</narrative>
+                <narrative xml:lang="fr">Dons de biens et de matériel. Cela comprend des denrées alimentaires, de l'équipement (y compris du matériel médical), des matériaux et des véhicules motorisés.</narrative>
+            </description>
+            <category>J</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>K01</code>
+            <name>
+                <narrative>(for SSC providers only) Research and development</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) Research and development</narrative>
+            </name>
+            <description>
+                <narrative>Disbursements for joint research projects between two or more developing countries, covering the working time and opportunity costs of scientists/specialists and other research personnel from the reporting country as well as expenses for scientific-related infrastructure and services (labs, equipment, materials, supplies) directly associated with the research activity.</narrative>
+                <narrative xml:lang="fr">Disbursements for joint research projects between two or more developing countries, covering the working time and opportunity costs of scientists/specialists and other research personnel from the reporting country as well as expenses for scientific-related infrastructure and services (labs, equipment, materials, supplies) directly associated with the research activity.</narrative>
+            </description>
+            <category>K</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>K011</code>
+            <name>
+                <narrative>(for SSC providers only) Scientific-related infrastructure</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) Scientific-related infrastructure</narrative>
+            </name>
+            <description>
+                <narrative>Laboratories, equipment and supplies directly associated with research and development activities.</narrative>
+                <narrative xml:lang="fr">Laboratories, equipment and supplies directly associated with research and development activities.</narrative>
+            </description>
+            <category>K01</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>K012</code>
+            <name>
+                <narrative>(for SSC providers only) Research personnel</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) Research personnel</narrative>
+            </name>
+            <description>
+                <narrative>Covers working hours and opportunity costs of scientists/specialists and other research personnel from the reporting country.</narrative>
+                <narrative xml:lang="fr">Covers working hours and opportunity costs of scientists/specialists and other research personnel from the reporting country.</narrative>
+            </description>
+            <category>K01</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2022-01-01">
+            <code>K02</code>
+            <name>
+                <narrative>RESEARCH AND DEVELOPMENT (R&amp;D)</narrative>
+                <narrative xml:lang="fr">RESEARCH AND DEVELOPMENT (R&amp;D)</narrative>
+            </name>
+            <description>
+                <narrative>Research and experimental development comprising creative and systematic work undertaken in order to increase the stock of knowledge – including knowledge of humankind, culture and society – and to devise new applications of available knowledge.</narrative>
+                <narrative xml:lang="fr">Research and experimental development comprising creative and systematic work undertaken in order to increase the stock of knowledge – including knowledge of humankind, culture and society – and to devise new applications of available knowledge.</narrative>
+            </description>
+            <category>K</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>L01</code>
+            <name>
+                <narrative>(for SSC providers only) Direct cash transfers under social development public programmes in partner countries</narrative>
+                <narrative xml:lang="fr">(for SSC providers only) Direct cash transfers under social development public programmes in partner countries</narrative>
+            </name>
+            <description>
+                <narrative>Direct cash transfers expenditure benefiting individuals, in the context of public programmes of sustainable development in partner countries (with the consent and support of the partner country).</narrative>
+                <narrative xml:lang="fr">Direct cash transfers expenditure benefiting individuals, in the context of public programmes of sustainable development in partner countries (with the consent and support of the partner country).</narrative>
+            </description>
+            <category>L</category>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -15,6 +15,7 @@
                 <narrative>Public Sector Institutions</narrative>
                 <narrative xml:lang="fr">Institutions du secteur public</narrative>
             </name>
+            <category>10000</category>
         </codelist-item>
         <codelist-item status="active">
             <code>11000</code>
@@ -27,24 +28,24 @@
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11001</code>
             <name>
-                <narrative>Central Government</narrative>
-                <narrative xml:lang="fr">Gouvernment central</narrative>
+                <narrative>Central Government (donor govt.)</narrative>
+                <narrative xml:lang="fr">Gouvernment central (gouv. du donneur)</narrative>
             </name>
             <category>11000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11002</code>
             <name>
-                <narrative>Local Government</narrative>
-                <narrative xml:lang="fr">Gouvernment local</narrative>
+                <narrative>Local Government (donor govt.)</narrative>
+                <narrative xml:lang="fr">Gouvernment local (gouv. du donneur)</narrative>
             </name>
             <category>11000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11003</code>
             <name>
-                <narrative>Public corporations</narrative>
-                <narrative xml:lang="fr">Entreprise publique</narrative>
+                <narrative>Public corporations (donor govt.)</narrative>
+                <narrative xml:lang="fr">Entreprise publique (gouv. du donneur)</narrative>
             </name>
             <category>11000</category>
         </codelist-item>
@@ -67,24 +68,24 @@
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12001</code>
             <name>
-                <narrative>Central Government</narrative>
-                <narrative xml:lang="fr">Gouvernment central</narrative>
+                <narrative>Central Government (recipient govt.)</narrative>
+                <narrative xml:lang="fr">Gouvernment central (gouv. du bénéficiaire)</narrative>
             </name>
             <category>12000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12002</code>
             <name>
-                <narrative>Local Government</narrative>
-                <narrative xml:lang="fr">Gouvernment local</narrative>
+                <narrative>Local Government (recipient govt.)</narrative>
+                <narrative xml:lang="fr">Gouvernment local (gouv. du bénéficiaire)</narrative>
             </name>
             <category>12000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12003</code>
             <name>
-                <narrative>Public corporations</narrative>
-                <narrative xml:lang="fr">Entreprise publique</narrative>
+                <narrative>Public corporations (recipient govt.)</narrative>
+                <narrative xml:lang="fr">Entreprise publique (gouv. du bénéficiaire)</narrative>
             </name>
             <category>12000</category>
         </codelist-item>
@@ -110,6 +111,7 @@
                 <narrative>Non-Governmental Organisation (NGO) and Civil Society</narrative>
                 <narrative xml:lang="fr">Organisations non gouvernementales (ONG) et société civile</narrative>
             </name>
+            <category>20000</category>
         </codelist-item>
         <codelist-item status="active">
             <code>21000</code>
@@ -239,7 +241,7 @@
             </name>
             <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2010-01-01">
+        <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2018-12-31">
             <code>21017</code>
             <name>
                 <narrative>International Centre for Trade and Sustainable Development</narrative>
@@ -603,7 +605,7 @@
             <code>21063</code>
             <name>
                 <narrative>Conservation International</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Conservation International</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -619,7 +621,7 @@
             <code>21501</code>
             <name>
                 <narrative>OXFAM International</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">OXFAM International</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -627,7 +629,7 @@
             <code>21502</code>
             <name>
                 <narrative>World Vision</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">World Vision</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -635,7 +637,7 @@
             <code>21503</code>
             <name>
                 <narrative>Family Health International 360</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Family Health International 360</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -643,7 +645,7 @@
             <code>21504</code>
             <name>
                 <narrative>International Relief and Development</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">International Relief and Development</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -651,7 +653,7 @@
             <code>21505</code>
             <name>
                 <narrative>Save the Children</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Save the Children</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -659,7 +661,7 @@
             <code>21506</code>
             <name>
                 <narrative>International Rescue Committee</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">International Rescue Committee</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -667,15 +669,23 @@
             <code>21507</code>
             <name>
                 <narrative>Pact World</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Pact World</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2022-01-01" withdrawal-date="2022-12-31">
+        <codelist-item status="active" activation-date="2022-01-01">
             <code>21508</code>
             <name>
                 <narrative>Sustainable Energy for All</narrative>
                 <narrative xml:lang="fr">Sustainable Energy for All</narrative>
+            </name>
+            <category>21000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>21509</code>
+            <name>
+                <narrative>AmplifyChange</narrative>
+                <narrative xml:lang="fr">AmplifyChange</narrative>
             </name>
             <category>21000</category>
         </codelist-item>
@@ -691,7 +701,7 @@
             <code>22501</code>
             <name>
                 <narrative>OXFAM - provider country office</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">OXFAM - provider country office</narrative>
             </name>
             <category>22000</category>
         </codelist-item>
@@ -699,7 +709,7 @@
             <code>22502</code>
             <name>
                 <narrative>Save the Children - donor country office</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Save the Children - donor country office</narrative>
             </name>
             <category>22000</category>
         </codelist-item>
@@ -725,6 +735,7 @@
                 <narrative>Public-Private Partnerships (PPP) and Networks</narrative>
                 <narrative xml:lang="fr">Partenariats public-privé (PPP) et réseaux</narrative>
             </name>
+            <category>30000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30001</code>
@@ -926,11 +937,11 @@
             </name>
             <category>32000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2017-01-01">
+        <codelist-item status="active" activation-date="2022-01-01">
             <code>31006</code>
             <name>
                 <narrative>Coalition for Epidemic Preparedness Innovations</narrative>
-                <narrative xml:lang="fr">Coalition pour les innovations en matière de préparation</narrative>
+                <narrative xml:lang="fr">Coalition pour les innovations en matière de préparation aux épidémies</narrative>
             </name>
             <category>31000</category>
         </codelist-item>
@@ -939,6 +950,14 @@
             <name>
                 <narrative>Drugs for Neglected Diseases initative</narrative>
                 <narrative xml:lang="fr">Initiative médicaments contres les maladies négligées</narrative>
+            </name>
+            <category>32000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>31008</code>
+            <name>
+                <narrative>Foundation for Innovative New Diagnostics</narrative>
+                <narrative xml:lang="fr">Fondation pour les nouveaux diagnostics innovants</narrative>
             </name>
             <category>32000</category>
         </codelist-item>
@@ -956,6 +975,7 @@
                 <narrative>Multilateral Organisations</narrative>
                 <narrative xml:lang="fr">Organisations multilatérales</narrative>
             </name>
+            <category>40000</category>
         </codelist-item>
         <codelist-item status="active">
             <code>41000</code>
@@ -1104,7 +1124,7 @@
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41121</code>
             <name>
-                <narrative>United Nations Office of the United Nations High Commissioner for Refugees</narrative>
+                <narrative>United Nations Office of the High Commissioner for Refugees</narrative>
                 <narrative xml:lang="fr">Haut Commissariat des Nations Unies pour les réfugiés</narrative>
             </name>
             <category>41100</category>
@@ -1325,7 +1345,7 @@
             </name>
             <category>41100</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2020-01-01">
+        <codelist-item status="active" activation-date="2023-01-01">
             <code>41150</code>
             <name>
                 <narrative>United Nations Institute for Disarmament Research</narrative>
@@ -1341,13 +1361,149 @@
             </name>
             <category>41300</category>
         </codelist-item>
-        <codelist-item status="withdrawn" activation-date="2020-01-01">
+        <codelist-item status="active" activation-date="2020-01-01">
             <code>41200</code>
             <name>
                 <narrative>UN entities (core contributions reportable in TOSSD only)</narrative>
                 <narrative xml:lang="fr">Entités des Nations Unies (contributions de base à déclarer dans TOSSD uniquement)</narrative>
             </name>
             <category>41000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41201</code>
+            <name>
+                <narrative>Comprehensive Nuclear Test Ban Treaty Organization</narrative>
+                <narrative xml:lang="fr">Organisation du traité d'interdiction complète des essais nucléaires</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41202</code>
+            <name>
+                <narrative>International Civil Aviation Organization</narrative>
+                <narrative xml:lang="fr">Organisation de l'aviation civile internationale</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41203</code>
+            <name>
+                <narrative>International Criminal Court</narrative>
+                <narrative xml:lang="fr">Cour Pénale Internationale</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41204</code>
+            <name>
+                <narrative>International Residual Mechanism for Criminal Tribunals</narrative>
+                <narrative xml:lang="fr">Mécanisme international appelé à exercer les fonctions résiduelles des Tribunaux pénaux</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41205</code>
+            <name>
+                <narrative>International Seabed Authority</narrative>
+                <narrative xml:lang="fr">Autorité internationale des fonds marins</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41206</code>
+            <name>
+                <narrative>International Tribunal for the Law of the Sea</narrative>
+                <narrative xml:lang="fr">Tribunal international du droit de la mer</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41207</code>
+            <name>
+                <narrative>Organization for the Prohibition of Chemical Weapons</narrative>
+                <narrative xml:lang="fr">Organisation pour l'interdiction des Armes Chimiques</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41208</code>
+            <name>
+                <narrative>Department of Economic and Social Affairs</narrative>
+                <narrative xml:lang="fr">Département des affaires économiques et sociales</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41209</code>
+            <name>
+                <narrative>Department of General Assembly and Conference Management</narrative>
+                <narrative xml:lang="fr">Département de l'Assemblée générale et de la gestion des conférences</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41210</code>
+            <name>
+                <narrative>Department of Global Communications</narrative>
+                <narrative xml:lang="fr">Département de la communication globale</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41211</code>
+            <name>
+                <narrative>Department of Management Strategy, Policy and Compliance, including UNOG, UNOV and UNON</narrative>
+                <narrative xml:lang="fr">Département des stratégies et politiques de gestion et de la conformité, y compris ? including ONUN, ONUG et ONUV</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41212</code>
+            <name>
+                <narrative>Department of Operational Support</narrative>
+                <narrative xml:lang="fr">Département de l’appui opérationnel</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41213</code>
+            <name>
+                <narrative>Department of Safety and Security</narrative>
+                <narrative xml:lang="fr">Département de la sûreté et de la sécurité</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41214</code>
+            <name>
+                <narrative>Office of Counter-Terrorism</narrative>
+                <narrative xml:lang="fr">Bureau de lutte contre le terrorisme</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>41215</code>
+            <name>
+                <narrative>United Nations Interregional Crime and Justice Research Institute</narrative>
+                <narrative xml:lang="fr">Institut interrégional de recherche des Nations unies sur la criminalité et la justice</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>41216</code>
+            <name>
+                <narrative>International Maritime Organization</narrative>
+                <narrative xml:lang="fr">International Maritime Organization</narrative>
+            </name>
+            <category>41200</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
+            <code>41217</code>
+            <name>
+                <narrative>World Trade Organisation</narrative>
+                <narrative xml:lang="fr">Organisation mondiale du commerce</narrative>
+            </name>
+            <category>41200</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41300</code>
@@ -1569,7 +1725,7 @@
             <code>41501</code>
             <name>
                 <narrative>United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
             </name>
             <category>41400</category>
         </codelist-item>
@@ -1585,7 +1741,7 @@
             <code>41503</code>
             <name>
                 <narrative>UN-led Country-based Pooled Funds</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">UN-led Country-based Pooled Funds</narrative>
             </name>
             <category>41400</category>
         </codelist-item>
@@ -1595,13 +1751,17 @@
                 <narrative>Existing UN channels not included in Standard I - UN entity- of the UN Data Cube reporting framework</narrative>
                 <narrative xml:lang="fr">Canaux de l'ONU existants non inclus dans la norme I du cadre de reporting du cube de l'ONU</narrative>
             </name>
-            <description>
-                <narrative>Canaux existants de l'ONU non inclus dans la norme I - entité des Nations Unies - du cadre de reporting du cube de données de l'ONU</narrative>
-                <narrative xml:lang="fr"/>
-            </description>
             <category>41000</category>
         </codelist-item>
-        <codelist-item status="withdrawn" activation-date="2021-01-01">
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>41601</code>
+            <name>
+                <narrative>United Nations Office for Disarmament Affairs</narrative>
+                <narrative xml:lang="fr">United Nations Office for Disarmament Affairs</narrative>
+            </name>
+            <category>41600</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2021-01-01">
             <code>41700</code>
             <name>
                 <narrative>UN entities, non-core contributions</narrative>
@@ -1721,7 +1881,7 @@
             </name>
             <category>43000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2015-01-01">
+        <codelist-item status="active" activation-date="2022-01-01">
             <code>43007</code>
             <name>
                 <narrative>IMF’s Resilience and Sustainability Trust</narrative>
@@ -1801,7 +1961,7 @@
             </name>
             <category>44000</category>
         </codelist-item>
-        <codelist-item status="active">
+        <codelist-item status="withdrawn" withdrawal-date="2026-04-02">
             <code>45000</code>
             <name>
                 <narrative>World Trade Organisation (WTO)</narrative>
@@ -1828,8 +1988,8 @@
         <codelist-item status="active" activation-date="2020-01-01">
             <code>45003</code>
             <name>
-                <narrative>World Trade Organisation - Doha Development Agenda Global Trust Fund</narrative>
-                <narrative xml:lang="fr">Organisation mondiale du commerce - Fonds global d'affectation spéciale pour le Programme de Doha pour le développement</narrative>
+                <narrative>World Trade Organisation Global Trust Fund</narrative>
+                <narrative xml:lang="fr">Organisation mondiale du commerce - Fonds global d'affectation spéciale</narrative>
             </name>
             <category>41100</category>
         </codelist-item>
@@ -1921,7 +2081,7 @@
             </name>
             <category>46000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2009-01-01">
+        <codelist-item status="active" activation-date="2023-01-01">
             <code>46015</code>
             <name>
                 <narrative>European Bank for Reconstruction and Development</narrative>
@@ -1937,7 +2097,7 @@
             </name>
             <category>46000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2009-01-01">
+        <codelist-item status="active" activation-date="2023-01-01">
             <code>46017</code>
             <name>
                 <narrative>European Bank for Reconstruction and Development - technical co-operation and special funds (all EBRD countries of operations)</narrative>
@@ -2013,7 +2173,7 @@
             <code>46026</code>
             <name>
                 <narrative>Asian Infrastructure Investment Bank</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Asian Infrastructure Investment Bank</narrative>
             </name>
             <category>46000</category>
         </codelist-item>
@@ -2022,6 +2182,14 @@
             <name>
                 <narrative>Financial Fund for the Development of the River Plate Basin</narrative>
                 <narrative xml:lang="fr">Fonds financier pour le développement du bassin fluvial de la Plata</narrative>
+            </name>
+            <category>46000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>46028</code>
+            <name>
+                <narrative>New Development Bank</narrative>
+                <narrative xml:lang="fr">Nouvelle banque de développement</narrative>
             </name>
             <category>46000</category>
         </codelist-item>
@@ -3125,7 +3293,7 @@
             <code>47145</code>
             <name>
                 <narrative>Center of Excellence in Finance</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Center of Excellence in Finance</narrative>
             </name>
             <category>47000</category>
         </codelist-item>
@@ -3133,7 +3301,7 @@
             <code>47146</code>
             <name>
                 <narrative>International Investment Bank</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">International Investment Bank</narrative>
             </name>
             <category>47000</category>
         </codelist-item>
@@ -3161,11 +3329,43 @@
             </name>
             <category>47000</category>
         </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>47150</code>
+            <name>
+                <narrative>Secretaría General Iberoamericana</narrative>
+                <narrative xml:lang="fr">Secretaría General Iberoamericana</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47151</code>
+            <name>
+                <narrative>Arab Bank for Economic Development in Africa</narrative>
+                <narrative xml:lang="fr">Banque arabe de développement économique en Afrique</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47152</code>
+            <name>
+                <narrative>Arab Fund for Economic and Social Development</narrative>
+                <narrative xml:lang="fr">Fonds arabe pour le développement économique et social</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47153</code>
+            <name>
+                <narrative>IFAD Core additional climate contributions</narrative>
+                <narrative xml:lang="fr">FIDA Contributions additionnelles de base pour le climat</narrative>
+            </name>
+            <category>41100</category>
+        </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>47400</code>
             <name>
                 <narrative>European Space Agency (ESA) programme 'Space in support of International Development Aid'</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">European Space Agency (ESA) programme 'Space in support of International Development Aid'</narrative>
             </name>
             <category>47000</category>
         </codelist-item>
@@ -3181,15 +3381,15 @@
             <code>47502</code>
             <name>
                 <narrative>Global Fund for Disaster Risk Reduction</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Global Fund for Disaster Risk Reduction</narrative>
             </name>
             <category>47000</category>
         </codelist-item>
-        <codelist-item status="active" activation-date="2014-01-01">
+        <codelist-item status="active" activation-date="2023-01-01">
             <code>47503</code>
             <name>
                 <narrative>Global Agriculture and Food Security Program</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Global Agriculture and Food Security Program</narrative>
             </name>
             <category>47000</category>
         </codelist-item>
@@ -3197,7 +3397,63 @@
             <code>47504</code>
             <name>
                 <narrative>Forest Carbon Partnership Facility</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Forest Carbon Partnership Facility</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47701</code>
+            <name>
+                <narrative>Global Environment Facility - Global biodiversity framework fund</narrative>
+                <narrative xml:lang="fr">FEM Fonds du cadre mondial pour la biodiversité</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>47702</code>
+            <name>
+                <narrative>Cali Fund For the Fair and Equitable Sharing of Benefits from the use of Digital Sequence Information on Genetic Resources (DSI)</narrative>
+                <narrative xml:lang="fr">Cali Fund For the Fair and Equitable Sharing of Benefits from the use of Digital Sequence Information on Genetic Resources (DSI)</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>47703</code>
+            <name>
+                <narrative>Kunming Biodiversity Fund</narrative>
+                <narrative xml:lang="fr">Kunming Biodiversity Fund</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>47704</code>
+            <name>
+                <narrative>SESRIC</narrative>
+                <narrative xml:lang="fr">SESRIC</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>47705</code>
+            <name>
+                <narrative>Interpol</narrative>
+                <narrative xml:lang="fr">Interpol</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>47706</code>
+            <name>
+                <narrative>Eurasian Fund for Stabilization and Development</narrative>
+                <narrative xml:lang="fr">Eurasian Fund for Stabilization and Development</narrative>
+            </name>
+            <category>47000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47707</code>
+            <name>
+                <narrative>Arab Monetary Fund</narrative>
+                <narrative xml:lang="fr">Arab Monetary Fund</narrative>
             </name>
             <category>47000</category>
         </codelist-item>
@@ -3214,7 +3470,7 @@
                 <narrative>University, college or other teaching institution, research institute or think-tank</narrative>
                 <narrative xml:lang="fr">Université, collège ou autre établissement d'enseignement, institut de recherche ou de réflexion</narrative>
             </name>
-            <category>50000</category>
+            <category>51000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>51001</code>
@@ -3238,6 +3494,7 @@
                 <narrative>Private Sector Institutions</narrative>
                 <narrative xml:lang="fr">Institutions du secteur privé</narrative>
             </name>
+            <category>60000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61000</code>
@@ -3250,8 +3507,8 @@
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61001</code>
             <name>
-                <narrative>Banks (deposit taking corporations)</narrative>
-                <narrative xml:lang="fr">Banques (institutions de dépôts)</narrative>
+                <narrative>Banks (in provider country) (deposit taking corporations)</narrative>
+                <narrative xml:lang="fr">Banques (du pays donneur) (institutions de dépôts)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
@@ -3266,15 +3523,15 @@
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61003</code>
             <name>
-                <narrative>Investment funds and other collective investment institutions</narrative>
-                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
+                <narrative>Investment funds and other collective investment institutions (in provider country)</narrative>
+                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61004</code>
             <name>
-                <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
+                <narrative>Holding companies, trusts and Special Purpose Vehicles (in provider country)</narrative>
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
             </name>
             <category>61000</category>
@@ -3282,48 +3539,48 @@
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61005</code>
             <name>
-                <narrative>Insurance Corporations</narrative>
-                <narrative xml:lang="fr">Sociétés d’assurance</narrative>
+                <narrative>Insurance Corporations (in provider country)</narrative>
+                <narrative xml:lang="fr">Sociétés d’assurance (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61006</code>
             <name>
-                <narrative>Pension Funds</narrative>
-                <narrative xml:lang="fr">Fonds de pension</narrative>
+                <narrative>Pension Funds (in provider country)</narrative>
+                <narrative xml:lang="fr">Fonds de pension (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61007</code>
             <name>
-                <narrative>Other financial corporations</narrative>
-                <narrative xml:lang="fr">Autres sociétés financières</narrative>
+                <narrative>Other financial corporations (in provider country)</narrative>
+                <narrative xml:lang="fr">Autres sociétés financières (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61008</code>
             <name>
-                <narrative>Exporters</narrative>
-                <narrative xml:lang="fr">Exportateurs</narrative>
+                <narrative>Exporters (in provider country)</narrative>
+                <narrative xml:lang="fr">Exportateurs (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61009</code>
             <name>
-                <narrative>Other non-financial corporations</narrative>
-                <narrative xml:lang="fr">Autres sociétés non financières</narrative>
+                <narrative>Other non-financial corporations (in provider country)</narrative>
+                <narrative xml:lang="fr">Autres sociétés non financières (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61010</code>
             <name>
-                <narrative>Retail investors</narrative>
-                <narrative xml:lang="fr">Investisseurs individuels</narrative>
+                <narrative>Retail investors (in provider country)</narrative>
+                <narrative xml:lang="fr">Investisseurs individuels (du pays donneur)</narrative>
             </name>
             <category>61000</category>
         </codelist-item>
@@ -3338,56 +3595,56 @@
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62001</code>
             <name>
-                <narrative>Banks (deposit taking corporations except Micro Finance Institutions)</narrative>
-                <narrative xml:lang="fr">Banques (institutions de dépôts hors institutions de microfinancement)</narrative>
+                <narrative>Banks (in recipient country) (deposit taking corporations except Micro Finance Institutions)</narrative>
+                <narrative xml:lang="fr">Banques (du pays bénéficiaire) (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62002</code>
             <name>
-                <narrative>Micro Finance Institutions (deposit and non-deposit)</narrative>
-                <narrative xml:lang="fr">Institutions de microfinancement (collectant ou pas des dépôts)</narrative>
+                <narrative>Micro Finance Institutions (in recipient country) (deposit and non-deposit)</narrative>
+                <narrative xml:lang="fr">Institutions de microfinancement (du pays bénéficiaire) (collectant ou pas des dépôts)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62003</code>
             <name>
-                <narrative>Investment funds and other collective investment institutions</narrative>
-                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
+                <narrative>Investment funds and other collective investment institutions (in recipient country)</narrative>
+                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62004</code>
             <name>
-                <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
-                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
+                <narrative>Holding companies, trusts and Special Purpose Vehicles (in recipient country)</narrative>
+                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62005</code>
             <name>
-                <narrative>Insurance Corporations</narrative>
-                <narrative xml:lang="fr">Sociétés d’assurance</narrative>
+                <narrative>Insurance Corporations (in recipient country)</narrative>
+                <narrative xml:lang="fr">Sociétés d’assurance (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62006</code>
             <name>
-                <narrative>Pension Funds</narrative>
-                <narrative xml:lang="fr">Fonds de pension</narrative>
+                <narrative>Pension Funds (in recipient country)</narrative>
+                <narrative xml:lang="fr">Fonds de pension (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62007</code>
             <name>
-                <narrative>Other financial corporations</narrative>
-                <narrative xml:lang="fr">Autres sociétés financières</narrative>
+                <narrative>Other financial corporations (in recipient country)</narrative>
+                <narrative xml:lang="fr">Autres sociétés financières (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
@@ -3402,16 +3659,16 @@
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62009</code>
             <name>
-                <narrative>Other non-financial corporations</narrative>
-                <narrative xml:lang="fr">Autres sociétés non financières</narrative>
+                <narrative>Other non-financial corporations (in recipient country)</narrative>
+                <narrative xml:lang="fr">Autres sociétés non financières (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62010</code>
             <name>
-                <narrative>Retail investors</narrative>
-                <narrative xml:lang="fr">Investisseurs individuels</narrative>
+                <narrative>Retail investors (in recipient country)</narrative>
+                <narrative xml:lang="fr">Investisseurs individuels (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
         </codelist-item>
@@ -3426,80 +3683,80 @@
         <codelist-item status="active" activation-date="2016-01-01">
             <code>63001</code>
             <name>
-                <narrative>Banks (deposit taking corporations except Micro Finance Institutions)</narrative>
-                <narrative xml:lang="fr">Banques (institutions de dépôts hors institutions de microfinancement)</narrative>
+                <narrative>Banks (in third country) (deposit taking corporations except Micro Finance Institutions)</narrative>
+                <narrative xml:lang="fr">Banques (d'un pays tiers) (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>63002</code>
             <name>
-                <narrative>Micro Finance Institutions (deposit and non-deposit)</narrative>
-                <narrative xml:lang="fr">Institutions de microfinancement (collectant ou pas des dépôts)</narrative>
+                <narrative>Micro Finance Institutions (in third country) (deposit and non-deposit)</narrative>
+                <narrative xml:lang="fr">Institutions de microfinancement (d'un pays tiers) (collectant ou pas des dépôts)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63003</code>
             <name>
-                <narrative>Investment funds and other collective investment institutions</narrative>
-                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs</narrative>
+                <narrative>Investment funds and other collective investment institutions (in third country)</narrative>
+                <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63004</code>
             <name>
-                <narrative>Holding companies, trusts and Special Purpose Vehicles</narrative>
-                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
+                <narrative>Holding companies, trusts and Special Purpose Vehicles (in third country)</narrative>
+                <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63005</code>
             <name>
-                <narrative>Insurance Corporations</narrative>
-                <narrative xml:lang="fr">Sociétés d’assurance</narrative>
+                <narrative>Insurance Corporations (in third country)</narrative>
+                <narrative xml:lang="fr">Sociétés d’assurance (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63006</code>
             <name>
-                <narrative>Pension Funds</narrative>
-                <narrative xml:lang="fr">Fonds de pension</narrative>
+                <narrative>Pension Funds (in third country)</narrative>
+                <narrative xml:lang="fr">Fonds de pension (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63007</code>
             <name>
-                <narrative>Other financial corporations</narrative>
-                <narrative xml:lang="fr">Autres sociétés financières</narrative>
+                <narrative>Other financial corporations (in third country)</narrative>
+                <narrative xml:lang="fr">Autres sociétés financières (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63008</code>
             <name>
-                <narrative>Exporters</narrative>
-                <narrative xml:lang="fr">Exportateurs</narrative>
+                <narrative>Exporters (in third country)</narrative>
+                <narrative xml:lang="fr">Exportateurs (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63009</code>
             <name>
-                <narrative>Other non-financial corporations</narrative>
-                <narrative xml:lang="fr">Autres sociétés non financières</narrative>
+                <narrative>Other non-financial corporations (in third country)</narrative>
+                <narrative xml:lang="fr">Autres sociétés non financières (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63010</code>
             <name>
-                <narrative>Retail investors</narrative>
-                <narrative xml:lang="fr">Investisseurs individuels</narrative>
+                <narrative>Retail investors (in third country)</narrative>
+                <narrative xml:lang="fr">Investisseurs individuels (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
         </codelist-item>
@@ -3509,6 +3766,7 @@
                 <narrative>Other</narrative>
                 <narrative xml:lang="fr">Autre</narrative>
             </name>
+            <category>90000</category>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -1,4 +1,4 @@
-<codelist name="CRSChannelCode" xml:lang="en" complete="1" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="CRSChannelCode" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
             <narrative>CRS Channel Code</narrative>
@@ -16,6 +16,8 @@
                 <narrative xml:lang="fr">Institutions du secteur public</narrative>
             </name>
             <category>10000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11000</code>
@@ -24,6 +26,8 @@
                 <narrative xml:lang="fr">Gouvernement du donneur</narrative>
             </name>
             <category>10000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11001</code>
@@ -32,6 +36,8 @@
                 <narrative xml:lang="fr">Gouvernment central (gouv. du donneur)</narrative>
             </name>
             <category>11000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11002</code>
@@ -40,6 +46,8 @@
                 <narrative xml:lang="fr">Gouvernment local (gouv. du donneur)</narrative>
             </name>
             <category>11000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11003</code>
@@ -48,6 +56,8 @@
                 <narrative xml:lang="fr">Entreprise publique (gouv. du donneur)</narrative>
             </name>
             <category>11000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11004</code>
@@ -56,6 +66,8 @@
                 <narrative xml:lang="fr">Autres entité publique dans le pays donneur</narrative>
             </name>
             <category>11000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12000</code>
@@ -64,6 +76,8 @@
                 <narrative xml:lang="fr">Gouvernement du bénéficiaire</narrative>
             </name>
             <category>10000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12001</code>
@@ -72,6 +86,8 @@
                 <narrative xml:lang="fr">Gouvernment central (gouv. du bénéficiaire)</narrative>
             </name>
             <category>12000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12002</code>
@@ -80,6 +96,8 @@
                 <narrative xml:lang="fr">Gouvernment local (gouv. du bénéficiaire)</narrative>
             </name>
             <category>12000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12003</code>
@@ -88,6 +106,8 @@
                 <narrative xml:lang="fr">Entreprise publique (gouv. du bénéficiaire)</narrative>
             </name>
             <category>12000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>12004</code>
@@ -96,6 +116,8 @@
                 <narrative xml:lang="fr">Autres entité publique dans le pays bénéficiaire</narrative>
             </name>
             <category>12000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>13000</code>
@@ -104,6 +126,8 @@
                 <narrative xml:lang="fr">Gouvernement tiers (coopération déléguée)</narrative>
             </name>
             <category>10000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>20000</code>
@@ -112,6 +136,8 @@
                 <narrative xml:lang="fr">Organisations non gouvernementales (ONG) et société civile</narrative>
             </name>
             <category>20000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21000</code>
@@ -120,6 +146,8 @@
                 <narrative xml:lang="fr">ONG internationales</narrative>
             </name>
             <category>20000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>21001</code>
@@ -128,6 +156,8 @@
                 <narrative xml:lang="fr">Association de géoscientifiques pour le développement international</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21002</code>
@@ -136,6 +166,8 @@
                 <narrative xml:lang="fr">Agence de coopération et d'information pour le commerce international</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21003</code>
@@ -144,6 +176,8 @@
                 <narrative xml:lang="fr">Conseil latino-américain des sciences sociales</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21004</code>
@@ -152,6 +186,8 @@
                 <narrative xml:lang="fr">Conseil pour le développement de la recherche en sciences sociales en Afrique</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
             <code>21005</code>
@@ -160,6 +196,8 @@
                 <narrative xml:lang="fr">Consumer Unity and Trust Society International</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21006</code>
@@ -168,6 +206,8 @@
                 <narrative xml:lang="fr">Development Gateway Foundation</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>21007</code>
@@ -176,6 +216,8 @@
                 <narrative xml:lang="fr">Centre international de liaison pour l’environnement</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21008</code>
@@ -184,6 +226,8 @@
                 <narrative xml:lang="fr">Eurostep</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21009</code>
@@ -192,6 +236,8 @@
                 <narrative xml:lang="fr">Forum pour la recherche agricole en Afrique</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21010</code>
@@ -200,6 +246,8 @@
                 <narrative xml:lang="fr">Forum des éducatrices africaines</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>21011</code>
@@ -208,6 +256,8 @@
                 <narrative xml:lang="fr">Campagne mondiale pour l’éducation</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1999-01-01">
             <code>21013</code>
@@ -216,6 +266,8 @@
                 <narrative xml:lang="fr">Health Action International</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21014</code>
@@ -224,6 +276,8 @@
                 <narrative xml:lang="fr">Systèmes d’Information et de Documentation sur les Droits de l’Homme</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21015</code>
@@ -232,6 +286,8 @@
                 <narrative xml:lang="fr">Association internationale rurale catholique</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>21016</code>
@@ -240,6 +296,8 @@
                 <narrative xml:lang="fr">Comité international de la Croix-Rouge</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2018-12-31">
             <code>21017</code>
@@ -248,6 +306,8 @@
                 <narrative xml:lang="fr">Centre international de commerce et de développement durable</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2000-01-01">
             <code>21018</code>
@@ -256,6 +316,8 @@
                 <narrative xml:lang="fr">Fédération internationale des Sociétés de la Croix-Rouge et du Croissant-Rouge</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21019</code>
@@ -264,6 +326,8 @@
                 <narrative xml:lang="fr">Fédération internationale des centres sociaux et communautaires</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>21020</code>
@@ -272,6 +336,8 @@
                 <narrative xml:lang="fr">International HIV/AIDS Alliance</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21021</code>
@@ -280,6 +346,8 @@
                 <narrative xml:lang="fr">Institut international pour l’environnement et le développement</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>21022</code>
@@ -288,6 +356,8 @@
                 <narrative xml:lang="fr">Réseau international d’institutions financières</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>21023</code>
@@ -296,6 +366,8 @@
                 <narrative xml:lang="fr">Fédération internationale pour le planning familial</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>21024</code>
@@ -304,6 +376,8 @@
                 <narrative xml:lang="fr">Inter Press Service, International Association</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21025</code>
@@ -312,6 +386,8 @@
                 <narrative xml:lang="fr">Centre séismologique international</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21026</code>
@@ -320,6 +396,8 @@
                 <narrative xml:lang="fr">Service International pour les Droits de l’Homme</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21027</code>
@@ -328,6 +406,8 @@
                 <narrative xml:lang="fr">ITF Améliorer la sécurité humaine</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21028</code>
@@ -336,6 +416,8 @@
                 <narrative xml:lang="fr">Fonds international d’échanges universitaires - Échanges intéressant l’Afrique et l’Amérique latine</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2001-01-01">
             <code>21029</code>
@@ -344,6 +426,8 @@
                 <narrative xml:lang="fr">Médecins Sans Frontières</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21030</code>
@@ -352,6 +436,8 @@
                 <narrative xml:lang="fr">Institut panafricain pour le développement</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>21031</code>
@@ -360,6 +446,8 @@
                 <narrative xml:lang="fr">Institut PANOS</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>21032</code>
@@ -368,6 +456,8 @@
                 <narrative xml:lang="fr">Organisation internationale pour les services en matière de population</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21033</code>
@@ -376,6 +466,8 @@
                 <narrative xml:lang="fr">Transparency International</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>21034</code>
@@ -384,6 +476,8 @@
                 <narrative xml:lang="fr">Union Internationale Contre la Tuberculose et les Maladies Respiratoires</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21035</code>
@@ -392,6 +486,8 @@
                 <narrative xml:lang="fr">Organisation mondiale contre la torture</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>21036</code>
@@ -400,6 +496,8 @@
                 <narrative xml:lang="fr">Entraide universitaire mondiale</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21037</code>
@@ -408,6 +506,8 @@
                 <narrative xml:lang="fr">Banque mondiale des femmes</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
             <code>21038</code>
@@ -416,6 +516,8 @@
                 <narrative xml:lang="fr">International Alert</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21039</code>
@@ -424,6 +526,8 @@
                 <narrative xml:lang="fr">Institut international de développement durable</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21040</code>
@@ -432,6 +536,8 @@
                 <narrative xml:lang="fr">Centre de la tribune internationale de la femme</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
             <code>21041</code>
@@ -440,6 +546,8 @@
                 <narrative xml:lang="fr">Société pour le développement international</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
             <code>21042</code>
@@ -448,6 +556,8 @@
                 <narrative xml:lang="fr">Alliance internationale pour la consolidation de la paix</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21043</code>
@@ -456,6 +566,8 @@
                 <narrative xml:lang="fr">Association des parlementaires d’Europe pour l’Afrique</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>21044</code>
@@ -464,6 +576,8 @@
                 <narrative xml:lang="fr">Conseil international pour la lutte contre les troubles dus à une carence en iode</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>21045</code>
@@ -472,6 +586,8 @@
                 <narrative xml:lang="fr">Fondation africaine pour la médecine et la recherche</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>21046</code>
@@ -480,6 +596,8 @@
                 <narrative xml:lang="fr">Association de Coopération et de Recherche pour le Développement</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21047</code>
@@ -488,6 +606,8 @@
                 <narrative xml:lang="fr">AgriCord</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21048</code>
@@ -496,6 +616,8 @@
                 <narrative xml:lang="fr">Association des universités africaines</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21049</code>
@@ -504,6 +626,8 @@
                 <narrative xml:lang="fr">Centre européen de gestion de politiques de développement</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21050</code>
@@ -512,6 +636,8 @@
                 <narrative xml:lang="fr">Appel de Genève</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21051</code>
@@ -520,6 +646,8 @@
                 <narrative xml:lang="fr">Institut supérieur panafricaine d’economie coopérative</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>21053</code>
@@ -528,6 +656,8 @@
                 <narrative xml:lang="fr">IPAS-Protecting Women's Health, Advancing Women's Reproductive Rights</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>21054</code>
@@ -536,6 +666,8 @@
                 <narrative xml:lang="fr">Institut Vie et Paix</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21055</code>
@@ -544,6 +676,8 @@
                 <narrative xml:lang="fr">Réseau régional de formation sur le SIDA</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21056</code>
@@ -552,6 +686,8 @@
                 <narrative xml:lang="fr">Partenariat pour les énergies renouvelables et l'efficience énergétique</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>21057</code>
@@ -560,6 +696,8 @@
                 <narrative xml:lang="fr">Centre International pour la Justice Transitionnelle</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21058</code>
@@ -568,6 +706,8 @@
                 <narrative xml:lang="fr">International Crisis Group</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21059</code>
@@ -576,6 +716,8 @@
                 <narrative xml:lang="fr">Fonds solidaire pour l'Afrique</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21060</code>
@@ -584,6 +726,8 @@
                 <narrative xml:lang="fr">Association pour la prévention de la torture</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>21061</code>
@@ -592,6 +736,8 @@
                 <narrative xml:lang="fr">Conseil international de réhabilitation pour les victimes de torture</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21062</code>
@@ -600,6 +746,8 @@
                 <narrative xml:lang="fr">The Nature Conservancy</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>21063</code>
@@ -608,6 +756,8 @@
                 <narrative xml:lang="fr">Conservation International</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>21064</code>
@@ -616,6 +766,8 @@
                 <narrative xml:lang="fr">Initiative Clinton pour l'accès à la santé</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21501</code>
@@ -624,6 +776,8 @@
                 <narrative xml:lang="fr">OXFAM International</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21502</code>
@@ -632,6 +786,8 @@
                 <narrative xml:lang="fr">World Vision</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21503</code>
@@ -640,6 +796,8 @@
                 <narrative xml:lang="fr">Family Health International 360</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21504</code>
@@ -648,6 +806,8 @@
                 <narrative xml:lang="fr">International Relief and Development</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21505</code>
@@ -656,6 +816,8 @@
                 <narrative xml:lang="fr">Save the Children</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21506</code>
@@ -664,6 +826,8 @@
                 <narrative xml:lang="fr">International Rescue Committee</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>21507</code>
@@ -672,6 +836,8 @@
                 <narrative xml:lang="fr">Pact World</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2022-01-01">
             <code>21508</code>
@@ -680,6 +846,8 @@
                 <narrative xml:lang="fr">Sustainable Energy for All</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>21509</code>
@@ -688,6 +856,8 @@
                 <narrative xml:lang="fr">AmplifyChange</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22000</code>
@@ -696,6 +866,8 @@
                 <narrative xml:lang="fr">ONG basée dans un pays donneur</narrative>
             </name>
             <category>20000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>22501</code>
@@ -704,6 +876,8 @@
                 <narrative xml:lang="fr">OXFAM - provider country office</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>22502</code>
@@ -712,6 +886,8 @@
                 <narrative xml:lang="fr">Save the Children - donor country office</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23000</code>
@@ -720,6 +896,8 @@
                 <narrative xml:lang="fr">ONG basée dans un pays en développement</narrative>
             </name>
             <category>20000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>23501</code>
@@ -728,6 +906,8 @@
                 <narrative xml:lang="fr">Sociétés nationales de la Croix-Rouge et du Croissant-Rouge</narrative>
             </name>
             <category>23000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>30000</code>
@@ -736,6 +916,8 @@
                 <narrative xml:lang="fr">Partenariats public-privé (PPP) et réseaux</narrative>
             </name>
             <category>30000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30001</code>
@@ -744,6 +926,8 @@
                 <narrative xml:lang="fr">Alliance mondiale pour une meilleure nutrition</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30003</code>
@@ -752,6 +936,8 @@
                 <narrative xml:lang="fr">Initiative mondiale en faveur de l’informatique dans les écoles et dans les communautés</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30004</code>
@@ -760,6 +946,8 @@
                 <narrative xml:lang="fr">Partenariat mondial pour l'eau</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30005</code>
@@ -768,6 +956,8 @@
                 <narrative xml:lang="fr">Initiative internationale pour un vaccin contre le SIDA</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30006</code>
@@ -776,6 +966,8 @@
                 <narrative xml:lang="fr">Partenariat international pour des microbicides</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30007</code>
@@ -784,6 +976,8 @@
                 <narrative xml:lang="fr">Alliance mondiale pour les TIC et le développement</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30008</code>
@@ -792,6 +986,8 @@
                 <narrative xml:lang="fr">Alliance pour les villes</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30009</code>
@@ -800,6 +996,8 @@
                 <narrative xml:lang="fr">Small Arms Survey</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>30010</code>
@@ -808,6 +1006,8 @@
                 <narrative xml:lang="fr">Facilité internationale d'achat de médicaments</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30011</code>
@@ -816,6 +1016,8 @@
                 <narrative xml:lang="fr">Union internationale pour la conservation de la nature</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30012</code>
@@ -824,6 +1026,8 @@
                 <narrative xml:lang="fr">Global Climate Partnership Fund</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30013</code>
@@ -832,6 +1036,8 @@
                 <narrative xml:lang="fr">Mécanisme de soutien au microfinancement</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30014</code>
@@ -840,6 +1046,8 @@
                 <narrative xml:lang="fr">Fonds régional d’investissement pour les très petites, petites et moyennes entreprises d’Afrique subsaharienne</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>30015</code>
@@ -848,6 +1056,8 @@
                 <narrative xml:lang="fr">Fonds mondial pour la promotion de l'efficacité énergétique et des énergies renouvelables</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>30016</code>
@@ -856,6 +1066,8 @@
                 <narrative xml:lang="fr">European Fund for Southeast Europe</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>30017</code>
@@ -864,6 +1076,8 @@
                 <narrative xml:lang="fr">SANAD Fund for Micro, Small and Medium Enterprises</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>30018</code>
@@ -872,6 +1086,8 @@
                 <narrative xml:lang="fr">Corporation Financière Africaine</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>30019</code>
@@ -880,6 +1096,8 @@
                 <narrative xml:lang="fr">Currency Exchange Fund N.V.</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>30020</code>
@@ -888,6 +1106,8 @@
                 <narrative xml:lang="fr">Global Energy Efficiency and Renewable Energy Fund II</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31000</code>
@@ -896,6 +1116,8 @@
                 <narrative xml:lang="fr">Partenariats public-privé (PPP)</narrative>
             </name>
             <category>30000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>31001</code>
@@ -904,6 +1126,8 @@
                 <narrative xml:lang="fr">Réseau de développement mondial</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>31002</code>
@@ -912,6 +1136,8 @@
                 <narrative xml:lang="fr">Alliance mondiale pour le savoir</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>31003</code>
@@ -920,6 +1146,8 @@
                 <narrative xml:lang="fr">Coalition internationale pour l'accès à la terre</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>31004</code>
@@ -928,6 +1156,8 @@
                 <narrative xml:lang="fr">Secrétariat de l'Initiative pour la transparence dans les industries extractives</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>31005</code>
@@ -936,6 +1166,8 @@
                 <narrative xml:lang="fr">Réseau parlementaire sur la Banque mondaile</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2022-01-01">
             <code>31006</code>
@@ -944,6 +1176,8 @@
                 <narrative xml:lang="fr">Coalition pour les innovations en matière de préparation aux épidémies</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>31007</code>
@@ -952,6 +1186,8 @@
                 <narrative xml:lang="fr">Initiative médicaments contres les maladies négligées</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>31008</code>
@@ -960,6 +1196,8 @@
                 <narrative xml:lang="fr">Fondation pour les nouveaux diagnostics innovants</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32000</code>
@@ -968,6 +1206,8 @@
                 <narrative xml:lang="fr">Réseaux</narrative>
             </name>
             <category>30000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>40000</code>
@@ -976,6 +1216,8 @@
                 <narrative xml:lang="fr">Organisations multilatérales</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41000</code>
@@ -984,6 +1226,8 @@
                 <narrative xml:lang="fr">Agence, fonds ou commission des Nations Unies (ONU)</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41100</code>
@@ -992,6 +1236,8 @@
                 <narrative xml:lang="fr">Entités des Nations Unies (contributions aux budgets reguliers à déclarer dans leur intégralité)</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41101</code>
@@ -1000,6 +1246,8 @@
                 <narrative xml:lang="fr">Convention sur la lutte contre la désertification</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41102</code>
@@ -1008,6 +1256,8 @@
                 <narrative xml:lang="fr">Organisation de lutte contre le criquet pèlerin dans l'Est Africain</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41103</code>
@@ -1016,6 +1266,8 @@
                 <narrative xml:lang="fr">Commission économique pour l'Afrique</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41104</code>
@@ -1024,6 +1276,8 @@
                 <narrative xml:lang="fr">Commission économique pour l'Amérique latine et les Caraïbes</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41105</code>
@@ -1032,6 +1286,8 @@
                 <narrative xml:lang="fr">Commission économique et sociale pour l'Asie occidentale</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41106</code>
@@ -1040,6 +1296,8 @@
                 <narrative xml:lang="fr">Commission économique et sociale pour l'Asie et le Pacifique</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41107</code>
@@ -1048,6 +1306,8 @@
                 <narrative xml:lang="fr">Agence internationale de l'énergie atomique (Contributions au Fonds de Coopération Technique uniquement)</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41108</code>
@@ -1056,6 +1316,8 @@
                 <narrative xml:lang="fr">Fonds international de développement agricole</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>41109</code>
@@ -1064,6 +1326,8 @@
                 <narrative xml:lang="fr">International Research and Training Institute for the Advancement of Women</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41110</code>
@@ -1072,6 +1336,8 @@
                 <narrative xml:lang="fr">Programme commun des Nations Unies sur le VIH/SIDA</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41111</code>
@@ -1080,6 +1346,8 @@
                 <narrative xml:lang="fr">Fonds d’équipement des Nations Unies</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41112</code>
@@ -1088,6 +1356,8 @@
                 <narrative xml:lang="fr">Conférence des Nations Unies sur le commerce et le développement</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41114</code>
@@ -1096,6 +1366,8 @@
                 <narrative xml:lang="fr">Programme des Nations Unies pour le développement</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41116</code>
@@ -1104,6 +1376,8 @@
                 <narrative xml:lang="fr">Programme des Nations Unies pour l'environnement</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41119</code>
@@ -1112,6 +1386,8 @@
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la population</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41120</code>
@@ -1120,6 +1396,8 @@
                 <narrative xml:lang="fr">Programme des Nations Unies pour les établissements humains</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41121</code>
@@ -1128,6 +1406,8 @@
                 <narrative xml:lang="fr">Haut Commissariat des Nations Unies pour les réfugiés</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41122</code>
@@ -1136,6 +1416,8 @@
                 <narrative xml:lang="fr">Fonds des Nations Unies pour l'enfance</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41123</code>
@@ -1144,6 +1426,8 @@
                 <narrative xml:lang="fr">Organisation des Nations Unies pour le développement industriel</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>41124</code>
@@ -1152,6 +1436,8 @@
                 <narrative xml:lang="fr">United Nations Development Fund for Women</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41125</code>
@@ -1160,6 +1446,8 @@
                 <narrative xml:lang="fr">Institut des Nations Unies pour la formation et la recherche</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41126</code>
@@ -1168,6 +1456,8 @@
                 <narrative xml:lang="fr">Service de l'action antimines des Nations Unies</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41127</code>
@@ -1176,6 +1466,8 @@
                 <narrative xml:lang="fr">Bureau des Nations Unies pour la coordination de l'assistance humanitaire</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41128</code>
@@ -1184,6 +1476,8 @@
                 <narrative xml:lang="fr">Office des Nations Unies contre la drogue et le crime</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41129</code>
@@ -1192,6 +1486,8 @@
                 <narrative xml:lang="fr">Institut de recherche des Nations Unies pour le développement social</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41130</code>
@@ -1200,6 +1496,8 @@
                 <narrative xml:lang="fr">Office de secours et de travaux des Nations Unies pour les réfugiés de Palestine dans le Proche-Orient</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41131</code>
@@ -1208,6 +1506,8 @@
                 <narrative xml:lang="fr">Ecole des cadres du système des Nations Unies</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41132</code>
@@ -1216,6 +1516,8 @@
                 <narrative xml:lang="fr">Comité permanent de la nutrition du système des Nations Unies</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41133</code>
@@ -1224,6 +1526,8 @@
                 <narrative xml:lang="fr">Initiative spéciale des Nations Unies pour l'Afrique</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41134</code>
@@ -1232,6 +1536,8 @@
                 <narrative xml:lang="fr">Université des Nations Unies (y compris le Fonds de dotation)</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41135</code>
@@ -1240,6 +1546,8 @@
                 <narrative xml:lang="fr">Programme des volontaires des Nations Unies</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41136</code>
@@ -1248,6 +1556,8 @@
                 <narrative xml:lang="fr">Fonds de contributions voluntaires des Nations Unies pour les handicapés</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41137</code>
@@ -1256,6 +1566,8 @@
                 <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour la coopération technique dans le domaine des droits de l'homme</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41138</code>
@@ -1264,6 +1576,8 @@
                 <narrative xml:lang="fr">Fonds de contributions volontaires des Nations Unies pour les victimes de la torture</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41140</code>
@@ -1272,6 +1586,8 @@
                 <narrative xml:lang="fr">Programme alimentaire mondial</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41141</code>
@@ -1280,6 +1596,8 @@
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41142</code>
@@ -1288,6 +1606,8 @@
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la démocratie</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41143</code>
@@ -1296,6 +1616,8 @@
                 <narrative xml:lang="fr">Organisation mondiale de la santé - compte de contributions volontaires sans objet désigné</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41144</code>
@@ -1304,6 +1626,8 @@
                 <narrative xml:lang="fr">Organisation internationale du Travail - Compte supplémentaire du budget ordinaire</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41145</code>
@@ -1312,6 +1636,8 @@
                 <narrative xml:lang="fr">Organisation maritime internationale - Programme intégré de coopération technique</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41146</code>
@@ -1320,6 +1646,8 @@
                 <narrative xml:lang="fr">Entité des Nations Unies pour l'égalité des sexes et l'autonomisation de la femme</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41147</code>
@@ -1328,6 +1656,8 @@
                 <narrative xml:lang="fr">Fonds central pour les interventions d'urgence</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41148</code>
@@ -1336,6 +1666,8 @@
                 <narrative xml:lang="fr">Département des affaires politiques et de consolidation de la paix des Nations Unies, Fonds d'affectation spéciale à l'appui des affaires politiques</narrative>
             </name>
             <category>41500</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41149</code>
@@ -1344,6 +1676,8 @@
                 <narrative xml:lang="fr">Bureau de la coordination des activités de développement des Nations Unies</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>41150</code>
@@ -1352,6 +1686,8 @@
                 <narrative xml:lang="fr">Institut des Nations unies pour la recherche sur le désarmement</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41151</code>
@@ -1360,6 +1696,8 @@
                 <narrative xml:lang="fr">Centre international de recherche sur le cancer</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41200</code>
@@ -1368,6 +1706,8 @@
                 <narrative xml:lang="fr">Entités des Nations Unies (contributions de base à déclarer dans TOSSD uniquement)</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41201</code>
@@ -1376,6 +1716,8 @@
                 <narrative xml:lang="fr">Organisation du traité d'interdiction complète des essais nucléaires</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41202</code>
@@ -1384,6 +1726,8 @@
                 <narrative xml:lang="fr">Organisation de l'aviation civile internationale</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41203</code>
@@ -1392,6 +1736,8 @@
                 <narrative xml:lang="fr">Cour Pénale Internationale</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41204</code>
@@ -1400,6 +1746,8 @@
                 <narrative xml:lang="fr">Mécanisme international appelé à exercer les fonctions résiduelles des Tribunaux pénaux</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41205</code>
@@ -1408,6 +1756,8 @@
                 <narrative xml:lang="fr">Autorité internationale des fonds marins</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41206</code>
@@ -1416,6 +1766,8 @@
                 <narrative xml:lang="fr">Tribunal international du droit de la mer</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41207</code>
@@ -1424,6 +1776,8 @@
                 <narrative xml:lang="fr">Organisation pour l'interdiction des Armes Chimiques</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41208</code>
@@ -1432,6 +1786,8 @@
                 <narrative xml:lang="fr">Département des affaires économiques et sociales</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41209</code>
@@ -1440,6 +1796,8 @@
                 <narrative xml:lang="fr">Département de l'Assemblée générale et de la gestion des conférences</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41210</code>
@@ -1448,6 +1806,8 @@
                 <narrative xml:lang="fr">Département de la communication globale</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41211</code>
@@ -1456,6 +1816,8 @@
                 <narrative xml:lang="fr">Département des stratégies et politiques de gestion et de la conformité, y compris ? including ONUN, ONUG et ONUV</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41212</code>
@@ -1464,6 +1826,8 @@
                 <narrative xml:lang="fr">Département de l’appui opérationnel</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41213</code>
@@ -1472,6 +1836,8 @@
                 <narrative xml:lang="fr">Département de la sûreté et de la sécurité</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41214</code>
@@ -1480,6 +1846,8 @@
                 <narrative xml:lang="fr">Bureau de lutte contre le terrorisme</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41215</code>
@@ -1488,6 +1856,8 @@
                 <narrative xml:lang="fr">Institut interrégional de recherche des Nations unies sur la criminalité et la justice</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41216</code>
@@ -1496,6 +1866,8 @@
                 <narrative xml:lang="fr">International Maritime Organization</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41217</code>
@@ -1504,6 +1876,8 @@
                 <narrative xml:lang="fr">Organisation mondiale du commerce</narrative>
             </name>
             <category>41200</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41300</code>
@@ -1512,6 +1886,8 @@
                 <narrative xml:lang="fr">Autres Nations Unies (contributions comptabilisables pour partie)</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41301</code>
@@ -1520,6 +1896,8 @@
                 <narrative xml:lang="fr">Organisation des Nations Unies pour l'alimentation et l'agriculture</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41302</code>
@@ -1528,6 +1906,8 @@
                 <narrative xml:lang="fr">Organisation internationale du travail - contributions obligatoires</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41303</code>
@@ -1536,6 +1916,8 @@
                 <narrative xml:lang="fr">Union internationale des télécommunications</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41304</code>
@@ -1544,6 +1926,8 @@
                 <narrative xml:lang="fr">Organisation des Nations Unies pour l’éducation, la science et la culture</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41305</code>
@@ -1552,6 +1936,8 @@
                 <narrative xml:lang="fr">Organisation des Nations Unies</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41306</code>
@@ -1560,6 +1946,8 @@
                 <narrative xml:lang="fr">Union postale universelle</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41307</code>
@@ -1568,6 +1956,8 @@
                 <narrative xml:lang="fr">Organisation mondiale de la santé - contributions obligatoires</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41308</code>
@@ -1576,6 +1966,8 @@
                 <narrative xml:lang="fr">Organisation mondiale de la propriété intellectuelle</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41309</code>
@@ -1584,6 +1976,8 @@
                 <narrative xml:lang="fr">Organisation météorologique mondiale</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41310</code>
@@ -1592,6 +1986,8 @@
                 <narrative xml:lang="fr">Département des opérations de paix des Nations unies. Opérations de maintien de la paix [seulement MINURSO,MINUSCA,MINUSMA, MINUSTAH,MONUSCO,MINUAD, FINUL,FISNUA,MINUK, MINUL,UNMISS,ONUCI]. Notifier les contributions mission par mission au format SNPC++</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2010-01-01" withdrawal-date="2019-12-31">
             <code>41311</code>
@@ -1600,6 +1996,8 @@
                 <narrative xml:lang="fr">Fonds des Nations Unies pour la consolidation de la paix (Guichet un:  contributions sans conditions)</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41312</code>
@@ -1608,6 +2006,8 @@
                 <narrative xml:lang="fr">Agence internationale de l'énergie atomique - contributions obligatoires</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41313</code>
@@ -1616,6 +2016,8 @@
                 <narrative xml:lang="fr">Haut-Commissariat des Nations unies aux droits de l'homme (contributions extrabudgétaires uniquement)</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41314</code>
@@ -1624,6 +2026,8 @@
                 <narrative xml:lang="fr">Commission économique des Nations unies pour l'Europe (contributions extrabudgétaires uniquement)</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41315</code>
@@ -1632,6 +2036,8 @@
                 <narrative xml:lang="fr">Bureau des Nations Unies pour la prévention de catastrophes</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41316</code>
@@ -1640,6 +2046,8 @@
                 <narrative xml:lang="fr">Convention-cadre des Nations unies sur les changements climatiques</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>41317</code>
@@ -1648,6 +2056,8 @@
                 <narrative xml:lang="fr">Fonds vert pour le climat</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41318</code>
@@ -1656,6 +2066,8 @@
                 <narrative xml:lang="fr">Mécanisme mondial</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41319</code>
@@ -1664,6 +2076,8 @@
                 <narrative xml:lang="fr">Organisation mondiale du tourisme</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41320</code>
@@ -1672,6 +2086,8 @@
                 <narrative xml:lang="fr">Banque de Technologies en faveur des Pays les Moins Avancés</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41321</code>
@@ -1680,6 +2096,8 @@
                 <narrative xml:lang="fr">Organisation mondiale de la santé - Plan stratégique de préparation et d'intervention</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41400</code>
@@ -1688,6 +2106,8 @@
                 <narrative xml:lang="fr">Fonds communs interinstitutions des Nations Unies</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41401</code>
@@ -1696,6 +2116,8 @@
                 <narrative xml:lang="fr">UN-Multi Partner Trust Fund Office</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41402</code>
@@ -1704,6 +2126,8 @@
                 <narrative xml:lang="fr">Fonds conjoint des objectifs de développement durable</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41403</code>
@@ -1712,6 +2136,8 @@
                 <narrative xml:lang="fr">COVID-19 Response and Recovery Multi-Partner Trust Fund</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41500</code>
@@ -1720,6 +2146,8 @@
                 <narrative xml:lang="fr">Fonds thématiques uniques des Nations Unies</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41501</code>
@@ -1728,6 +2156,8 @@
                 <narrative xml:lang="fr">United Nations Reducing Emissions from Deforestation and Forest Degradation</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41502</code>
@@ -1736,6 +2166,8 @@
                 <narrative xml:lang="fr">Le Bureau des Nations Unies pour les services d'appui aux projets</narrative>
             </name>
             <category>41300</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41503</code>
@@ -1744,6 +2176,8 @@
                 <narrative xml:lang="fr">UN-led Country-based Pooled Funds</narrative>
             </name>
             <category>41400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>41600</code>
@@ -1752,6 +2186,8 @@
                 <narrative xml:lang="fr">Canaux de l'ONU existants non inclus dans la norme I du cadre de reporting du cube de l'ONU</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>41601</code>
@@ -1760,6 +2196,8 @@
                 <narrative xml:lang="fr">United Nations Office for Disarmament Affairs</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41700</code>
@@ -1768,6 +2206,8 @@
                 <narrative xml:lang="fr">Entités des Nations Unies, contributions autres que de base</narrative>
             </name>
             <category>41000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41701</code>
@@ -1776,6 +2216,8 @@
                 <narrative xml:lang="fr">International Labour Organisation - non-core</narrative>
             </name>
             <category>41700</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>41702</code>
@@ -1784,6 +2226,8 @@
                 <narrative xml:lang="fr">World Health Organisation - non-core</narrative>
             </name>
             <category>41700</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>42000</code>
@@ -1792,6 +2236,8 @@
                 <narrative xml:lang="fr">Institutions de l'Union européenne</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>42001</code>
@@ -1800,6 +2246,8 @@
                 <narrative xml:lang="fr">Commission européenne - partie du budget affectée au développement</narrative>
             </name>
             <category>42000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>42003</code>
@@ -1808,6 +2256,8 @@
                 <narrative xml:lang="fr">Commission européenne - Fonds européen de développement</narrative>
             </name>
             <category>42000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>42004</code>
@@ -1816,6 +2266,8 @@
                 <narrative xml:lang="fr">Banque européenne d'investissement</narrative>
             </name>
             <category>42000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2004-01-01" withdrawal-date="2009-12-31">
             <code>42005</code>
@@ -1824,6 +2276,8 @@
                 <narrative xml:lang="fr">Facility for Euro-Mediterranean Investment and Partnership Trust Fund</narrative>
             </name>
             <category>42000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43000</code>
@@ -1832,6 +2286,8 @@
                 <narrative xml:lang="fr">Fonds monétaire international (FMI)</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>43001</code>
@@ -1840,6 +2296,8 @@
                 <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>43002</code>
@@ -1848,6 +2306,8 @@
                 <narrative xml:lang="fr">Fonds monétaire international – Réduction de la pauvreté et croissance – Initiative d’allègement de la dette en faveur des pays pauvres très endettés [y compris Initiative PPTE, Facilité élargie de crédit (FEC) et sous-comptes (FEC-PPTE)]</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
             <code>43003</code>
@@ -1856,6 +2316,8 @@
                 <narrative xml:lang="fr">Fonds monétaire international – Aide d’urgence après un conflit (EPCA) et aide d’urgence à la suite de catastrophes naturelles (ENDA) pour les membres pouvant bénéficier de la FRPC</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>43004</code>
@@ -1864,6 +2326,8 @@
                 <narrative xml:lang="fr">Fonds monétaire international – Facilité pour la réduction de la pauvreté et pour la croissance – Initiative d’allègement de la dette multilatérale</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>43005</code>
@@ -1872,6 +2336,8 @@
                 <narrative xml:lang="fr">Fonds monétaire international  - Fonds fiduciaire pour l'allégement de la dette après une catastrophe</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>43006</code>
@@ -1880,6 +2346,8 @@
                 <narrative xml:lang="fr">Fonds fiduciaire d’assistance et de riposte aux catastrophes</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2022-01-01">
             <code>43007</code>
@@ -1888,6 +2356,8 @@
                 <narrative xml:lang="fr">Fonds fiduciaire pour la résilience et la durabilité</narrative>
             </name>
             <category>43000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>44000</code>
@@ -1896,6 +2366,8 @@
                 <narrative xml:lang="fr">Groupe de la Banque mondiale (BM)</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>44001</code>
@@ -1904,6 +2376,8 @@
                 <narrative xml:lang="fr">Banque internationale pour la reconstruction et le développement</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>44002</code>
@@ -1912,6 +2386,8 @@
                 <narrative xml:lang="fr">Association internationale de développement</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>44003</code>
@@ -1920,6 +2396,8 @@
                 <narrative xml:lang="fr">Association internationale de développement - Fonds fiduciaire de l'IDA en faveur des pays pauvres très endettés</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>44004</code>
@@ -1928,6 +2406,8 @@
                 <narrative xml:lang="fr">Société financière internationale</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>44005</code>
@@ -1936,6 +2416,8 @@
                 <narrative xml:lang="fr">Agence multilatérale de garantie des investissements</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
             <code>44006</code>
@@ -1944,6 +2426,8 @@
                 <narrative xml:lang="fr">Garanties de marché</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>44007</code>
@@ -1952,6 +2436,8 @@
                 <narrative xml:lang="fr">Association internationale de développement - Initiative d’allégement de la dette multilatérale</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>44008</code>
@@ -1960,6 +2446,8 @@
                 <narrative xml:lang="fr">Partnership for Market Implementation</narrative>
             </name>
             <category>44000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2026-04-02">
             <code>45000</code>
@@ -1976,6 +2464,8 @@
                 <narrative xml:lang="fr">Centre du commerce international de l'Organisation mondiale du commerce</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>45002</code>
@@ -1984,6 +2474,8 @@
                 <narrative xml:lang="fr">Centre consultatif sur la législation de l'Organisation mondiale du commerce</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>45003</code>
@@ -1992,6 +2484,8 @@
                 <narrative xml:lang="fr">Organisation mondiale du commerce - Fonds global d'affectation spéciale</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>46000</code>
@@ -2000,6 +2494,8 @@
                 <narrative xml:lang="fr">Banques régionales de développement</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46002</code>
@@ -2008,6 +2504,8 @@
                 <narrative xml:lang="fr">Banque africaine de développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46003</code>
@@ -2016,6 +2514,8 @@
                 <narrative xml:lang="fr">Fonds africain de développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46004</code>
@@ -2024,6 +2524,8 @@
                 <narrative xml:lang="fr">Banque asiatique de développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46005</code>
@@ -2032,6 +2534,8 @@
                 <narrative xml:lang="fr">Fonds asiatique de développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2008-01-01">
             <code>46006</code>
@@ -2040,6 +2544,8 @@
                 <narrative xml:lang="fr">Black Sea Trade and Development Bank</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46007</code>
@@ -2048,6 +2554,8 @@
                 <narrative xml:lang="fr">Banque centroaméricaine d'intégration économique</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46008</code>
@@ -2056,6 +2564,8 @@
                 <narrative xml:lang="fr">Banque de développement de l'Amérique latine</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46009</code>
@@ -2064,6 +2574,8 @@
                 <narrative xml:lang="fr">Banque de développement des Caraïbes</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46012</code>
@@ -2072,6 +2584,8 @@
                 <narrative xml:lang="fr">Banque interaméricaine de développement, Société interaméricaine d'investissements, Fonds multilatéral d'investissements</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>46013</code>
@@ -2080,6 +2594,8 @@
                 <narrative xml:lang="fr">Banque interaméricaine de développement, Fonds opérations spécial</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>46015</code>
@@ -2088,6 +2604,8 @@
                 <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>46016</code>
@@ -2096,6 +2614,8 @@
                 <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (pays éligibles à l'APD)</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>46017</code>
@@ -2104,6 +2624,8 @@
                 <narrative xml:lang="fr">Banque européenne pour la reconstruction et le développement - coopération technique et fonds spéciaux (tous pays)</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>46018</code>
@@ -2112,6 +2634,8 @@
                 <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Initiative en faveur des pays en transition précoce</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>46019</code>
@@ -2120,6 +2644,8 @@
                 <narrative xml:lang="fr">Banque européenne de reconstruction et de développement - Fonds spécial pour les Balkans occidentaux</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>46020</code>
@@ -2128,6 +2654,8 @@
                 <narrative xml:lang="fr">Banque de développement des États de l'Afrique Centrale</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>46021</code>
@@ -2136,6 +2664,8 @@
                 <narrative xml:lang="fr">Banque ouest-africaine de développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
             <code>46022</code>
@@ -2144,6 +2674,8 @@
                 <narrative xml:lang="fr">Banque Africaine d'Import-Export</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
             <code>46023</code>
@@ -2152,6 +2684,8 @@
                 <narrative xml:lang="fr">Banque de l’Afrique de l’Est et de l’Afrique Australe pour le Commerce et le Développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>46024</code>
@@ -2160,6 +2694,8 @@
                 <narrative xml:lang="fr">Banque de Développement du Conseil de l'Europe</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>46025</code>
@@ -2168,6 +2704,8 @@
                 <narrative xml:lang="fr">Banque Islamique de Développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>46026</code>
@@ -2176,6 +2714,8 @@
                 <narrative xml:lang="fr">Asian Infrastructure Investment Bank</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>46027</code>
@@ -2184,6 +2724,8 @@
                 <narrative xml:lang="fr">Fonds financier pour le développement du bassin fluvial de la Plata</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>46028</code>
@@ -2192,6 +2734,8 @@
                 <narrative xml:lang="fr">Nouvelle banque de développement</narrative>
             </name>
             <category>46000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>47000</code>
@@ -2200,6 +2744,8 @@
                 <narrative xml:lang="fr">Autres institutions multilatérales</narrative>
             </name>
             <category>40000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2000-01-01">
             <code>47001</code>
@@ -2208,6 +2754,8 @@
                 <narrative xml:lang="fr">Fondation pour le renforcement des capacités en Afrique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47002</code>
@@ -2216,6 +2764,8 @@
                 <narrative xml:lang="fr">Organisation asiatique de productivité</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47003</code>
@@ -2224,6 +2774,8 @@
                 <narrative xml:lang="fr">Association des nations de l'Asie du Sud-Est - coopération économique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47004</code>
@@ -2232,6 +2784,8 @@
                 <narrative xml:lang="fr">ASEAN Cultural Fund</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47005</code>
@@ -2240,6 +2794,8 @@
                 <narrative xml:lang="fr">Union Africaine (à l'exclusion de la Facilité de soutien à la paix)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47008</code>
@@ -2248,6 +2804,8 @@
                 <narrative xml:lang="fr">Centre international de cultures maraîchères</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47009</code>
@@ -2256,6 +2814,8 @@
                 <narrative xml:lang="fr">Conseil africain et malgache pour l'enseignement supérieur</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47010</code>
@@ -2264,6 +2824,8 @@
                 <narrative xml:lang="fr">Agence du Commonwealth pour l'administration et la gestion publiques</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
             <code>47011</code>
@@ -2272,6 +2834,8 @@
                 <narrative xml:lang="fr">Secrétariat de la Communauté des Caraïbes</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47012</code>
@@ -2280,6 +2844,8 @@
                 <narrative xml:lang="fr">Centre épidémiologique des Caraïbes</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47013</code>
@@ -2288,6 +2854,8 @@
                 <narrative xml:lang="fr">Fondation du Commonwealth</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47014</code>
@@ -2296,6 +2864,8 @@
                 <narrative xml:lang="fr">Commonwealth Fund for Technical Co-operation</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47015</code>
@@ -2304,6 +2874,8 @@
                 <narrative xml:lang="fr">CGIAR Fund</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2009-12-31">
             <code>47016</code>
@@ -2312,6 +2884,8 @@
                 <narrative xml:lang="fr">Commonwealth Institute</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47017</code>
@@ -2320,6 +2894,8 @@
                 <narrative xml:lang="fr">Centre international d'agriculture tropicale</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47018</code>
@@ -2328,6 +2904,8 @@
                 <narrative xml:lang="fr">Centre de recherche forestière internationale</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47019</code>
@@ -2336,6 +2914,8 @@
                 <narrative xml:lang="fr">Centre international de hautes études agronomique méditerranéennes</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47020</code>
@@ -2344,6 +2924,8 @@
                 <narrative xml:lang="fr">Centre international d’amélioration du maïs et du blé</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47021</code>
@@ -2352,6 +2934,8 @@
                 <narrative xml:lang="fr">Centre international de la pomme de terre</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47022</code>
@@ -2360,6 +2944,8 @@
                 <narrative xml:lang="fr">Convention sur le commerce international des espèces de faune et de flore sauvages menacées d'extinction</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47023</code>
@@ -2368,6 +2954,8 @@
                 <narrative xml:lang="fr">Commonwealth Legal Advisory Service</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47024</code>
@@ -2376,6 +2964,8 @@
                 <narrative xml:lang="fr">Commonwealth Media Development Fund</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47025</code>
@@ -2384,6 +2974,8 @@
                 <narrative xml:lang="fr">Commonwealth of Learning</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
             <code>47026</code>
@@ -2392,6 +2984,8 @@
                 <narrative xml:lang="fr">Communauté des pays de langue portugaise</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47027</code>
@@ -2400,6 +2994,8 @@
                 <narrative xml:lang="fr">Plan de Colombo</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47028</code>
@@ -2408,6 +3004,8 @@
                 <narrative xml:lang="fr">Partenariat pour la gestion technique (Commonwealth)</narrative>
             </name>
             <category>32000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47029</code>
@@ -2416,6 +3014,8 @@
                 <narrative xml:lang="fr">Club du Sahel et de l’Afrique de l’Ouest</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2009-12-31">
             <code>47030</code>
@@ -2424,6 +3024,8 @@
                 <narrative xml:lang="fr">Commonwealth Scientific Council</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47031</code>
@@ -2432,6 +3034,8 @@
                 <narrative xml:lang="fr">Commonwealth Small States Office</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2009-12-31">
             <code>47032</code>
@@ -2440,6 +3044,8 @@
                 <narrative xml:lang="fr">Commonwealth Trade and Investment Access Facility</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47033</code>
@@ -2448,6 +3054,8 @@
                 <narrative xml:lang="fr">Commonwealth Youth Programme</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>47034</code>
@@ -2456,6 +3064,8 @@
                 <narrative xml:lang="fr">Communauté économique des Etats de l’Afrique de l’Ouest</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47035</code>
@@ -2464,6 +3074,8 @@
                 <narrative xml:lang="fr">Environnement et développement du Tiers-monde</narrative>
             </name>
             <category>21000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47036</code>
@@ -2472,6 +3084,8 @@
                 <narrative xml:lang="fr">Organisation Européenne et Méditerranéenne pour la Protection des Plantes</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47037</code>
@@ -2480,6 +3094,8 @@
                 <narrative xml:lang="fr">Organisation régionale de l'Orient pour l'administration publique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47038</code>
@@ -2488,6 +3104,8 @@
                 <narrative xml:lang="fr">INTERPOL Fund for Aid and Technical Assistance to Developing Countries</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47040</code>
@@ -2496,6 +3114,8 @@
                 <narrative xml:lang="fr">Agence des pêches</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47041</code>
@@ -2504,6 +3124,8 @@
                 <narrative xml:lang="fr">Centre des techniques de l'alimentation et des engrais</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47042</code>
@@ -2512,6 +3134,8 @@
                 <narrative xml:lang="fr">Fondation pour la formation internationale dans les pays du tiers monde</narrative>
             </name>
             <category>22000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47043</code>
@@ -2520,6 +3144,8 @@
                 <narrative xml:lang="fr">Global Crop Diversity Trust</narrative>
             </name>
             <category>31000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>47044</code>
@@ -2528,6 +3154,8 @@
                 <narrative xml:lang="fr">Fonds pour l'environnement mondial - fonds fiduciaire</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>47045</code>
@@ -2536,6 +3164,8 @@
                 <narrative xml:lang="fr">Fonds mondial de lutte contre le SIDA, la tuberculose et la paludisme</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47046</code>
@@ -2544,6 +3174,8 @@
                 <narrative xml:lang="fr">Organisation internationale de la Francophonie</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47047</code>
@@ -2552,6 +3184,8 @@
                 <narrative xml:lang="fr">Institut international africain</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47048</code>
@@ -2560,6 +3194,8 @@
                 <narrative xml:lang="fr">Inter-American Indian Institute</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47049</code>
@@ -2568,6 +3204,8 @@
                 <narrative xml:lang="fr">International Bureau of Education - International Educational Reporting System (IERS)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47050</code>
@@ -2576,6 +3214,8 @@
                 <narrative xml:lang="fr">Comité consultatif international du coton</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47051</code>
@@ -2584,6 +3224,8 @@
                 <narrative xml:lang="fr">Centre international de recherche agricole dans les zones arides</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47053</code>
@@ -2592,6 +3234,8 @@
                 <narrative xml:lang="fr">International Centre for Diarrhoeal Disease Research, Bangladesh</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47054</code>
@@ -2600,6 +3244,8 @@
                 <narrative xml:lang="fr">Centre international sur la physiologie et l’écologie des insectes</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47055</code>
@@ -2608,6 +3254,8 @@
                 <narrative xml:lang="fr">Centre International pour la Recherche Agricole orientée vers le développement</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47056</code>
@@ -2616,6 +3264,8 @@
                 <narrative xml:lang="fr">Centre mondial de l’agroforesterie</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47057</code>
@@ -2624,6 +3274,8 @@
                 <narrative xml:lang="fr">Institut international de recherche sur les cultures des zones tropicales semi-arides</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>47058</code>
@@ -2632,6 +3284,8 @@
                 <narrative xml:lang="fr">International Institute for Democracy and Electoral Assistance</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47059</code>
@@ -2640,6 +3294,8 @@
                 <narrative xml:lang="fr">Organisation internationale de droit du développement</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47060</code>
@@ -2648,6 +3304,8 @@
                 <narrative xml:lang="fr">International Institute for Cotton</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47061</code>
@@ -2656,6 +3314,8 @@
                 <narrative xml:lang="fr">Institut interaméricain de coopération pour l’agriculture</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47062</code>
@@ -2664,6 +3324,8 @@
                 <narrative xml:lang="fr">Institut international d’agriculture tropicale</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47063</code>
@@ -2672,6 +3334,8 @@
                 <narrative xml:lang="fr">International Livestock Research Institute</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
             <code>47064</code>
@@ -2680,6 +3344,8 @@
                 <narrative xml:lang="fr">Réseau International sur le bambou et le rotin</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47065</code>
@@ -2688,6 +3354,8 @@
                 <narrative xml:lang="fr">Commission océanographique intergouvernementale</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47066</code>
@@ -2696,6 +3364,8 @@
                 <narrative xml:lang="fr">Organisation internationale des migrations</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47067</code>
@@ -2704,6 +3374,8 @@
                 <narrative xml:lang="fr">Groupe d’experts intergouvernemental sur l’évolution du climat</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47068</code>
@@ -2712,6 +3384,8 @@
                 <narrative xml:lang="fr">Commission Asie-Pacifique des pêches</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47069</code>
@@ -2720,6 +3394,8 @@
                 <narrative xml:lang="fr">Bioversity International</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47070</code>
@@ -2728,6 +3404,8 @@
                 <narrative xml:lang="fr">Institut international de recherche sur le riz</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47071</code>
@@ -2736,6 +3414,8 @@
                 <narrative xml:lang="fr">Association internationale d’essais de semences</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2001-01-01">
             <code>47073</code>
@@ -2744,6 +3424,8 @@
                 <narrative xml:lang="fr">Organisation Internationale des Bois Tropicaux</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47074</code>
@@ -2752,6 +3434,8 @@
                 <narrative xml:lang="fr">Institut international de vaccins</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47075</code>
@@ -2760,6 +3444,8 @@
                 <narrative xml:lang="fr">Institut international de gestion des ressources en eau</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
             <code>47076</code>
@@ -2768,6 +3454,8 @@
                 <narrative xml:lang="fr">Centre d’études sur la justice dans les Amériques</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>47077</code>
@@ -2776,6 +3464,8 @@
                 <narrative xml:lang="fr">Commission du Mékong</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47078</code>
@@ -2784,6 +3474,8 @@
                 <narrative xml:lang="fr">Fonds multilatéral pour l’application du Protocole de Montréal</narrative>
             </name>
             <category>41600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47079</code>
@@ -2792,6 +3484,8 @@
                 <narrative xml:lang="fr">Organisation des États américains</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47080</code>
@@ -2800,6 +3494,8 @@
                 <narrative xml:lang="fr">Organisation de Coopération et de développement économiques (contributions aux fonds spéciaux pour les activités de coopération technique uniquement)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2003-01-01">
             <code>47081</code>
@@ -2808,6 +3504,8 @@
                 <narrative xml:lang="fr">OCDE Centre de développement</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2004-01-01">
             <code>47082</code>
@@ -2816,6 +3514,8 @@
                 <narrative xml:lang="fr">Organisation des États des Caraïbes orientales</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47083</code>
@@ -2824,6 +3524,8 @@
                 <narrative xml:lang="fr">Organisation panaméricaine de la santé</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47084</code>
@@ -2832,6 +3534,8 @@
                 <narrative xml:lang="fr">Institut panaméricain de géographie et d’histoire</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47085</code>
@@ -2840,6 +3544,8 @@
                 <narrative xml:lang="fr">Pan-American Railway Congress Association</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>47086</code>
@@ -2848,6 +3554,8 @@
                 <narrative xml:lang="fr">Private Infrastructure Development Group</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47087</code>
@@ -2856,6 +3564,8 @@
                 <narrative xml:lang="fr">Secrétariat du Forum des Iles du Pacifique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47088</code>
@@ -2864,6 +3574,8 @@
                 <narrative xml:lang="fr">Relief Net</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>47089</code>
@@ -2872,6 +3584,8 @@
                 <narrative xml:lang="fr">Communauté pour le développement de l’Afrique australe</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47090</code>
@@ -2880,6 +3594,8 @@
                 <narrative xml:lang="fr">Southern African Transport and Communications Commission</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="1998-01-01" withdrawal-date="2010-12-31">
             <code>47091</code>
@@ -2888,6 +3604,8 @@
                 <narrative xml:lang="fr">(Colombo Plan) Special Commonwealth African Assistance Programme</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47092</code>
@@ -2896,6 +3614,8 @@
                 <narrative xml:lang="fr">Centre de développement des pêches de l’Asie du Sud-Est</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47093</code>
@@ -2904,6 +3624,8 @@
                 <narrative xml:lang="fr">Organisation des Ministres de l’éducation de l’Asie du Sud-Est</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2000-01-01" withdrawal-date="2010-12-31">
             <code>47094</code>
@@ -2912,6 +3634,8 @@
                 <narrative xml:lang="fr">South Pacific Applied Geoscience Commission</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2000-01-01">
             <code>47095</code>
@@ -2920,6 +3644,8 @@
                 <narrative xml:lang="fr">Programme d'évaluation et de qualité de l'éducation</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47096</code>
@@ -2928,6 +3654,8 @@
                 <narrative xml:lang="fr">Secrétariat Général de la Communauté du Pacifique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47097</code>
@@ -2936,6 +3664,8 @@
                 <narrative xml:lang="fr">Programme régional océanien de l’environnement</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="1998-01-01">
             <code>47098</code>
@@ -2944,6 +3674,8 @@
                 <narrative xml:lang="fr">Organisation des peuples et des nations non représentés</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47099</code>
@@ -2952,6 +3684,8 @@
                 <narrative xml:lang="fr">Université du Pacifique Sud</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2002-01-01">
             <code>47100</code>
@@ -2960,6 +3694,8 @@
                 <narrative xml:lang="fr">Union monétaire ouest-africaine</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47101</code>
@@ -2968,6 +3704,8 @@
                 <narrative xml:lang="fr">Centre du riz pour l’Afrique</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2000-01-01" withdrawal-date="2012-12-31">
             <code>47102</code>
@@ -2976,6 +3714,8 @@
                 <narrative xml:lang="fr">Organisation mondiale des douanes, programme de bourses</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47103</code>
@@ -2984,6 +3724,8 @@
                 <narrative xml:lang="fr">Université maritime mondiale</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47104</code>
@@ -2992,6 +3734,8 @@
                 <narrative xml:lang="fr">Centre international pour l’aménagement des ressources bioaquatiques</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2001-01-01">
             <code>47105</code>
@@ -3000,6 +3744,8 @@
                 <narrative xml:lang="fr">Fonds commun pour les produits de base</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
             <code>47106</code>
@@ -3008,6 +3754,8 @@
                 <narrative xml:lang="fr">Centre de contrôle démocratique des forces armées - Genève</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
             <code>47107</code>
@@ -3016,6 +3764,8 @@
                 <narrative xml:lang="fr">Facilité internationale de financement pour la vaccination</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2006-01-01" withdrawal-date="2010-12-31">
             <code>47108</code>
@@ -3024,6 +3774,8 @@
                 <narrative xml:lang="fr">Multi-Country Demobilisation and Reintegration Program</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
             <code>47109</code>
@@ -3032,6 +3784,8 @@
                 <narrative xml:lang="fr">Fonds de soutien de la coopération économique Asie-Pacifique (hors lutte contre le terrorisme)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2006-01-01">
             <code>47110</code>
@@ -3040,6 +3794,8 @@
                 <narrative xml:lang="fr">Organisation de coopération économique de la mer Noire</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47111</code>
@@ -3048,6 +3804,8 @@
                 <narrative xml:lang="fr">Fonds pour l’adaptation</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47112</code>
@@ -3056,6 +3814,8 @@
                 <narrative xml:lang="fr">Initiative de l’Europe centrale - Fonds Spécial pour la protection climatique et environnementale</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47113</code>
@@ -3064,6 +3824,8 @@
                 <narrative xml:lang="fr">Communauté économique et monétaire de l’Afrique Centrale</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47114</code>
@@ -3072,6 +3834,8 @@
                 <narrative xml:lang="fr">Asian Forest Cooperation Organisation</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47116</code>
@@ -3080,6 +3844,8 @@
                 <narrative xml:lang="fr">Cadre intégré pour l'assistance technique liée au commerce en faveur des pays les moins avancés</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47117</code>
@@ -3088,6 +3854,8 @@
                 <narrative xml:lang="fr">Nouveau Partenariat pour le développement de l’Afrique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47118</code>
@@ -3096,6 +3864,8 @@
                 <narrative xml:lang="fr">Conseil Régional de Formation des Institutions Supérieures de Contrôle des Finances Publiques d’Afrique Francophone Subsaharienne</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47119</code>
@@ -3104,6 +3874,8 @@
                 <narrative xml:lang="fr">Observatoire du Sahara et du Sahel</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47120</code>
@@ -3112,6 +3884,8 @@
                 <narrative xml:lang="fr">Association de l'Asie du Sud pour la coopération régionale</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47121</code>
@@ -3120,6 +3894,8 @@
                 <narrative xml:lang="fr">Cités et gouvernements locaux unis d’Afrique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2007-01-01">
             <code>47122</code>
@@ -3128,6 +3904,8 @@
                 <narrative xml:lang="fr">Alliance mondiale pour la vaccination et l’immunisation</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2005-01-01">
             <code>47123</code>
@@ -3136,6 +3914,8 @@
                 <narrative xml:lang="fr">Centre International de Déminage Humanitaire Genève</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47124</code>
@@ -3144,6 +3924,8 @@
                 <narrative xml:lang="fr">International Anti-Corruption Academy</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>47125</code>
@@ -3152,6 +3934,8 @@
                 <narrative xml:lang="fr">International Centre for Genetic Engineering and Biotechnology</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2008-01-01">
             <code>47127</code>
@@ -3160,6 +3944,8 @@
                 <narrative xml:lang="fr">Organisation latino-américaine de l'énergie</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>47128</code>
@@ -3168,6 +3954,8 @@
                 <narrative xml:lang="fr">Nordic Development Fund</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>47129</code>
@@ -3176,6 +3964,8 @@
                 <narrative xml:lang="fr">FEM Fonds pour les pays les moins avancés</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2009-01-01">
             <code>47130</code>
@@ -3184,6 +3974,8 @@
                 <narrative xml:lang="fr">FEM Fonds spécial pour les changements climatiques</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2010-01-01">
             <code>47131</code>
@@ -3192,6 +3984,8 @@
                 <narrative xml:lang="fr">Organisation pour la sécurité et la coopération en Europe</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2011-01-01">
             <code>47132</code>
@@ -3200,6 +3994,8 @@
                 <narrative xml:lang="fr">Secrétariat du Commonwealth (seulement les contributions éligibles à l'APD)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
             <code>47134</code>
@@ -3208,6 +4004,8 @@
                 <narrative xml:lang="fr">Fonds pour les technologies propres</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
             <code>47135</code>
@@ -3216,6 +4014,8 @@
                 <narrative xml:lang="fr">Fonds stratégique pour le climat</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2012-01-01">
             <code>47136</code>
@@ -3224,6 +4024,8 @@
                 <narrative xml:lang="fr">Institut mondial de la croissance verte</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>47137</code>
@@ -3232,6 +4034,8 @@
                 <narrative xml:lang="fr">Mutuelle panafricaine de gestion des risques</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>47138</code>
@@ -3240,6 +4044,8 @@
                 <narrative xml:lang="fr">Conseil de l’Europe</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>47139</code>
@@ -3248,6 +4054,8 @@
                 <narrative xml:lang="fr">Organisation Mondiale des Douanes Fonds de coopération douanière</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>47140</code>
@@ -3256,6 +4064,8 @@
                 <narrative xml:lang="fr">Organisation des états ibéro-américains pour l'éducation, la science et la culture (OEI)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>47141</code>
@@ -3264,6 +4074,8 @@
                 <narrative xml:lang="fr">Forum sur l’Administration Fiscale Africaine</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>47142</code>
@@ -3272,6 +4084,8 @@
                 <narrative xml:lang="fr">Le Fonds OPEP pour le développement international</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>47143</code>
@@ -3280,6 +4094,8 @@
                 <narrative xml:lang="fr">Fonds mondial pour l’engagement de la communauté et la résilience</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>47144</code>
@@ -3288,6 +4104,8 @@
                 <narrative xml:lang="fr">Agence internationale pour les energies renouvelables</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>47145</code>
@@ -3296,6 +4114,8 @@
                 <narrative xml:lang="fr">Center of Excellence in Finance</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>47146</code>
@@ -3304,6 +4124,8 @@
                 <narrative xml:lang="fr">International Investment Bank</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>47147</code>
@@ -3312,6 +4134,8 @@
                 <narrative xml:lang="fr">Facilité internationale de financement pour l'éducation</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>47148</code>
@@ -3320,6 +4144,8 @@
                 <narrative xml:lang="fr">Organisation mondiale de la santé animale</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2021-01-01">
             <code>47149</code>
@@ -3328,6 +4154,8 @@
                 <narrative xml:lang="fr">Commission internationale pour les personnes disparues</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>47150</code>
@@ -3336,6 +4164,8 @@
                 <narrative xml:lang="fr">Secretaría General Iberoamericana</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>47151</code>
@@ -3344,6 +4174,8 @@
                 <narrative xml:lang="fr">Banque arabe de développement économique en Afrique</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>47152</code>
@@ -3352,6 +4184,8 @@
                 <narrative xml:lang="fr">Fonds arabe pour le développement économique et social</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>47153</code>
@@ -3360,6 +4194,8 @@
                 <narrative xml:lang="fr">FIDA Contributions additionnelles de base pour le climat</narrative>
             </name>
             <category>41100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>47400</code>
@@ -3368,6 +4204,8 @@
                 <narrative xml:lang="fr">European Space Agency (ESA) programme 'Space in support of International Development Aid'</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>47501</code>
@@ -3376,6 +4214,8 @@
                 <narrative xml:lang="fr">Partenariat Mondial pour l'Education</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>47502</code>
@@ -3384,6 +4224,8 @@
                 <narrative xml:lang="fr">Global Fund for Disaster Risk Reduction</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>47503</code>
@@ -3392,6 +4234,8 @@
                 <narrative xml:lang="fr">Global Agriculture and Food Security Program</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2014-01-01">
             <code>47504</code>
@@ -3400,6 +4244,8 @@
                 <narrative xml:lang="fr">Forest Carbon Partnership Facility</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>47701</code>
@@ -3408,6 +4254,8 @@
                 <narrative xml:lang="fr">FEM Fonds du cadre mondial pour la biodiversité</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>47702</code>
@@ -3416,6 +4264,8 @@
                 <narrative xml:lang="fr">Cali Fund For the Fair and Equitable Sharing of Benefits from the use of Digital Sequence Information on Genetic Resources (DSI)</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>47703</code>
@@ -3424,6 +4274,8 @@
                 <narrative xml:lang="fr">Kunming Biodiversity Fund</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>47704</code>
@@ -3432,6 +4284,8 @@
                 <narrative xml:lang="fr">SESRIC</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>47705</code>
@@ -3440,6 +4294,8 @@
                 <narrative xml:lang="fr">Interpol</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>47706</code>
@@ -3448,6 +4304,8 @@
                 <narrative xml:lang="fr">Eurasian Fund for Stabilization and Development</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2025-01-01">
             <code>47707</code>
@@ -3456,6 +4314,8 @@
                 <narrative xml:lang="fr">Arab Monetary Fund</narrative>
             </name>
             <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>50000</code>
@@ -3471,6 +4331,8 @@
                 <narrative xml:lang="fr">Université, collège ou autre établissement d'enseignement, institut de recherche ou de réflexion</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2013-01-01">
             <code>51001</code>
@@ -3479,6 +4341,8 @@
                 <narrative xml:lang="fr">Institut International de Recherche sur les Politiques Alimentaires</narrative>
             </name>
             <category>51000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>52000</code>
@@ -3495,6 +4359,8 @@
                 <narrative xml:lang="fr">Institutions du secteur privé</narrative>
             </name>
             <category>60000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61000</code>
@@ -3503,6 +4369,8 @@
                 <narrative xml:lang="fr">Secteur privé du pays donneur</narrative>
             </name>
             <category>60000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61001</code>
@@ -3511,6 +4379,8 @@
                 <narrative xml:lang="fr">Banques (du pays donneur) (institutions de dépôts)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" activation-date="2016-01-01" withdrawal-date="2016-12-31">
             <code>61002</code>
@@ -3519,6 +4389,8 @@
                 <narrative xml:lang="fr">Exportateur privé dans le pays donneur</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61003</code>
@@ -3527,6 +4399,8 @@
                 <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>61004</code>
@@ -3535,6 +4409,8 @@
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61005</code>
@@ -3543,6 +4419,8 @@
                 <narrative xml:lang="fr">Sociétés d’assurance (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61006</code>
@@ -3551,6 +4429,8 @@
                 <narrative xml:lang="fr">Fonds de pension (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61007</code>
@@ -3559,6 +4439,8 @@
                 <narrative xml:lang="fr">Autres sociétés financières (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61008</code>
@@ -3567,6 +4449,8 @@
                 <narrative xml:lang="fr">Exportateurs (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61009</code>
@@ -3575,6 +4459,8 @@
                 <narrative xml:lang="fr">Autres sociétés non financières (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>61010</code>
@@ -3583,6 +4469,8 @@
                 <narrative xml:lang="fr">Investisseurs individuels (du pays donneur)</narrative>
             </name>
             <category>61000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62000</code>
@@ -3591,6 +4479,8 @@
                 <narrative xml:lang="fr">Secteur privé du pays bénéficiaire</narrative>
             </name>
             <category>60000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62001</code>
@@ -3599,6 +4489,8 @@
                 <narrative xml:lang="fr">Banques (du pays bénéficiaire) (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62002</code>
@@ -3607,6 +4499,8 @@
                 <narrative xml:lang="fr">Institutions de microfinancement (du pays bénéficiaire) (collectant ou pas des dépôts)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>62003</code>
@@ -3615,6 +4509,8 @@
                 <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62004</code>
@@ -3623,6 +4519,8 @@
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62005</code>
@@ -3631,6 +4529,8 @@
                 <narrative xml:lang="fr">Sociétés d’assurance (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62006</code>
@@ -3639,6 +4539,8 @@
                 <narrative xml:lang="fr">Fonds de pension (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62007</code>
@@ -3647,6 +4549,8 @@
                 <narrative xml:lang="fr">Autres sociétés financières (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62008</code>
@@ -3655,6 +4559,8 @@
                 <narrative xml:lang="fr">Importateurs / Exportateurs</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62009</code>
@@ -3663,6 +4569,8 @@
                 <narrative xml:lang="fr">Autres sociétés non financières (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>62010</code>
@@ -3671,6 +4579,8 @@
                 <narrative xml:lang="fr">Investisseurs individuels (du pays bénéficiaire)</narrative>
             </name>
             <category>62000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>63000</code>
@@ -3679,6 +4589,8 @@
                 <narrative xml:lang="fr">Secteur privé d'un pays tiers</narrative>
             </name>
             <category>60000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>63001</code>
@@ -3687,6 +4599,8 @@
                 <narrative xml:lang="fr">Banques (d'un pays tiers) (institutions de dépôts hors institutions de microfinancement)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>63002</code>
@@ -3695,6 +4609,8 @@
                 <narrative xml:lang="fr">Institutions de microfinancement (d'un pays tiers) (collectant ou pas des dépôts)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63003</code>
@@ -3703,6 +4619,8 @@
                 <narrative xml:lang="fr">Fonds d’investissements et autres organismes de placement collectifs (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63004</code>
@@ -3711,6 +4629,8 @@
                 <narrative xml:lang="fr">Sociétés holding, fonds fiduciaires et structures de titrisation (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63005</code>
@@ -3719,6 +4639,8 @@
                 <narrative xml:lang="fr">Sociétés d’assurance (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63006</code>
@@ -3727,6 +4649,8 @@
                 <narrative xml:lang="fr">Fonds de pension (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63007</code>
@@ -3735,6 +4659,8 @@
                 <narrative xml:lang="fr">Autres sociétés financières (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63008</code>
@@ -3743,6 +4669,8 @@
                 <narrative xml:lang="fr">Exportateurs (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63009</code>
@@ -3751,6 +4679,8 @@
                 <narrative xml:lang="fr">Autres sociétés non financières (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>63010</code>
@@ -3759,6 +4689,8 @@
                 <narrative xml:lang="fr">Investisseurs individuels (d'un pays tiers)</narrative>
             </name>
             <category>63000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>90000</code>
@@ -3767,6 +4699,8 @@
                 <narrative xml:lang="fr">Autre</narrative>
             </name>
             <category>90000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/CRSChannelCode.xml
+++ b/xml/CRSChannelCode.xml
@@ -27,7 +27,7 @@
             </name>
             <category>10000</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11001</code>
@@ -37,7 +37,7 @@
             </name>
             <category>11000</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11002</code>
@@ -47,7 +47,7 @@
             </name>
             <category>11000</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11003</code>
@@ -57,7 +57,7 @@
             </name>
             <category>11000</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2015-01-01">
             <code>11004</code>
@@ -2449,7 +2449,7 @@
             <extras:crs>1</extras:crs>
             <extras:tossd>0</extras:tossd>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2026-04-02">
+        <codelist-item status="withdrawn" withdrawal-date="2026-06-04">
             <code>45000</code>
             <name>
                 <narrative>World Trade Organisation (WTO)</narrative>
@@ -4312,6 +4312,56 @@
             <name>
                 <narrative>Arab Monetary Fund</narrative>
                 <narrative xml:lang="fr">Arab Monetary Fund</narrative>
+            </name>
+            <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47708</code>
+            <name>
+                <narrative>Andean Community</narrative>
+                <narrative xml:lang="fr">Andean Community</narrative>
+            </name>
+            <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47709</code>
+            <name>
+                <narrative>Community of Latin American and Caribbean States</narrative>
+                <narrative xml:lang="fr">Community of Latin American and Caribbean States</narrative>
+            </name>
+            <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47710</code>
+            <name>
+                <narrative>Pacific Alliance</narrative>
+                <narrative xml:lang="fr">Pacific Alliance</narrative>
+            </name>
+            <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47711</code>
+            <name>
+                <narrative>Southern Common Market</narrative>
+                <narrative xml:lang="fr">Southern Common Market</narrative>
+            </name>
+            <category>47000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2025-01-01">
+            <code>47712</code>
+            <name>
+                <narrative>Antarctic Treaty Secretariat</narrative>
+                <narrative xml:lang="fr">Antartic Treaty Secretariat</narrative>
             </name>
             <category>47000</category>
             <extras:crs>0</extras:crs>

--- a/xml/CollaborationType.xml
+++ b/xml/CollaborationType.xml
@@ -1,4 +1,4 @@
-<codelist name="CollaborationType" xml:lang="en" complete="1" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="CollaborationType" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
             <narrative>Collaboration Type</narrative>
@@ -18,6 +18,8 @@
                 <narrative>Bilateral</narrative>
                 <narrative xml:lang="fr">Bilatéral</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>2</code>
@@ -25,6 +27,8 @@
                 <narrative>Multilateral (inflows)</narrative>
                 <narrative xml:lang="fr">Multilatéral (contributions des donneurs du CAD)</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>3</code>
@@ -32,6 +36,8 @@
                 <narrative>Bilateral, core contributions to NGOs and other private bodies / PPPs</narrative>
                 <narrative xml:lang="fr">Contributions bilatérales au budget général d'organisations non gouvernementales, d'autres organisations de la société civile, de partenariats publics-privés et d'instituts de recherches</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>4</code>
@@ -39,6 +45,8 @@
                 <narrative>Multilateral outflows</narrative>
                 <narrative xml:lang="fr">Apports des institutions multilatérales</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>6</code>
@@ -46,6 +54,8 @@
                 <narrative>Private Sector Outflows</narrative>
                 <narrative xml:lang="fr">Apports du secteur privé</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>7</code>
@@ -53,6 +63,8 @@
                 <narrative>Bilateral, ex-post reporting on NGOs’ activities funded through core contributions</narrative>
                 <narrative xml:lang="fr">Contributions bilatérales, notification ex post des activités des ONG financées par des contributions des donneurs au budget général de l'ONG</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>8</code>
@@ -64,6 +76,8 @@
                 <narrative>Activities where one or more bilateral providers of development co-operation or international organisations support South-South co-operation, joining forces with developing countries to facilitate a sharing of knowledge and experience among all partners involved. (Activities that only involve bilateral providers or multilateral agencies without a South-South co-operation element (e.g. joint programming, pooled funding or delegated co-operation) should not be assigned bi_multi 8.)</narrative>
                 <narrative xml:lang="fr">Activités où un ou plusieurs pourvoyeurs bilatéraux de coopération pour le développement ou organisations internationales soutiennent la coopération Sud-Sud, conjointement avec des pays en développement afin de faciliter le partage des connaissances et d'expériences entre tous les partenaires impliqués. (Les activités qui n'impliquent que des pourvoyeurs bilatéraux ou des organismes multilatéraux sans coopération Sud-Sud (programmes conjoints, financements groupés ou coopération déléguée) ne devraient pas être codés bi_multi 8.)</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/FinanceType-category.xml
+++ b/xml/FinanceType-category.xml
@@ -1,4 +1,4 @@
-<codelist name="FinanceType-category" xml:lang="en" complete="1" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="FinanceType-category" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
             <narrative>Finance Type (category)</narrative>
@@ -22,6 +22,8 @@
                 <narrative>Non resource flow items requested on DAC table 1</narrative>
                 <narrative xml:lang="fr">Rubriques requises sur le tableau CAD 1 portant sur des informations autre que des apports</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>100</code>
@@ -29,6 +31,8 @@
                 <narrative>GRANTS</narrative>
                 <narrative xml:lang="fr">DONS</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>1000</code>
@@ -36,6 +40,8 @@
                 <narrative>GUARANTEES AND OTHER UNFUNDED CONTINGENT LIABILITIES</narrative>
                 <narrative xml:lang="fr">GARANTIES ET AUTRES ENGAGEMENTS CONDITIONNELS NON PROVISIONNÉS</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>200</code>
@@ -58,6 +64,8 @@
                 <narrative>Direct provider spending</narrative>
                 <narrative xml:lang="fr">Direct provider spending</narrative>
             </description>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>300</code>
@@ -80,6 +88,8 @@
                 <narrative>Subsidies and similar transfers</narrative>
                 <narrative xml:lang="fr">Subsidies and similar transfers</narrative>
             </description>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>400</code>
@@ -98,6 +108,8 @@
                 <narrative>DEBT INSTRUMENTS</narrative>
                 <narrative xml:lang="fr">INSTRUMENTS DE DETTE</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>430</code>
@@ -105,6 +117,8 @@
                 <narrative>MEZZANINE FINANCE INSTRUMENTS</narrative>
                 <narrative xml:lang="fr">INSTRUMENTS DE DETTE</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>500</code>
@@ -112,6 +126,8 @@
                 <narrative>EQUITY AND SHARES IN COLLECTIVE INVESTMENT VEHICLES</narrative>
                 <narrative xml:lang="fr">ACTIONS ET PARTS DANS DES VEHICULES COLLECTIFS D'INVESTISSEMENT</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>600</code>
@@ -123,6 +139,8 @@
                 <narrative>Debt cancellations, debt conversions, debt rescheduling within or outside the framework of the Paris Club.</narrative>
                 <narrative xml:lang="fr">Annulation de dette, conversion de dette, rééchelonnement de dette au sein ou en dehors du Club de Paris.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>700</code>

--- a/xml/FinanceType-category.xml
+++ b/xml/FinanceType-category.xml
@@ -48,6 +48,17 @@
                 <narrative xml:lang="fr">Subventions visant à assouplir les conditions des crédits à l’exportation ou des prêts/crédits du secteur bancaire.</narrative>
             </description>
         </codelist-item>
+        <codelist-item status="active">
+            <code>2000</code>
+            <name>
+                <narrative>Direct provider spending</narrative>
+                <narrative xml:lang="fr">Direct provider spending</narrative>
+            </name>
+            <description>
+                <narrative>Direct provider spending</narrative>
+                <narrative xml:lang="fr">Direct provider spending</narrative>
+            </description>
+        </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>300</code>
             <name>
@@ -57,6 +68,17 @@
             <description>
                 <narrative>Payments to multilateral agencies in the form of notes and similar instruments, unconditionally cashable at sight by the recipient institutions.</narrative>
                 <narrative xml:lang="fr">Versements aux agences multilatérales sous forme de billets à ordre et effets similaires encaissables à vue sans condition par l'institution bénéficiaire.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>3000</code>
+            <name>
+                <narrative>Subsidies and similar transfers</narrative>
+                <narrative xml:lang="fr">Subsidies and similar transfers</narrative>
+            </name>
+            <description>
+                <narrative>Subsidies and similar transfers</narrative>
+                <narrative xml:lang="fr">Subsidies and similar transfers</narrative>
             </description>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
@@ -87,8 +109,8 @@
         <codelist-item status="active">
             <code>500</code>
             <name>
-                <narrative>EQUITY  AND SHARES IN COLLECTIVE INVESTMENT VEHICLES</narrative>
-                <narrative xml:lang="fr">ACTIONS ET  PARTS DANS DES VEHICULES COLLECTIFS D'INVESTISSEMENT</narrative>
+                <narrative>EQUITY AND SHARES IN COLLECTIVE INVESTMENT VEHICLES</narrative>
+                <narrative xml:lang="fr">ACTIONS ET PARTS DANS DES VEHICULES COLLECTIFS D'INVESTISSEMENT</narrative>
             </name>
         </codelist-item>
         <codelist-item status="active">

--- a/xml/FinanceType.xml
+++ b/xml/FinanceType.xml
@@ -1,4 +1,4 @@
-<codelist name="FinanceType" xml:lang="en" complete="1" category-codelist="FinanceType-category" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="FinanceType" xml:lang="en" complete="1" category-codelist="FinanceType-category" embedded="0">
     <metadata>
         <name>
             <narrative>Finance Type</narrative>
@@ -19,6 +19,8 @@
                 <narrative xml:lang="fr">RNB : Revenu national brut</narrative>
             </name>
             <category>0</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>110</code>
@@ -31,6 +33,8 @@
                 <narrative xml:lang="fr">Transferts en espèces ou en nature qui n'entraînent pas d'obligation juridique de remboursement pour le bénéficiaire.</narrative>
             </description>
             <category>100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>1100</code>
@@ -39,6 +43,8 @@
                 <narrative xml:lang="fr">Garanties/assurances</narrative>
             </name>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1101</code>
@@ -51,6 +57,8 @@
                 <narrative xml:lang="fr">Une garantie sur un prêt individuel standard</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1102</code>
@@ -63,6 +71,8 @@
                 <narrative xml:lang="fr">Une garantie couvrant un portefeuille de prêts standards administrés par des intermédiaires financiers, tels que des banques, des institutions de microfinance ou des véhicules de placement collectif.</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1103</code>
@@ -75,6 +85,8 @@
                 <narrative xml:lang="fr">Une garantie sur un investissement individuel en financement mezzanine (prêts subordonnés ou actions privilégiées).</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1104</code>
@@ -87,6 +99,8 @@
                 <narrative xml:lang="fr">Une garantie couvrant un portefeuille d'investissements en financement mezzanine (prêts subordonnés ou actions privilégiées) administré par des intermédiaires financiers, tels que des banques, des institutions de microfinance ou des véhicules de placement collectif.</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1105</code>
@@ -99,6 +113,8 @@
                 <narrative xml:lang="fr">Une garantie couvrant un investissement en actions.</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1106</code>
@@ -111,6 +127,8 @@
                 <narrative xml:lang="fr">Garantie couvrant un portefeuille de participations administré par des intermédiaires financiers, tels que des banques, des institutions de microfinance ou des organismes de placement collectif.</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1107</code>
@@ -123,6 +141,8 @@
                 <narrative xml:lang="fr">Une garantie spécifiquement conçue pour absorber la toute première perte sur un ou plusieurs investissements, comme dans le cadre de véhicules de placement collectif. Veuillez utiliser d'autres codes pour les garanties qui ne sont pas spécifiquement conçues pour absorber la toute première perte.</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>1108</code>
@@ -135,6 +155,8 @@
                 <narrative xml:lang="fr">Autres garanties, telles que garanties de volume, garanties de paiement, etc.</narrative>
             </description>
             <category>1000</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>111</code>
@@ -143,6 +165,8 @@
                 <narrative xml:lang="fr">Don hors réorganisation de la dette (y compris quasi-dons)</narrative>
             </name>
             <category>100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>2</code>
@@ -151,6 +175,8 @@
                 <narrative xml:lang="fr">APD en % du RNB</narrative>
             </name>
             <category>0</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>200</code>
@@ -162,6 +188,8 @@
                 <narrative>Subsidies to soften the terms of private export credits, or loans or credits by the banking sector.</narrative>
                 <narrative xml:lang="fr">Subventions visant à assouplir les conditions des crédits à l’exportation ou des prêts/crédits du secteur bancaire.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>210</code>
@@ -174,6 +202,8 @@
                 <narrative xml:lang="fr">Subventions visant à assouplir les conditions des crédits à l’exportation ou des prêts/crédits du secteur bancaire.</narrative>
             </description>
             <category>100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>2100</code>
@@ -182,6 +212,8 @@
                 <narrative xml:lang="fr">Direct provider spending</narrative>
             </name>
             <category>2000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>211</code>
@@ -190,6 +222,8 @@
                 <narrative xml:lang="fr">Bonification d’intérêt octroyée aux exportateurs privés nationaux</narrative>
             </name>
             <category>100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>3</code>
@@ -198,6 +232,8 @@
                 <narrative xml:lang="fr">Apports totaux en % du RNB</narrative>
             </name>
             <category>0</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>300</code>
@@ -209,6 +245,8 @@
                 <narrative>Payments to multilateral agencies in the form of notes and similar instruments, unconditionally cashable at sight by the recipient institutions.</narrative>
                 <narrative xml:lang="fr">Versements aux agences multilatérales sous forme de billets à ordre et effets similaires encaissables à vue sans condition par l'institution bénéficiaire.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>310</code>
@@ -221,6 +259,8 @@
                 <narrative xml:lang="fr">Versements aux agences multilatérales sous forme de billets à ordre et effets similaires encaissables à vue sans condition par l'institution bénéficiaire.</narrative>
             </description>
             <category>100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>3100</code>
@@ -233,6 +273,8 @@
                 <narrative xml:lang="fr">This category includes subsidies and social benefits to households as defined in the System of National Accounts (SNA). Subsidies are unrequited payments that government units, including non-resident government units, make to enterprises on the basis of the levels of their production activities or the quantities or values of the goods or services which they produce, sell or import. Subsidies prohibited by the WTO are not reportable in TOSSD. Social benefits to households are current transfers received by households that are intended to provide for the needs that arise from certain events or circumstances, for example housing. Subsidies and similar transfers can be used by governments to promote sustainable development objectives, for example by supporting research activities carried out by pharmaceutical firms or efforts by households to improve the energy efficiency of their housing. According to the United Nations System of Environmental-Economic Accounting (SEEA), an environmental subsidy or similar transfer is a transfer intended to support activities that protect the environment or reduce the use and extraction of natural resources.</narrative>
             </description>
             <category>3000</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>311</code>
@@ -245,6 +287,8 @@
                 <narrative xml:lang="fr">Versements aux agences multilatérales sous forme de billets à ordre et effets similaires encaissables à vue sans condition par l'institution bénéficiaire.</narrative>
             </description>
             <category>100</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>4</code>
@@ -253,6 +297,8 @@
                 <narrative xml:lang="fr">Population</narrative>
             </name>
             <category>0</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>400</code>
@@ -264,6 +310,8 @@
                 <narrative>Transfers in cash or in kind for which the recipient incurs legal debt.</narrative>
                 <narrative xml:lang="fr">Transferts en espèce ou en nature qui entraînent une obligation juridique de remboursement pour le bénéficiaire.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>410</code>
@@ -272,6 +320,8 @@
                 <narrative xml:lang="fr">Prêt d’aide hors réorganisation de la dette</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>411</code>
@@ -280,6 +330,8 @@
                 <narrative xml:lang="fr">Prêt lié à un investissement dans les pays en développement</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>412</code>
@@ -288,6 +340,8 @@
                 <narrative xml:lang="fr">Prêt dans une coentreprise avec le pays bénéficiaire</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>413</code>
@@ -296,6 +350,8 @@
                 <narrative xml:lang="fr">Prêt à un investisseur privé national</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>414</code>
@@ -304,6 +360,8 @@
                 <narrative xml:lang="fr">Prêt à un exportateur privé national</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>421</code>
@@ -316,6 +374,8 @@
                 <narrative xml:lang="fr">Transferts en espèce ou en nature qui entraînent une obligation juridique de remboursement pour le bénéficiaire (dont la créance n'est pas échangeable.) Lorsque les obligations de remboursement sur les prêts ordinaires sont senior, càd que le créditeur est éligible à percevoir le remboursement de sa créance avant quiconque, on parle de prêt senior.</narrative>
             </description>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>422</code>
@@ -328,6 +388,8 @@
                 <narrative xml:lang="fr">Contribution fournie à une institution bénéficiaire à des fins d'investissement, dans une perspective de remboursement à long-terme à des conditions spécifiées dans l'accord de financement. Le fournisseur assume le risque partiel ou total de faillite de l'investissement ; il peut aussi décider si et quand il récupère son investissement.</narrative>
             </description>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>4221</code>
@@ -340,6 +402,8 @@
                 <narrative xml:lang="fr">Contribution fournie à une institution bénéficiaire à des fins d'investissement, dont les conditions – y compris un calendrier de remboursement concret – sont précisées dans l'accord de financement.</narrative>
             </description>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>4222</code>
@@ -352,6 +416,8 @@
                 <narrative xml:lang="fr">Contribution fournie à une institution bénéficiaire à des fins d'investissement, pour laquelle les détails des remboursements sont inconnus au moment de l'investissement car ils dépendent de la performance des investissements sous-jacents.</narrative>
             </description>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>423</code>
@@ -364,6 +430,8 @@
                 <narrative xml:lang="fr">Instruments de dette à intérêts fixes émis par des gouvernements, entités publiques, banques ou sociétés, échangeables sur les marchés financiers.</narrative>
             </description>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>424</code>
@@ -376,6 +444,8 @@
                 <narrative xml:lang="fr">Actifs dont la valeur et les revenus sont dérivés de et adossés à un panier d'actifs sous-jacents.</narrative>
             </description>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>425</code>
@@ -384,6 +454,8 @@
                 <narrative xml:lang="fr">Autres actifs de dette</narrative>
             </name>
             <category>420</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>431</code>
@@ -396,6 +468,8 @@
                 <narrative xml:lang="fr">Prêt qui, en cas de défaut, ne sera remboursé qu'après que les obligations senior soient satisfaites.  En compensation du risque accru, les détenteurs de dette mezzanine exigent un retour sur investissement plus élevé que les prêteurs garantis ou senior.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>432</code>
@@ -408,6 +482,8 @@
                 <narrative xml:lang="fr">Action qui, en cas de défaut, ne sera remboursé qu'après que les obligations senior soient satisfaites ; mais avant les détenteurs d'actions ordinaires.  Il s'agit d'une source de financement plus onéreuse que la dette senior mais moins coûteuse que les actions.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>433</code>
@@ -420,6 +496,8 @@
                 <narrative xml:lang="fr">Incluant les dettes convertibles et les actions.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2024-01-01">
             <code>434</code>
@@ -432,6 +510,8 @@
                 <narrative xml:lang="fr">Instruments de capital hybride émis par des institutions multilatérales</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>451</code>
@@ -440,6 +520,8 @@
                 <narrative xml:lang="fr">Crédits à l'exportation garantis du secteur non bancaire</narrative>
             </name>
             <category>450</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>452</code>
@@ -448,6 +530,8 @@
                 <narrative xml:lang="fr">Fraction non garantie des crédits à l'exportation garantis du secteur bancaire</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>453</code>
@@ -456,6 +540,8 @@
                 <narrative xml:lang="fr">Crédits à l'exportation du secteur bancaire</narrative>
             </name>
             <category>400</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>510</code>
@@ -468,6 +554,8 @@
                 <narrative xml:lang="fr">Part de propriété dans une société donnant à son détenteur une créance sur la valeurs résiduelle de la société une fois que les créances de ses créditeurs ont été satisfaites.</narrative>
             </description>
             <category>500</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>511</code>
@@ -476,6 +564,8 @@
                 <narrative xml:lang="fr">Acquisition de prises de participation en dehors des coentreprises avec les pays en développement</narrative>
             </name>
             <category>500</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>512</code>
@@ -484,6 +574,8 @@
                 <narrative xml:lang="fr">Autre acquisition de prises de participation</narrative>
             </name>
             <category>500</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>520</code>
@@ -496,6 +588,8 @@
                 <narrative xml:lang="fr">Placement collectif par lequel un groupe d'investisseurs abonde un fond d'actifs financiers ou non financiers ou les deux. Ces véhicules émettent des parts (en cas de structure d'entreprise) ou des unités de compte (en cas de structure fiduciaire.)</narrative>
             </description>
             <category>500</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>530</code>
@@ -508,6 +602,8 @@
                 <narrative xml:lang="fr">Cet item n'est applicable qu'aux investissement direct étrangers (IDE). Les bénéfices réinvestis sur des IDE consistent en des bénéfices retenus d'un investissement direct à l'étranger qui sont traités comme s'ils étaient redistribués et versés aux investisseurs en proportion de leur part dans l'actionnariat puis réinvestis par eux dans l'entreprise.</narrative>
             </description>
             <category>500</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>610</code>
@@ -516,6 +612,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance APD (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>611</code>
@@ -524,6 +622,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance APD (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>612</code>
@@ -532,6 +632,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance AASP (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>613</code>
@@ -540,6 +642,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance AASP (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>614</code>
@@ -548,6 +652,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance du secteur privé (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>615</code>
@@ -556,6 +662,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance du secteur privé (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>616</code>
@@ -564,6 +672,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance AASP (DSR)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>617</code>
@@ -572,6 +682,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance du secteur privé (DSR)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>618</code>
@@ -580,6 +692,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : autre</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>620</code>
@@ -588,6 +702,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance APD (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>621</code>
@@ -596,6 +712,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance APD (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>622</code>
@@ -604,6 +722,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>623</code>
@@ -612,6 +732,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>624</code>
@@ -620,6 +742,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>625</code>
@@ -628,6 +752,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>626</code>
@@ -636,6 +762,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (RSD)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>627</code>
@@ -644,6 +772,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (RSD)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>630</code>
@@ -652,6 +782,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (RSD – principal du prêt d’origine)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>631</code>
@@ -660,6 +792,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance AASP (RSD – intérêts du prêt d’origine)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>632</code>
@@ -668,6 +802,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance du secteur privé (RSD – principal du prêt d’origine)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>633</code>
@@ -676,6 +812,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance de crédit à l'exportation (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>634</code>
@@ -684,6 +822,8 @@
                 <narrative xml:lang="fr">Annulation/conversion de la dette : créance de crédit à l'exportation (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>635</code>
@@ -692,6 +832,8 @@
                 <narrative xml:lang="fr">Annulation de la dette : créance de crédit à l'exportation (DSR)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>636</code>
@@ -700,6 +842,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (P)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>637</code>
@@ -708,6 +852,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (I)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>638</code>
@@ -716,6 +862,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (DSR)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>639</code>
@@ -724,6 +872,8 @@
                 <narrative xml:lang="fr">Rééchelonnement de la dette : créance de crédit à  l'exportation (DSR - principal du prêt originel)</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>700</code>
@@ -735,6 +885,8 @@
                 <narrative>Investment made by a private entity resident in a reporting country to acquire or add to a lasting interest(1) in an enterprise in a country on the DAC List of ODA Recipients.</narrative>
                 <narrative xml:lang="fr">L’investissement direct est motivé par la volonté d’une entité résidente d’un pays déclarant d’acquérir ou de maintenir un intérêt durable1 dans une entité résidente d’un pays en développement.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>710</code>
@@ -743,6 +895,8 @@
                 <narrative xml:lang="fr">Investissement direct international</narrative>
             </name>
             <category>700</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>711</code>
@@ -751,6 +905,8 @@
                 <narrative xml:lang="fr">Autre investissement direct international , y compris les bénéfices réinvestis</narrative>
             </name>
             <category>700</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>712</code>
@@ -759,6 +915,8 @@
                 <narrative xml:lang="fr"/>
             </name>
             <category>700</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>800</code>
@@ -770,6 +928,8 @@
                 <narrative>Acquisition of bonds issued by developing countries.</narrative>
                 <narrative xml:lang="fr">Acquisition d’obligations émises par les pays en développement.</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>810</code>
@@ -778,6 +938,8 @@
                 <narrative xml:lang="fr">Obligations du secteur bancaire</narrative>
             </name>
             <category>800</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>811</code>
@@ -786,6 +948,8 @@
                 <narrative xml:lang="fr">Obligations du secteur non bancaire</narrative>
             </name>
             <category>800</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>900</code>
@@ -793,6 +957,8 @@
                 <narrative>OTHER SECURITIES/CLAIMS</narrative>
                 <narrative xml:lang="fr">AUTRES TITRES/CREANCES</narrative>
             </name>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>910</code>
@@ -801,6 +967,8 @@
                 <narrative xml:lang="fr">Autres titres/créances du secteur bancaire</narrative>
             </name>
             <category>900</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>911</code>
@@ -809,6 +977,8 @@
                 <narrative xml:lang="fr">Autres titres/créances du secteur non bancaire</narrative>
             </name>
             <category>900</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>912</code>
@@ -817,6 +987,8 @@
                 <narrative xml:lang="fr">Titres et autres instruments émis par les agences multilatérales</narrative>
             </name>
             <category>900</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>913</code>
@@ -825,6 +997,8 @@
                 <narrative xml:lang="fr"/>
             </name>
             <category>900</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/FinanceType.xml
+++ b/xml/FinanceType.xml
@@ -1,4 +1,4 @@
-<codelist name="FinanceType" xml:lang="en" category-codelist="FinanceType-category" complete="1" embedded="0">
+<codelist name="FinanceType" xml:lang="en" complete="1" category-codelist="FinanceType-category" embedded="0">
     <metadata>
         <name>
             <narrative>Finance Type</narrative>
@@ -40,6 +40,102 @@
             </name>
             <category>1000</category>
         </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1101</code>
+            <name>
+                <narrative>Individual loan guarantee</narrative>
+                <narrative xml:lang="fr">Garantie individuelle accordée prêt par prêt</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee on an individual standard loan</narrative>
+                <narrative xml:lang="fr">Une garantie sur un prêt individuel standard</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1102</code>
+            <name>
+                <narrative>Loan portfolio guarantee</narrative>
+                <narrative xml:lang="fr">Garantie de portefeuille de prêts</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee covering a portfolio of standard loans administered by financial intermediaries, such as banks, microfinance institutions or collective investment vehicles.</narrative>
+                <narrative xml:lang="fr">Une garantie couvrant un portefeuille de prêts standards administrés par des intermédiaires financiers, tels que des banques, des institutions de microfinance ou des véhicules de placement collectif.</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1103</code>
+            <name>
+                <narrative>Individual mezzanine finance guarantee</narrative>
+                <narrative xml:lang="fr">Garantie individuelle pour le financement mezzanine</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee on an individual mezzanine finance investment (subordinated loans or preferred equities).</narrative>
+                <narrative xml:lang="fr">Une garantie sur un investissement individuel en financement mezzanine (prêts subordonnés ou actions privilégiées).</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1104</code>
+            <name>
+                <narrative>Mezzanine finance portfolio guarantee</narrative>
+                <narrative xml:lang="fr">Garantie de portefeuille des instruments mezzanine</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee covering a portfolio of mezzanine finance investments (subordinated loans or preferred equities) administered by financial intermediaries, such as banks, microfinance institutions or collective investment vehicles.</narrative>
+                <narrative xml:lang="fr">Une garantie couvrant un portefeuille d'investissements en financement mezzanine (prêts subordonnés ou actions privilégiées) administré par des intermédiaires financiers, tels que des banques, des institutions de microfinance ou des véhicules de placement collectif.</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1105</code>
+            <name>
+                <narrative>Individual equity finance guarantee</narrative>
+                <narrative xml:lang="fr">Garantie individuelle pour le financement en fonds propres</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee covering an equity investment.</narrative>
+                <narrative xml:lang="fr">Une garantie couvrant un investissement en actions.</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1106</code>
+            <name>
+                <narrative>Equity portfolio guarantee</narrative>
+                <narrative xml:lang="fr">Garantie de portefeuille d'actions</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee covering a portfolio of equity investments administered by financial intermediaries, such as banks, microfinance institutions or collective investment vehicles.</narrative>
+                <narrative xml:lang="fr">Garantie couvrant un portefeuille de participations administré par des intermédiaires financiers, tels que des banques, des institutions de microfinance ou des organismes de placement collectif.</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1107</code>
+            <name>
+                <narrative>First-loss guarantee</narrative>
+                <narrative xml:lang="fr">Garantie des premières pertes</narrative>
+            </name>
+            <description>
+                <narrative>A guarantee specifically designed to absorb the very first loss on one or more investments, such as in the context of collective investment vehicles. Please use other codes for guarantees that are not specifically designed to absorb the very first loss.</narrative>
+                <narrative xml:lang="fr">Une garantie spécifiquement conçue pour absorber la toute première perte sur un ou plusieurs investissements, comme dans le cadre de véhicules de placement collectif. Veuillez utiliser d'autres codes pour les garanties qui ne sont pas spécifiquement conçues pour absorber la toute première perte.</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>1108</code>
+            <name>
+                <narrative>Other guarantees</narrative>
+                <narrative xml:lang="fr">Autres garanties</narrative>
+            </name>
+            <description>
+                <narrative>Other guarantees, such as volume guarantees, payment guarantees etc.</narrative>
+                <narrative xml:lang="fr">Autres garanties, telles que garanties de volume, garanties de paiement, etc.</narrative>
+            </description>
+            <category>1000</category>
+        </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>111</code>
             <name>
@@ -56,6 +152,17 @@
             </name>
             <category>0</category>
         </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>200</code>
+            <name>
+                <narrative>INTEREST SUBSIDY</narrative>
+                <narrative xml:lang="fr">BONIFICATION  D’INTERET</narrative>
+            </name>
+            <description>
+                <narrative>Subsidies to soften the terms of private export credits, or loans or credits by the banking sector.</narrative>
+                <narrative xml:lang="fr">Subventions visant à assouplir les conditions des crédits à l’exportation ou des prêts/crédits du secteur bancaire.</narrative>
+            </description>
+        </codelist-item>
         <codelist-item status="active">
             <code>210</code>
             <name>
@@ -67,6 +174,14 @@
                 <narrative xml:lang="fr">Subventions visant à assouplir les conditions des crédits à l’exportation ou des prêts/crédits du secteur bancaire.</narrative>
             </description>
             <category>100</category>
+        </codelist-item>
+        <codelist-item status="active">
+            <code>2100</code>
+            <name>
+                <narrative>Direct provider spending</narrative>
+                <narrative xml:lang="fr">Direct provider spending</narrative>
+            </name>
+            <category>2000</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>211</code>
@@ -84,6 +199,17 @@
             </name>
             <category>0</category>
         </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>300</code>
+            <name>
+                <narrative>CAPITAL SUBSCRIPTION</narrative>
+                <narrative xml:lang="fr">SOUSCRIPTION AU CAPITAL</narrative>
+            </name>
+            <description>
+                <narrative>Payments to multilateral agencies in the form of notes and similar instruments, unconditionally cashable at sight by the recipient institutions.</narrative>
+                <narrative xml:lang="fr">Versements aux agences multilatérales sous forme de billets à ordre et effets similaires encaissables à vue sans condition par l'institution bénéficiaire.</narrative>
+            </description>
+        </codelist-item>
         <codelist-item status="active">
             <code>310</code>
             <name>
@@ -95,6 +221,18 @@
                 <narrative xml:lang="fr">Versements aux agences multilatérales sous forme de billets à ordre et effets similaires encaissables à vue sans condition par l'institution bénéficiaire.</narrative>
             </description>
             <category>100</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2020-01-01">
+            <code>3100</code>
+            <name>
+                <narrative>Subsidies and similar transfers</narrative>
+                <narrative xml:lang="fr">Subsidies and similar transfers</narrative>
+            </name>
+            <description>
+                <narrative>This category includes subsidies and social benefits to households as defined in the System of National Accounts (SNA). Subsidies are unrequited payments that government units, including non-resident government units, make to enterprises on the basis of the levels of their production activities or the quantities or values of the goods or services which they produce, sell or import. Subsidies prohibited by the WTO are not reportable in TOSSD. Social benefits to households are current transfers received by households that are intended to provide for the needs that arise from certain events or circumstances, for example housing. Subsidies and similar transfers can be used by governments to promote sustainable development objectives, for example by supporting research activities carried out by pharmaceutical firms or efforts by households to improve the energy efficiency of their housing. According to the United Nations System of Environmental-Economic Accounting (SEEA), an environmental subsidy or similar transfer is a transfer intended to support activities that protect the environment or reduce the use and extraction of natural resources.</narrative>
+                <narrative xml:lang="fr">This category includes subsidies and social benefits to households as defined in the System of National Accounts (SNA). Subsidies are unrequited payments that government units, including non-resident government units, make to enterprises on the basis of the levels of their production activities or the quantities or values of the goods or services which they produce, sell or import. Subsidies prohibited by the WTO are not reportable in TOSSD. Social benefits to households are current transfers received by households that are intended to provide for the needs that arise from certain events or circumstances, for example housing. Subsidies and similar transfers can be used by governments to promote sustainable development objectives, for example by supporting research activities carried out by pharmaceutical firms or efforts by households to improve the energy efficiency of their housing. According to the United Nations System of Environmental-Economic Accounting (SEEA), an environmental subsidy or similar transfer is a transfer intended to support activities that protect the environment or reduce the use and extraction of natural resources.</narrative>
+            </description>
+            <category>3000</category>
         </codelist-item>
         <codelist-item status="active">
             <code>311</code>
@@ -115,6 +253,17 @@
                 <narrative xml:lang="fr">Population</narrative>
             </name>
             <category>0</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>400</code>
+            <name>
+                <narrative>LOAN</narrative>
+                <narrative xml:lang="fr">PRÊT</narrative>
+            </name>
+            <description>
+                <narrative>Transfers in cash or in kind for which the recipient incurs legal debt.</narrative>
+                <narrative xml:lang="fr">Transferts en espèce ou en nature qui entraînent une obligation juridique de remboursement pour le bénéficiaire.</narrative>
+            </description>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>410</code>
@@ -177,6 +326,30 @@
             <description>
                 <narrative>A contribution provided to a recipient institution for investment purposes, with the expectation of long-term reflows at conditions specified in the financing agreement. The provider assumes the risk of total or partial failure of the investment; it can also decide if and when to reclaim its investment.</narrative>
                 <narrative xml:lang="fr">Contribution fournie à une institution bénéficiaire à des fins d'investissement, dans une perspective de remboursement à long-terme à des conditions spécifiées dans l'accord de financement. Le fournisseur assume le risque partiel ou total de faillite de l'investissement ; il peut aussi décider si et quand il récupère son investissement.</narrative>
+            </description>
+            <category>420</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>4221</code>
+            <name>
+                <narrative>Loan-type reimbursable grant</narrative>
+                <narrative xml:lang="fr">Don remboursable de type prêt</narrative>
+            </name>
+            <description>
+                <narrative>A contribution provided to a recipient institution for investment purposes, for which the conditions - including a concrete repayment schedule – are specified in the financing agreement.</narrative>
+                <narrative xml:lang="fr">Contribution fournie à une institution bénéficiaire à des fins d'investissement, dont les conditions – y compris un calendrier de remboursement concret – sont précisées dans l'accord de financement.</narrative>
+            </description>
+            <category>420</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>4222</code>
+            <name>
+                <narrative>Reflow-based reimbursable grant</narrative>
+                <narrative xml:lang="fr">Don remboursable par retour de capitaux</narrative>
+            </name>
+            <description>
+                <narrative>A contribution provided to a recipient institution for investment purposes, for which the details on reflows are unknown at the time of investment as they depend on the performance of the underlying investments.</narrative>
+                <narrative xml:lang="fr">Contribution fournie à une institution bénéficiaire à des fins d'investissement, pour laquelle les détails des remboursements sont inconnus au moment de l'investissement car ils dépendent de la performance des investissements sous-jacents.</narrative>
             </description>
             <category>420</category>
         </codelist-item>
@@ -245,6 +418,18 @@
             <description>
                 <narrative>Including convertible debt or equity.</narrative>
                 <narrative xml:lang="fr">Incluant les dettes convertibles et les actions.</narrative>
+            </description>
+            <category>430</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2024-01-01">
+            <code>434</code>
+            <name>
+                <narrative>Multilateral hybrid capital</narrative>
+                <narrative xml:lang="fr">Capital hybride multilatéral</narrative>
+            </name>
+            <description>
+                <narrative>Hybrid capital instruments issued by multilateral institutions</narrative>
+                <narrative xml:lang="fr">Instruments de capital hybride émis par des institutions multilatérales</narrative>
             </description>
             <category>430</category>
         </codelist-item>
@@ -541,6 +726,17 @@
             <category>600</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>700</code>
+            <name>
+                <narrative>INVESTMENT</narrative>
+                <narrative xml:lang="fr">INVESTISSEMENTS DIRECTS INTERNATIONAUX</narrative>
+            </name>
+            <description>
+                <narrative>Investment made by a private entity resident in a reporting country to acquire or add to a lasting interest(1) in an enterprise in a country on the DAC List of ODA Recipients.</narrative>
+                <narrative xml:lang="fr">L’investissement direct est motivé par la volonté d’une entité résidente d’un pays déclarant d’acquérir ou de maintenir un intérêt durable1 dans une entité résidente d’un pays en développement.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>710</code>
             <name>
                 <narrative>Foreign direct investment, new capital outflow (includes reinvested earnings if separate identification not available)</narrative>
@@ -565,6 +761,17 @@
             <category>700</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>800</code>
+            <name>
+                <narrative>BONDS</narrative>
+                <narrative xml:lang="fr">OBLIGATIONS</narrative>
+            </name>
+            <description>
+                <narrative>Acquisition of bonds issued by developing countries.</narrative>
+                <narrative xml:lang="fr">Acquisition d’obligations émises par les pays en développement.</narrative>
+            </description>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>810</code>
             <name>
                 <narrative>Bank bonds</narrative>
@@ -579,6 +786,13 @@
                 <narrative xml:lang="fr">Obligations du secteur non bancaire</narrative>
             </name>
             <category>800</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
+            <code>900</code>
+            <name>
+                <narrative>OTHER SECURITIES/CLAIMS</narrative>
+                <narrative xml:lang="fr">AUTRES TITRES/CREANCES</narrative>
+            </name>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>910</code>

--- a/xml/FlowType.xml
+++ b/xml/FlowType.xml
@@ -122,5 +122,16 @@
                 <narrative xml:lang="fr">ex : élément non APD des opérations de maintien de la paix</narrative>
             </description>
         </codelist-item>
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>60</code>
+            <name>
+                <narrative>PSI</narrative>
+                <narrative xml:lang="fr">ISP</narrative>
+            </name>
+            <description>
+                <narrative>Private sector instruments</narrative>
+                <narrative xml:lang="fr">Instruments du secteur privé</narrative>
+            </description>
+        </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/FlowType.xml
+++ b/xml/FlowType.xml
@@ -1,4 +1,4 @@
-<codelist name="FlowType" xml:lang="en" complete="1" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="FlowType" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
             <narrative>Flow Type</narrative>
@@ -22,6 +22,8 @@
                 <narrative>Official Development Assistance</narrative>
                 <narrative xml:lang="fr">Aide Publique au Développement</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>20</code>
@@ -33,6 +35,8 @@
                 <narrative>Other Official Flows</narrative>
                 <narrative xml:lang="fr">Autres Apports du Secteur Public</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>21</code>
@@ -44,6 +48,8 @@
                 <narrative>Other Official Flows, excl. export credits</narrative>
                 <narrative xml:lang="fr">Autres Apports du Secteur Public, à l'exclusion des crédits à l'exportation</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>22</code>
@@ -55,6 +61,8 @@
                 <narrative>Officially supported export credits. Covers both official direct export credits and private export credits under official guarantee or insurance</narrative>
                 <narrative xml:lang="fr">Autres Apports du Secteur Public, comprenant les crédits à l'exportation soutenus par le secteur public et les exportations privées bénéficiant de garantie ou d'assurance publiques</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>30</code>
@@ -66,6 +74,8 @@
                 <narrative>Financing by civil society organisations (NGOs, philantropic foundations, etc.)</narrative>
                 <narrative xml:lang="fr">Financement par les organisations de la société civile (ONG, fondations philantropiques, etc.)</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2015-12-31">
             <code>35</code>
@@ -77,6 +87,8 @@
                 <narrative>Private long-term (i.e. over one-year maturity) capital transactions made by residents of DAC countries</narrative>
                 <narrative xml:lang="fr">Apports privés aux conditions du marché</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>36</code>
@@ -88,6 +100,8 @@
                 <narrative>Private Foreign Direct Investment</narrative>
                 <narrative xml:lang="fr">Investissements directs à l'étranger</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>37</code>
@@ -99,6 +113,8 @@
                 <narrative>Private long-term (i.e. over one-year maturity) capital transactions made by residents of DAC countries</narrative>
                 <narrative xml:lang="fr">Apports privés de long-terme (i.e. dont la maturité est  supérieure à un an), transactions en capital faites par des résidents de pays du CAD</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>40</code>
@@ -110,6 +126,8 @@
                 <narrative>e.g. GNI, ODA%GNI, Population etc</narrative>
                 <narrative xml:lang="fr">ex : RNB, APD%RNB, Population etc</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>50</code>
@@ -121,6 +139,8 @@
                 <narrative>e.g. non-ODA component of peacebuilding operations</narrative>
                 <narrative xml:lang="fr">ex : élément non APD des opérations de maintien de la paix</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>60</code>
@@ -132,6 +152,8 @@
                 <narrative>Private sector instruments</narrative>
                 <narrative xml:lang="fr">Instruments du secteur privé</narrative>
             </description>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/Sector.xml
+++ b/xml/Sector.xml
@@ -1,4 +1,4 @@
-<codelist name="Sector" xml:lang="en" complete="1" category-codelist="SectorCategory" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="Sector" xml:lang="en" complete="1" category-codelist="SectorCategory" embedded="0">
     <metadata>
         <name>
             <narrative>DAC 5 Digit Sector</narrative>
@@ -20,6 +20,8 @@
                 <narrative xml:lang="fr">Politique de l'éducation, planification et programmes ; aide aux ministères de l'éducation, à l'administration et au développement de systèmes de gestion, renforcement des capacités institutionnelles et conseils ; gestion et direction des écoles, développement des programmes d'études et des matériels pédagogiques ; activités d'éducation non spécifiées.</narrative>
             </description>
             <category>111</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11120</code>
@@ -32,6 +34,8 @@
                 <narrative xml:lang="fr">Bâtiments scolaires, équipement, fournitures ; services pour l'éducation (équipement pour les pensionnaires, logement pour le personnel) ; cours de langues ; colloques, séminaires, conférences, etc.</narrative>
             </description>
             <category>111</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11130</code>
@@ -44,6 +48,8 @@
                 <narrative xml:lang="fr">Éducation des enseignants (quand le niveau d'éducation n'est pas spécifié) ; formation et formation continue ; développement des matériels pédagogiques.</narrative>
             </description>
             <category>111</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11182</code>
@@ -56,6 +62,8 @@
                 <narrative xml:lang="fr">Recherche et études sur l'efficacité, la pertinence et la qualité de l'éducation ; évaluation et suivi systématiques.</narrative>
             </description>
             <category>111</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11220</code>
@@ -68,6 +76,8 @@
                 <narrative xml:lang="fr">Enseignement primaire formel et non formel pour les enfants ; enseignement élémentaire général ; fournitures scolaires.</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11230</code>
@@ -80,6 +90,8 @@
                 <narrative xml:lang="fr">Éducation formelle et non formelle pour une meilleure qualité de vie pour les jeunes et les adultes (éducation des adultes) ; alphabétisation et apprentissage du calcul. Exclut l'éducation sanitaire (12261) et les activités relatives à la prévention des maladies non-transmissibles (123xx)</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11231</code>
@@ -92,6 +104,8 @@
                 <narrative xml:lang="fr">Éducation formelle et non formelle pour une meilleure qualité de vie pour les jeunes.</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11232</code>
@@ -104,6 +118,8 @@
                 <narrative xml:lang="fr">Éducation primaire formelle pour adultes.</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11240</code>
@@ -116,6 +132,8 @@
                 <narrative xml:lang="fr">Éducation préscolaire formelle et non formelle.</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>11250</code>
@@ -128,6 +146,8 @@
                 <narrative xml:lang="fr">Fourniture de repas ou de collations à l'école; autres utilisations des aliments pour l'obtention des résultats scolaires, y compris les rations «à emporter» fournies comme incitations économiques aux familles (ou aux familles d'accueil ou autres institutions de garde d'enfants) en contrepartie de la fréquentation scolaire régulière d'un enfant; nourriture fournie aux adultes ou aux jeunes qui participent à des programmes d'alphabétisation ou de formation professionnelle; nourriture pour les activités préscolaires avec une composante éducative. Ces activités peuvent aider à réduire la faim des enfants pendant la journée scolaire si la fourniture d'aliments / repas contient des nutriments biodisponibles pour répondre à des besoins nutritionnels spécifiques et donne les résultats attendus en matière de nutrition chez les enfants scolarisés, ou si la logique de la nutrition ou des résultats attendus est liée à la nutrition.</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2020-01-01">
             <code>11260</code>
@@ -140,6 +160,8 @@
                 <narrative xml:lang="fr">Éducation secondaire généralisée pour le dernier cycle.</narrative>
             </description>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11320</code>
@@ -152,6 +174,8 @@
                 <narrative xml:lang="fr">Enseignement systématique de deuxième cycle aux niveaux supérieurs.</narrative>
             </description>
             <category>113</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2019-12-31">
             <code>11321</code>
@@ -164,6 +188,8 @@
                 <narrative xml:lang="fr">Éducation secondaire généralisée pour le premier cycle.</narrative>
             </description>
             <category>113</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2019-12-31">
             <code>11322</code>
@@ -176,6 +202,8 @@
                 <narrative xml:lang="fr">Éducation secondaire généralisée pour le dernier cycle.</narrative>
             </description>
             <category>113</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11330</code>
@@ -188,6 +216,8 @@
                 <narrative xml:lang="fr">Formation professionnelle élémentaire et enseignement technique au niveau secondaire ; formation sur le tas ; apprentissage.</narrative>
             </description>
             <category>113</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11420</code>
@@ -200,6 +230,8 @@
                 <narrative xml:lang="fr">Diplômes universitaires, de l'enseignement supérieur, de technologie ; bourses d'études.</narrative>
             </description>
             <category>114</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>11430</code>
@@ -212,6 +244,8 @@
                 <narrative xml:lang="fr">Formation professionnelle supérieure et formation sur le tas.</narrative>
             </description>
             <category>114</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12110</code>
@@ -224,6 +258,8 @@
                 <narrative xml:lang="fr">Politique de la santé, planification et programmes ; aide aux ministères de la santé ; administration de la santé publique ; renforcement des capacités institutionnelles et conseils ; programmes d'assurance-maladie ; y compris le renforcement du système de santé et la gouvernance de la santé ; activités de santé non spécifiés.</narrative>
             </description>
             <category>121</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12181</code>
@@ -236,6 +272,8 @@
                 <narrative xml:lang="fr">Enseignement médical et formation pour les services au niveau tertiaire.</narrative>
             </description>
             <category>121</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12182</code>
@@ -248,6 +286,8 @@
                 <narrative xml:lang="fr">Recherche médicale (à l'exclusion de la recherche sur la santé de base et la recherche pour la prévention et le contrôle des MNT (12382)).</narrative>
             </description>
             <category>121</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12191</code>
@@ -260,6 +300,8 @@
                 <narrative xml:lang="fr">Laboratoires, centres de santé et hôpitaux spécialisés (y compris l'équipement et les fournitures) ; ambulances ; services dentaires ; rééducation médicale. Exclut les maladies non-transmissibles (123XX)</narrative>
             </description>
             <category>121</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>12196</code>
@@ -272,6 +314,8 @@
                 <narrative xml:lang="fr">Collecte, production, gestion et diffusion de statistiques et de données relatives à la santé. Comprend les enquêtes sur la santé, la création de bases de données sur la santé, la collecte de données sur les épidémies, etc.</narrative>
             </description>
             <category>121</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12220</code>
@@ -284,6 +328,8 @@
                 <narrative xml:lang="fr">Programmes de soins sanitaires primaires et de base ; programmes de soins paramédicaux et infirmiers ; approvisionnement en médicaments et en vaccins relatifs aux soins et services de santé de base ; activités visant à réaliser la couverture sanitaire universelle.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12230</code>
@@ -296,6 +342,8 @@
                 <narrative xml:lang="fr">Hôpitaux régionaux, centres de santé, dispensaires et équipements médicaux ; à l'exclusion des hôpitaux et centres de santé spécialisés (12191).</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12240</code>
@@ -308,6 +356,8 @@
                 <narrative xml:lang="fr">Identification et supplémentation en carence en micronutriments; Promotion de l'alimentation du nourrisson et du jeune enfant, y compris l'allaitement maternel exclusif; Gestion non urgente de la malnutrition aiguë et d'autres programmes d'alimentation ciblés (y compris l'alimentation complémentaire); Enrichissement des aliments de base, y compris l'iodation du sel; Surveillance de l'état nutritionnel et surveillance nutritionnelle nationale; Recherche, renforcement des capacités, élaboration de politiques, suivi et évaluation à l'appui de ces interventions. Utilisez le code 11250 pour l'alimentation scolaire et le code 43072 pour la sécurité alimentaire des ménages.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12250</code>
@@ -320,6 +370,8 @@
                 <narrative xml:lang="fr">Vaccination ;  prévention et lutte contre les maladies infectieuses parasitaires à l’exception du paludisme (12262), de la tuberculose (12263), de la COVID-19 (12264), du VIH/sida et autres MST (13040). Ceci inclus les diarrhées chroniques, les maladies transmises par un vecteur (par exemple onchocercose, bilharziose), les maladies virales, les mycoses, l’helminthiasis, les zoonoses et les maladies provoquées par d’autres bactéries et virus, pédiculose, etc.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12261</code>
@@ -332,6 +384,8 @@
                 <narrative xml:lang="fr">Information, éducation et formation de la population pour l'amélioration des connaissances et des pratiques liées à la santé ; campagnes pour la santé publique et programmes de sensibilisation ; promotion de meilleures pratiques d'hygiène personnelle, notamment de l'utilisation d'équipements sanitaires et du savonnage des mains.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12262</code>
@@ -344,6 +398,8 @@
                 <narrative xml:lang="fr">Prévention et lutte contre le paludisme.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12263</code>
@@ -356,6 +412,8 @@
                 <narrative xml:lang="fr">Vaccination, prévention et lutte contre la tuberculose.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12264</code>
@@ -368,6 +426,8 @@
                 <narrative xml:lang="fr">Toutes les activités liées à la lutte contre la COVID-19, par ex. information, éducation et communication; essai; la prévention; vaccination, traitement, soins.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>12281</code>
@@ -380,6 +440,8 @@
                 <narrative xml:lang="fr">Formation du personnel de santé pour les services et les soins sanitaires de base.</narrative>
             </description>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>12310</code>
@@ -392,6 +454,8 @@
                 <narrative xml:lang="fr">Programmes de prévention et de lutte contre les MNT qui ne peuvent pas être répartis dans les codes ci-dessous.</narrative>
             </description>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>12320</code>
@@ -404,6 +468,8 @@
                 <narrative xml:lang="fr">Mesures et interventions individuelles / démographiques pour réduire toutes les formes de tabagisme. Comprend des activités liées à la mise en œuvre de la Convention-cadre de l'OMS pour la lutte antitabac, y compris des mesures spécifiques de réduction de la demande à fort impact pour une lutte antitabac efficace.</narrative>
             </description>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>12330</code>
@@ -416,6 +482,8 @@
                 <narrative xml:lang="fr">Prévention et réduction de l'usage nocif de l'alcool et des drogues psychoactives; élaboration, mise en œuvre, suivi et évaluation de stratégies, programmes et interventions de prévention et de traitement; Identification précoce et gestion des problèmes de santé causés par la consommation d'alcool et de drogues [à l'exclusion du contrôle de la circulation des stupéfiants (16063)].</narrative>
             </description>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>12340</code>
@@ -428,6 +496,8 @@
                 <narrative xml:lang="fr">Promotion de programmes et d'interventions favorables à la résilience en santé mentale et au bien-être; prévention, soins et soutien aux personnes suicidaires. Non compris le traitement de la dépendance au tabac, à l'alcool et aux drogues (inclus dans les codes 12320 et 12330).</narrative>
             </description>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>12350</code>
@@ -440,6 +510,8 @@
                 <narrative xml:lang="fr">Mesures individuelles / démographiques visant à réduire l'exposition aux régimes alimentaires malsains et à l'inactivité physique et à renforcer les capacités de prévention, de détection précoce, de traitement et de gestion durable des MNT, notamment: Contrôle des maladies cardiovasculaires: prévention, dépistage et traitement des maladies cardiovasculaires (notamment hypertension, hyperlipidémie,cardiopathies ischémiques, accidents vasculaires cérébraux, cardiopathies rhumatismales, cardiopathies congénitales, insuffisance cardiaque, etc.). Contrôle du diabète: prévention, dépistage, diagnostic, traitement et gestion des complications liées à tous les types de diabète. Exposition à l'inactivité physique: Promotion de l'activité physique par le biais d'un environnement bâti favorable (conception urbaine, transports), de sports, de soins de santé, d'écoles et de programmes communautaires et d'une campagne dans les médias. Exposition à une alimentation malsaine: programmes et interventions qui favorisent une alimentation saine grâce à une consommation réduite de sel, de sucre et de graisses et à une consommation accrue de fruits et de légumes, par exemple. reformulation des aliments, étiquetage des éléments nutritifs, taxes sur les aliments, restriction de la commercialisation des aliments malsains, éducation et conseils en matière de nutrition et interventions en fonction des contextes (écoles, lieux de travail, villages, communautés). Lutte contre le cancer: prévention (y compris vaccination, VPH et VHB), diagnostic précoce (pathologie comprise), dépistage, traitement (radiothérapie, chimiothérapie, chirurgie, etc.) et soins palliatifs pour tous les types de cancer. La mise en œuvre, la maintenance et l'amélioration des registres du cancer sont également incluses. Maladies respiratoires chroniques: prévention, diagnostic précoce et traitement des maladies respiratoires chroniques, y compris l'asthme. Sont exclus: Contrôle de l'usage du tabac (12320), Contrôle de l'usage nocif d'alcool et de drogues (12330), Recherche pour la prévention et le contrôle des MNT (12382).</narrative>
             </description>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>12382</code>
@@ -452,6 +524,8 @@
                 <narrative xml:lang="fr">Recherche visant à améliorer la compréhension des MNT, de leurs facteurs de risque, de leur épidémiologie, de leurs déterminants sociaux et de leur impact économique; recherche translationnelle et de mise en œuvre pour améliorer la mise en œuvre de stratégies rentables de prévention et de contrôle des MNT; surveillance et suivi de la mortalité et de la morbidité liées aux MNT, de l'exposition aux facteurs de risque et de la capacité nationale de prévention et de contrôle des MNT.</narrative>
             </description>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>13010</code>
@@ -464,6 +538,8 @@
                 <narrative xml:lang="fr">Politique en matière de population et de développement ; données sur la migration ; recherche et analyse démographiques ; recherche en santé et fertilité ; activités de population non spécifiées. (Utiliser le code 15190 pour les données sur la migration et les refugiés. Utiliser le code 13096 pour recensement, enregistrement des naissances/décès.)</narrative>
             </description>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>13020</code>
@@ -476,6 +552,8 @@
                 <narrative xml:lang="fr">Santé et fertilité ; soins prénatals et périnatals, y compris l'accouchement ; prévention et traitement de la stérilité ; prévention et suites de l'avortement ; activités pour une maternité sans risque.</narrative>
             </description>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>13030</code>
@@ -488,6 +566,8 @@
                 <narrative xml:lang="fr">Conseils en planification familiale ; activités d'information, d'éducation et de communication (IEC) ; distribution de produits contraceptifs ; accroissement des moyens et aptitudes, formation.</narrative>
             </description>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>13040</code>
@@ -500,6 +580,8 @@
                 <narrative xml:lang="fr">Toutes activités liées au contrôle des maladies sexuellement transmissibles et du VIH/sida ; activités d'information, éducation et communication ; dépistage ; prévention ; traitement, soins.</narrative>
             </description>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>13081</code>
@@ -512,6 +594,8 @@
                 <narrative xml:lang="fr">Éducation et formation du personnel de santé pour les services de population ainsi que les soins en matière de santé et fertilité.</narrative>
             </description>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>13096</code>
@@ -524,6 +608,8 @@
                 <narrative xml:lang="fr">Collecte, production, gestion et diffusion de statistiques et de données relatives à la population et à la santé génésique. Comprend les travaux de recensement, l'état civil, la collecte de données sur la migration, les données démographiques, etc.</narrative>
             </description>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14010</code>
@@ -536,6 +622,8 @@
                 <narrative xml:lang="fr">Politique et gouvernance du secteur de l'eau, y compris législation, réglementation, planification et gestion ainsi que gestion transfrontalière de l'eau; renforcement des capacités institutionnelles ; activités favorisant une approche intégrée de la gestion des ressources en eau (GIRE).</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14015</code>
@@ -548,6 +636,8 @@
                 <narrative xml:lang="fr">Collecte et utilisation de données quantitatives et qualitatives sur les ressources en eau ; création et mise en commun de connaissances sur l'eau ; préservation et remise en état des eaux intérieures de surface (rivières, lacs, etc.), des nappes souterraines et des eaux côtières ; prévention de la contamination des eaux.</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14020</code>
@@ -560,6 +650,8 @@
                 <narrative xml:lang="fr">Programmes dont les composantes relatives aux codes 14021 et 14022 ne peuvent être identifiées séparément. Lorsque les composantes sont connues, elles devraient être individuellement notifiées sous leurs codes respectifs : approvisionnement en eau [14021], assainissement [14022] et hygiène [12261].</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14021</code>
@@ -572,6 +664,8 @@
                 <narrative xml:lang="fr">Usines de traitement d'eau potable ; ouvrages d'adduction ; stockage ; stations de pompage pour l'approvisionnement en eau ; réseaux d'adduction et de distribution à grande échelle.</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14022</code>
@@ -584,6 +678,8 @@
                 <narrative xml:lang="fr">Réseaux d'assainissement à grande échelle y compris égouts et stations de pompage des eaux d'égouts ; usines de traitement des eaux usées domestiques et industrielles.</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14030</code>
@@ -596,6 +692,8 @@
                 <narrative xml:lang="fr">Programmes dont les composantes relatives aux codes 14031 et 14032 ne peuvent être identifiées séparément. Lorsque les composantes sont connues, elles devraient être individuellement notifiées sous leurs codes respectifs : approvisionnement en eau [14031], assainissement [14032] et hygiène [12261].</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14031</code>
@@ -608,6 +706,8 @@
                 <narrative xml:lang="fr">Dispositifs ruraux d'approvisionnement en eau reposant sur des pompes manuelles, des captages de sources, des systèmes par gravité, la collecte des eaux de pluie et de brouillard, des citernes, des systèmes simplifiés de distribution avec points d'eau collectifs/branchements partagés. Dispositifs urbains utilisant des pompes manuelles et mini-réseaux, y compris ceux avec branchements partagés et bornes-fontaines.</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14032</code>
@@ -620,6 +720,8 @@
                 <narrative xml:lang="fr">Latrines, dispositifs d'assainissement autonomes et systèmes alternatifs, y compris la promotion d'investissements de la part des ménages et des communautés locales dans la construction d'équipements de ce type. (Utiliser le code 12261 pour les activités de promotion des règles d'hygiène personnelle.)</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14040</code>
@@ -632,6 +734,8 @@
                 <narrative xml:lang="fr">Projets de bassins fluviaux centrés sur les infrastructures et activités institutionnelles connexes ; régulation des cours d'eau ; barrages et réservoirs [à l'exclusion des barrages hydroélectriques (23220) et barrages pour l'irrigation (31140) et activités liées au transport fluvial (21040)].</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14050</code>
@@ -644,6 +748,8 @@
                 <narrative xml:lang="fr">Au niveau municipal et industriel, y compris les déchets dangereux et toxiques ; enlèvement et traitement ; zones d'enfouissement des déchets ; compost et recyclage.</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>14081</code>
@@ -656,6 +762,8 @@
                 <narrative xml:lang="fr">Activités d'éducation et de formation destinées aux professionnels et fournisseurs de services de ce secteur.</narrative>
             </description>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15110</code>
@@ -668,6 +776,8 @@
                 <narrative xml:lang="fr">Aide au renforcement des institutions visant à consolider les capacités et systèmes principaux de gestion du secteur public. Ceci recouvre la gestion des politiques publiques générales, la coordination, la planification et la réforme ; la gestion des ressources humaines ; le développement organisationnel ; la réforme de la fonction publique ; l'administration électronique ; la planification, le suivi et l'évaluation du développement ;  soutien aux ministères impliqués dans la coordination de l'aide; d'autres ministères et services gouvernementaux lorsque le secteur ne peut pas être spécifié. (Utilisez des codes sectoriels spécifiques pour le développement de systèmes et de capacités dans les ministères sectoriels. Pour la politique macro-économique, utilisez le code 15142. Pour les marchés publics, utilisez le code 15125.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15111</code>
@@ -680,6 +790,8 @@
                 <narrative xml:lang="fr">Politique et planification budgétaires ; soutien aux ministères des finances ; renforcement de la responsabilité financière et administrative ; gestion des dépenses publiques ; amélioration des systèmes de gestion financière ; préparation du budget ; relations budgétaires intergouvernementales, audit public, dette publique. (Utiliser les codes 15114 pour la mobilisation des ressources intérieures et 33120 pour les douanes.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15112</code>
@@ -692,6 +804,8 @@
                 <narrative xml:lang="fr">Processus de décentralisation (y compris aspects politiques, administratifs et budgétaires) ; relations intergouvernementales et fédéralisme ; renforcement des services des administrations régionales et locales, des autorités régionales et locales et de leurs associations nationales. (Utiliser des codes sectoriels spécifiques pour la décentralisation de la gestion et des services sectoriels.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15113</code>
@@ -704,6 +818,8 @@
                 <narrative xml:lang="fr">Organisations, institutions et cadres spécialisés dans la prévention et la lutte contre la corruption active et passive, le blanchiment d'argent et d'autres aspects du crime organisé, dotés ou non de pouvoirs pour faire respecter la loi, comme les commissions chargées de la lutte contre la corruption et les organismes de suivi, les services spéciaux d'enquête, les institutions et les initiatives de contrôle de l'intégrité et de l'éthique, les ONG spécialisées, d'autres organisations de citoyens et de la société civile s'occupant directement de lutter contre la corruption.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15114</code>
@@ -716,6 +832,8 @@
                 <narrative xml:lang="fr">Soutien à la mobilisation des ressources intérieures/politique fiscale, analyse et administration ainsi que les recettes non-fiscales, incluant le travail avec les ministères des finances, les ministères de tutelle, les autorités fiscales ou autres institutions publiques locales, régionales ou nationales (Utiliser le code 16010 pour la sécurité sociale et autres plans sociaux.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15116</code>
@@ -728,6 +846,8 @@
                 <narrative xml:lang="fr">Fonctionnement de l'autorité nationale de recouvrement des impôts.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15117</code>
@@ -740,6 +860,8 @@
                 <narrative xml:lang="fr">Fonctionnement des services de préparation du budget.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15118</code>
@@ -752,6 +874,8 @@
                 <narrative xml:lang="fr">Administration et fonctionnement des services de vérification.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15119</code>
@@ -764,6 +888,8 @@
                 <narrative xml:lang="fr">Gestion de la dette publique et de l'aide étrangère reçue (par le pays partenaire). Pour rapporter des ré-échelonnements de dette, utiliser les codes 600xx.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>15120</code>
@@ -786,6 +912,8 @@
                 <narrative xml:lang="fr">Administration des affaires étrangères et services associés.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15122</code>
@@ -798,6 +926,8 @@
                 <narrative xml:lang="fr">Fonctionnement des missions diplomatiques ou consulaires à l'étranger ou auprès d'organisations internationales.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15123</code>
@@ -810,6 +940,8 @@
                 <narrative xml:lang="fr">Soutien à la gestion de l'aide étrangère offerte par les pays en développement (y compris la cooperation triangulaire et sud-sud).</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15124</code>
@@ -822,6 +954,8 @@
                 <narrative xml:lang="fr">Administration et fonctionnement de services généraux de personnel, y compris les politiques, réglements et procédures.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15125</code>
@@ -834,6 +968,8 @@
                 <narrative xml:lang="fr">Soutien aux marchés publics, notamment pour la création et l'évaluation de cadres juridiques; des conseils pour l'établissement d'une orientation stratégique des politiques et des réformes en matière de marchés publics; conseils en matière de conception de systèmes et de processus de passation des marchés publics; soutien aux organismes de passation des marchés publics (y compris les marchés électroniques) ainsi qu'aux structures ou initiatives d'évaluation des systèmes de passation des marchés publics; et développement des capacités professionnelles des organismes et du personnel des marchés publics.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15126</code>
@@ -846,6 +982,8 @@
                 <narrative xml:lang="fr">Tenue et stockage de dossiers et archives des administrations publiques, exploitation d'immeubles dont des administrations publiques sont propriétaires ou occupants, parcs centraux de véhicules, imprimeries exploitées par des administrations publiques, services centraux de calcul et d'informatique, etc.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15127</code>
@@ -858,6 +996,8 @@
                 <narrative xml:lang="fr">Administration ou fonctionnement des services s'occupant de suivi et d'évaluation au niveau national.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15128</code>
@@ -870,6 +1010,8 @@
                 <narrative xml:lang="fr">Transferts financiers aux gouvernements locaux; soutien aux institutions administrant ces transferts. (Pour des transferts concernant des secteurs particuliers, utiliser les codes sectoriels appropriés.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15129</code>
@@ -882,6 +1024,8 @@
                 <narrative xml:lang="fr">Transferts aux organisations autonomes ou entreprises d'États non inclus dans le financement des gouvernements locaux; soutien aux institutions administrant ces transferts. (Pour des transferts concernant des secteurs particuliers, utiliser les codes sectoriels appropriés.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15130</code>
@@ -894,6 +1038,8 @@
                 <narrative xml:lang="fr">Soutien aux institutions, systèmes et procédures du secteur de la justice, aussi bien officiels que non officiels ; soutien aux ministères de la justice et de l'intérieur ; juges et tribunaux ; services de rédaction des actes juridiques ; associations d'avocats et de juristes ; formation juridique professionnelle ; maintien de l'ordre et de la sécurité publique ; gestion des frontières ; organismes chargés de faire respecter la loi, police, prisons et leur supervision ; médiateurs ; mécanismes alternatifs de règlement des conflits, d'arbitrage et de médiation ; aide et conseil juridiques ; pratiques traditionnelles, indigènes et paralégales ne faisant pas partie du système juridique officiel. Mesures à l'appui de l'amélioration des cadres juridiques, constitutions, lois  et  réglementations ; rédaction et révision de textes législatifs et constitutionnels ; réforme juridique ; intégration des systèmes légaux officiels et non officiels. Éducation juridique ; diffusion d'informations sur les droits et les voies de recours en cas d'injustice ; campagnes de sensibilisation. (Utiliser les codes 152xx pour les activités ayant principalement pour objet de soutenir la réforme des systèmes de sécurité ou entreprises en liaison avec des activités de maintien de la paix à l'issue d'un conflit. Utiliser le code 15190 pour le renforcement des capacités dans le domaine de la surveillance des frontières en relation avec les migrations)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1513010</code>
@@ -906,6 +1052,8 @@
                 <narrative xml:lang="fr">Activities that support law enforcement agencies in the fight against all forms of transnational organised crime, including trafficking in cultural property, money laundering and illicit financial flows; trafficking of wild fauna and flora and forest products; maritime piracy; illegal mining, trafficking in precious metals; crimes related to fishing; illicit trafficking in firearms; human trafficking and migrant smuggling. Activities should be aligned with the United Nations Convention against Transnational Organised Crime (UNTOC). The provision, or training on the use, of lethal equipment is excluded even if related to the above-mentioned crimes. [Use code 16063 for counter-narcotics and code 1513030 for cyber security].</narrative>
             </description>
             <category>151</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1513020</code>
@@ -918,6 +1066,8 @@
                 <narrative xml:lang="fr">Activities aimed at combating terrorism. The activities reported here should be aligned with the United Nations Global Counter-Terrorism Strategy and the 19 international legal instruments to prevent terrorist acts. Examples include the facilitation of the implementation of the relevant legal instruments, combating money laundering and financing of terrorism, capacity-building programmes to strengthen transport security and border management systems, and assistance in developing an effective and rule of law-based criminal justice system. The provision, or training on the use, of lethal equipment is excluded.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1513030</code>
@@ -930,6 +1080,8 @@
                 <narrative xml:lang="fr">Operational policing to protect computer systems from theft or damage covering hardware, software and electronic data.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15131</code>
@@ -942,6 +1094,8 @@
                 <narrative xml:lang="fr">Justice et maintien de l'ordre; développement des politiques dans les ministères de la justice ou leur équivalent.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15132</code>
@@ -954,6 +1108,8 @@
                 <narrative xml:lang="fr">Administration des affaires et services de police.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15133</code>
@@ -966,6 +1122,8 @@
                 <narrative xml:lang="fr">Administration des affaires et services de protection et de lutte contre l'incendie.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15134</code>
@@ -978,6 +1136,8 @@
                 <narrative xml:lang="fr">Administration, fonctionnement ou soutien des tribunaux civils et pénals et du système judiciaire, y compris mise à exécution des amendes et des obligations imposées par les tribunaux, et suivi des programmes de mise en liberté conditionnelle et de mise à l'épreuve.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15135</code>
@@ -990,6 +1150,8 @@
                 <narrative xml:lang="fr">Officier indépendant représentant les intérêts du public en faisant enquête et en remédiant aux plaintes de traitement inéquitable ou de mauvaise gestion.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15136</code>
@@ -1002,6 +1164,8 @@
                 <narrative xml:lang="fr">Administration des affaires et services d'immigration, y compris l'enregistrement des étrangers et la délivrance de documents de travail et de voyage aux immigrants.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15137</code>
@@ -1010,6 +1174,8 @@
                 <narrative xml:lang="fr">Prisons</narrative>
             </name>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>15140</code>
@@ -1032,6 +1198,8 @@
                 <narrative xml:lang="fr">Soutien à la stabilité macroéconomique, à la viabilité de la dette et aux réformes structurelles. Comprend une assistance technique pour la formulation stratégique de politiques, lois et réglementations; renforcement des capacités pour améliorer le développement du secteur public; financement basé sur les politiques. Pour la politique fiscale et la mobilisation des recettes intérieures, utilisez les codes 15111 et 15114.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15143</code>
@@ -1044,6 +1212,8 @@
                 <narrative xml:lang="fr">Administration ou fonctionnement des institutions s'occupant de météorologie.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15144</code>
@@ -1056,6 +1226,8 @@
                 <narrative xml:lang="fr">Administration ou fonctionnement des institutions s'occupant des normes nationales. (Utiliser le code 16062 pour le renforcement des capacités statistiques)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15150</code>
@@ -1068,6 +1240,8 @@
                 <narrative xml:lang="fr">Soutien à l'exercice de la démocratie et à diverses formes de participation des citoyens, excepté les élections (15151) ; instruments de démocratie directe comme les référendums et les initiatives de citoyens ; soutien aux organisations pour représenter et défendre leurs membres, assurer un suivi, participer et demander des comptes aux gouvernements, et pour aider les citoyens à apprendre à agir dans la sphère publique ; programmes d'études et enseignement de l'éducation civique à différents niveaux. (Ce code-objet est limité aux activités ciblées sur des questions de gouvernance. Lorsque l'aide à la société civile ne concerne pas la gouvernance, utiliser d'autres codes-objet appropriés.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15151</code>
@@ -1080,6 +1254,8 @@
                 <narrative xml:lang="fr">Organes et processus de gestion électorale, observation des processus électoraux, éducation civique des électeurs. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d'une opération internationale de maintien de la paix.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15152</code>
@@ -1092,6 +1268,8 @@
                 <narrative xml:lang="fr">Aide au renforcement des fonctions clés des assemblées législatives/parlements, y compris des assemblées et conseils infranationaux (représentation ; surveillance ; législation), par exemple amélioration des capacités des organes législatifs, amélioration du fonctionnement des commissions et des procédures administratives des assemblées législatives ; systèmes de gestion de la recherche et de l'information ; mise en place de programmes de formation à l'intention des législateurs et du personnel de soutien. Aide aux partis politiques et renforcement des systèmes de partis.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15153</code>
@@ -1104,6 +1282,8 @@
                 <narrative xml:lang="fr">Activités qui favorisent une diffusion libre et non censurée de l'information sur les questions publiques ; activités visant à améliorer les compétences rédactionnelles et techniques, et l'intégrité des médias imprimés, audiovisuels et en ligne, par exemple, formation des journalistes. (Utiliser les codes du secteur 220 pour la fourniture d'équipements et d'une aide financière aux médias.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15154</code>
@@ -1116,6 +1296,8 @@
                 <narrative xml:lang="fr">Administration, fonctionnement des organes exécutifs, y compris le cabinet du chef de l'exécutif à tous les niveaux de gouvernement (monarque, gouverneur général, président, premier ministre, gouverneur, maire, etc.).</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15155</code>
@@ -1124,6 +1306,8 @@
                 <narrative xml:lang="fr">Politique et administration fiscales</narrative>
             </name>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15156</code>
@@ -1136,6 +1320,8 @@
                 <narrative xml:lang="fr">Recettes non-fiscales incluant les ministères de tutelle, les autorités fiscales ou autres institutions publiques locales, régionales ou nationales.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15160</code>
@@ -1148,6 +1334,8 @@
                 <narrative xml:lang="fr">Mesures visant à aider les institutions et mécanismes spécialisés dans les droits de la personne opérant aux niveaux mondial, régional, national ou local, dans leur mission officielle de promotion et de protection des droits civils et politiques, économiques, sociaux et culturels tels que définis dans les conventions et pactes internationaux; transposition dans la législation nationale des engagements internationaux concernant les droits de la personne; notification et suivi; dialogue sur les droits de la personne. Défenseurs des droits de la personne et ONG oeuvrant dans ce domaine ; promotion des droits de la personne, défense active, mobilisation ; sensibilisation et éducation des citoyens aux droits de la personne.  Élaboration de programmes concernant les droits de la personne ciblés sur des groupes particuliers comme les enfants, les individus en situation de handicap, les minorités ethniques, religieuses, linguistiques et sexuelles, les populations autochtones et celles qui sont victimes de discrimination fondée sur la caste, les victimes de la traite d'êtres humains, les victimes de la torture. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d'une opération internationale de maintien de la paix et le code 15180 pour les activités visant l'élimination de la violence à l'égard des femmes et des filles. Utiliser le code 15190 pour la programmation des droits de l'homme des réfugiés ou des migrants, y compris lorsqu'ils sont victimes de la traite d'êtres humains. Utiliser le code 16070 pour les activités concernant les Principes fondamentaux et Droits au travail, c'est-à-dire travail des enfants, travail forcé, non-discrimination dans l'emploi et le travail, liberté syndicale et négociation collective.)</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1516010</code>
@@ -1160,6 +1348,8 @@
                 <narrative xml:lang="fr">Support beyond the regular justice system to address large-scale or systematic human rights violations.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1516020</code>
@@ -1172,6 +1362,8 @@
                 <narrative xml:lang="fr">Support to international mechanisms aimed at ensuring accountability for serious crimes such as genocide, crimes against humanity and war crimes as defined in international law.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>15161</code>
@@ -1224,6 +1416,8 @@
                 <narrative xml:lang="fr">Appui aux organisations et mouvements féministes, dirigés par des femmes et de défense des droits des femmes, ainsi qu'aux institutions (gouvernementales et non gouvernementales) à tous les niveaux pour améliorer leur efficacité, leur influence et leur durabilité (activités et financement de base). Ces organisations existent pour apporter un changement transformateur pour l'égalité des sexes et / ou les droits des femmes et des filles dans les pays en développement. Leurs activités comprennent la définition de l'agenda, le plaidoyer, le dialogue politique, le renforcement des capacités, la sensibilisation et la prévention, la prestation de services, la prévention des conflits et la consolidation de la paix, la recherche, l'organisation et la création d'alliances et de réseaux.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2016-01-01">
             <code>15180</code>
@@ -1236,6 +1430,8 @@
                 <narrative xml:lang="fr">Soutien à des programmes visant à prévenir et éliminer toutes les formes de violence à l'égard des femmes et des filles/violence basée sur le genre. Cette définition recouvre des formes diverses de violence physique, sexuelle et psychologique et s'entend comme englobant, sans y être limitée : la violence infligée par un partenaire intime (violence domestique) ; la violence sexuelle ; les mutilations génitales féminines/excision (MGF/E); les mariages d'enfants, précoces et forcés ; les attaques à l'acide ; les crimes d'honneur ; et la traite des femmes et des filles. Les activités de prévention peuvent notamment inclure les efforts visant soutenir l'autonomisation des femmes et des filles ; le changement des attitudes, normes et comportements ; l'adoption et la mise en oeuvre de réformes légales ; et le renforcement de l'application des lois et des politiques visant à mettre fin à la violence à l'égard des femmes et des filles, y compris à travers le renforcement des capacités institutionnelles. Les interventions visant à répondre à la violence à l'égard des femmes et des filles/violence basée sur le genre peuvent notamment inclure l'élargissement de l'accès aux services y compris à l'assistance juridique, l'accompagnement psychologique et les soins médicaux ; la formation du personnel en vue de répondre plus efficacement aux besoins des survivantes ; et les actions visant à garantir l'ouverture d'enquêtes, la poursuite en justice et la condamnation des auteurs de violence.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15185</code>
@@ -1248,6 +1444,8 @@
                 <narrative xml:lang="fr">Processus de décentralisation (y compris aspects politiques, administratifs et budgétaires) ; relations intergouvernementales et fédéralisme ; renforcement des autorités locales.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15190</code>
@@ -1260,6 +1458,8 @@
                 <narrative xml:lang="fr">Aide apportée aux pays en développement dans le but de favoriser des migrations et une mobilité des personnes qui soient ordonnées, sûres, régulières et responsables. Elle recouvre : - le renforcement des capacités concernant la politique, l'analyse, la planification et la gestion dans le domaine des migrations et de la mobilité. Celui-ci comprend le soutien visant à favoriser des migrations sûres et régulières et à remédier aux migrations irrégulières, la coopération avec la diaspora et les programmes destinés à renforcer l'impact des envois de fonds des émigrés sur le développement et/ou l'utilisation de ces fonds pour financer des projets utiles au développement dans les pays en développement ; - les mesures visant à améliorer les systèmes de recrutement de la main-d'œuvre migrante dans les pays en développement ; - le renforcement des capacités en matière d'élaboration de stratégies et de politiques, ainsi que pour le développement des services juridiques et judiciaires (y compris la gestion des frontières) dans les pays en développement. Il comprend le soutien apporté pour la prise en main et la réduction des facteurs de vulnérabilité existant en situation de migration, et pour le renforcement des efforts transnationaux visant à lutter contre le trafic de migrants, ainsi qu'à prévenir et combattre le trafic d'êtres humains ; - le soutien à la mise en place de stratégies efficaces pour garantir la protection internationale et le droit à l'asile ; - le soutien à la mise en place de stratégies efficaces pour assurer aux personnes déplacées l'accès à la justice et à une aide ; - l'aide dispensée aux migrants pour leur permettre de rentrer dans leur pays d'origine en toute sécurité, dans la dignité, en pleine connaissance de cause et de façon volontaire (ne sont couverts que les retours effectués à partir d'un autre pays en développement ; l'aide au titre des retours forcés est exclue de l'APD) ; - l'aide dispensée aux migrants en vue de leur réintégration durable dans leur pays d'origine (utiliser le code 93010 pour l'aide apportée dans les pays donneurs préalablement au départ, dans le contexte de retours volontaires). Les activités visant à servir avant tout les intérêts des fournisseurs sont exclues de l'APD. Les activités visant à remédier aux causes profondes des déplacements forcés et des migrations irrégulières ne doivent pas être classées sous ce code, mais dans le secteur d'intervention correspondant. De plus, il faut utiliser le code 15136 pour le soutien dispensé aux autorités des pays aux fins des questions et des services relatifs à l'immigration (facultatif), le code 24050 pour les dispositifs visant à réduire le coût des envois de fonds des émigrés, le code 72010 pour les aspects humanitaires de l'aide apportée aux réfugiés et aux personnes déplacées à l'intérieur de leur propre pays, comme la fourniture de services d'urgence et la protection humanitaire. Le code 93010 doit être employé lorsque les dépenses sont destinées à l'entretien temporaire des réfugiés dans le pays donneur, notamment dans le cas de leur retour volontaire et de leur réintégration lorsque ce soutien est fourni dans le pays donneur en liaison avec le retour à partir de ce pays (aide préalable au départ) ou de leur réinstallation volontaire dans un pays développé tiers.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>15196</code>
@@ -1272,6 +1472,8 @@
                 <narrative xml:lang="fr">Collecte, production, gestion et diffusion de statistiques et de données relatives au gouvernement et à la société civile. Comprend les statistiques macroéconomiques, les finances publiques, les statistiques fiscales et du secteur public, le soutien au développement de l'infrastructure de données administratives, les enquêtes de la société civile.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1520010</code>
@@ -1284,6 +1486,8 @@
                 <narrative xml:lang="fr">Activities intended at supporting disarmament and non-proliferation of biological, chemical and nuclear weapons.</narrative>
             </description>
             <category>152</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>1520020</code>
@@ -1296,6 +1500,8 @@
                 <narrative xml:lang="fr">Actions intended at addressing the drivers of violent extremism such as those outlined in the United Nations Secretary General Plan of Action to Prevent Violent Extremism: dialogue and conflict prevention; strengthening good governance, human rights and the rule of law; engaging communities; empowering youth; gender equality and empowering women; education, skills development and employment facilitation; strategic communications, the Internet and social media.</narrative>
             </description>
             <category>152</category>
+            <extras:crs>0</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15210</code>
@@ -1308,6 +1514,8 @@
                 <narrative xml:lang="fr">Coopération technique en faveur des parlements, des ministères publics, des services chargés de faire respecter la loi et des instances judiciaires pour aider à examiner et à réformer les systèmes de sécurité afin d'améliorer la gouvernance démocratique et le contrôle par les civils ; coopération technique en faveur des gouvernements à l'appui du renforcement de la supervision civile et du contrôle démocratique sur la budgétisation, la gestion, la transparence et l'audit des dépenses de sécurité, y compris les dépenses militaires, dans le cadre d'un programme d'amélioration de la gestion des dépenses publiques ; assistance apportée à la société civile en vue de renforcer ses compétences en matière de sécurité et sa capacité de veiller à ce que le système de sécurité soit géré conformément aux normes démocratiques et aux principes de responsabilité, de transparence et de bonne gouvernance. [Autre que dans le cadre d'une opération internationale de maintien de la paix (15230)].</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15220</code>
@@ -1320,6 +1528,8 @@
                 <narrative xml:lang="fr">Aide à des activités civiles de construction de la paix, et de prévention et de règlement des conflits, y compris renforcement des capacités, suivi, dialogue et échange d'informations. Participation bilatérale à des missions civiles internationales en faveur de la paix comme celles qui sont conduites par le Département des affaires politiques des Nations unies (UNDPA) ou l'Union européenne (Politique européenne de sécurité et de défense), et contributions à des fonds ou commissions civils pour la paix (par exemple, Commission de consolidation de la paix, guichet thématique "Construction de la paix" du Fonds pour la réalisation des OMD, etc.). Les contributions peuvent être apportées sous la forme d'un financement ou à travers la fourniture de matériel ou de personnel civil ou militaire (par exemple, pour la formation des civils). (Utiliser le code [15230] pour la participation bilatérale à des opérations internationales de maintien de la paix.)</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15230</code>
@@ -1332,6 +1542,8 @@
                 <narrative xml:lang="fr">Participation bilatérale à des opérations de maintien de la paix mandatées ou autorisées par les Nations unies (NU) à travers des résolutions du Conseil de sécurité, et conduites par des organisations internationales, par exemple les Nations unies, l'OTAN, l'Union européenne (opérations liées à la sécurité dans le cadre de la Politique européenne de sécurité et de défense) ou des groupements régionaux de pays en développement. Les contributions directes au budget du Département des opérations de maintien de la paix des NU (UNDPKO) ne sont pas à notifier comme opérations bilatérales (elles comptent en partie comme APD multilatérale, voir l'annexe 9). Les activités qui peuvent être notifiées au titre de l'APD bilatérale sous ce code sont uniquement les suivantes : droits de l'homme et supervision des élections ; réinsertion des soldats démobilisés ; remise en état des infrastructures de base du pays ; supervision ou recyclage des administrateurs civils et des forces de police ; réforme des systèmes de sécurité et autres activités liées à l'État de droit ; formation aux procédures douanières et de contrôle aux frontières ; conseil ou formation concernant les politiques budgétaires ou macroéconomiques de stabilisation ; rapatriement et démobilisation des factions armées et destruction de leurs armes ; déminage. Les activités d'imposition de la paix entreprises dans le cadre des opérations internationales de maintien de la paix ne sont comptabilisables dans l'APD. Les contributions bilatérales comptabilisables dans l'APD au titre des opérations de maintien de la paix peuvent être apportées sous la forme d'un financement ou à travers la fourniture de matériel ou de personnel militaire ou civil (par exemple, fonctionnaires de police). Le coût à notifier est donné par le surcoût encouru pour l'entretien du personnel et du matériel du fait qu'ils ont pris part à une opération de maintien de la paix. Les coûts relatifs aux contingents militaires participant à des opérations de maintien de la paix de l'UNDPKO ne sont pas comptabilisables en APD. Les opérations internationales de maintien de la paix peuvent comprendre des activités de type humanitaire (contributions apportées sous la forme de matériel ou de personnel), comme celles qui sont décrites sous les codes 7xxxx. Elles doivent être incluses sous le code 15230 si elles font partie intégrante des activités ci-dessus, sinon elles doivent être notifiées sous l'aide humanitaire. NB : Lors de l'utilisation de ce code, indiquer le nom de l'opération dans la description succincte de l'activité notifiée.</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15240</code>
@@ -1344,6 +1556,8 @@
                 <narrative xml:lang="fr">Réinsertion du personnel militaire démobilisé dans la vie économique et civile ; conversion des usines d'armes en usines de produits à usage civil ; coopération technique destinée à contrôler, prévenir et/ou réduire la prolifération d'armes légères et de petit calibre – voir le paragraphe 120 des Directives pour la définition des activités couvertes. [Autre que dans le cadre d'une opération internationale de maintien de la paix (15230) ou enfants soldats (15261)].</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15250</code>
@@ -1356,6 +1570,8 @@
                 <narrative xml:lang="fr">Toutes les activités liées aux mines terrestres et aux restes explosifs de guerre dont le but essentiel est de bénéficier aux pays en développement, y compris l'enlèvement des mines terrestres et des restes explosifs de guerre et la destruction des stocks à des fins de développement [autre qu'en rapport avec la participation à des opérations internationales de maintien de la paix (15230)] ; sensibilisation au risque ; réhabilitation, réinsertion et assistance aux victimes, et les activités de recherche et développement sur le déminage. Seules les activités menées à fins civiles sont éligibles à l'APD.</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>15261</code>
@@ -1368,6 +1584,8 @@
                 <narrative xml:lang="fr">Coopération technique en faveur des gouvernements – et assistance aux organisations de la société civile – à l'appui de l'adoption et de l'application de lois destinées à empêcher le recrutement d'enfants en tant que soldats ; appui à la démobilisation, au désarmement, à la réinsertion, au rapatriement et à la réintégration (DDR) des enfants soldats.</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16010</code>
@@ -1380,6 +1598,8 @@
                 <narrative xml:lang="fr">Stratégies de protection sociale ou de sécurité sociale, législation et administration; renforcement des capacités institutionnelles et conseils; sécurité sociale et autres régimes sociaux; programmes de soutien, prestations en espèces, pensions et programmes spéciaux pour les personnes âgées, les orphelins, les personnes handicapées, les enfants, les mères de nouveau-nés, les personnes vivant dans la pauvreté, sans emploi et autres groupes vulnérables; dimensions sociales de l'ajustement structurel.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16011</code>
@@ -1392,6 +1612,8 @@
                 <narrative xml:lang="fr">Administration des politiques, plans, programmes et budgets généraux de protection sociale y compris les lois, normes et statistiques sur la protection sociale.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16012</code>
@@ -1404,6 +1626,8 @@
                 <narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces ou en nature aux personnes inaptes au travail pour cause de maladie ou par suite d'un accident.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16013</code>
@@ -1416,6 +1640,8 @@
                 <narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces et en nature contre les risques liés à la vieillesse.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16014</code>
@@ -1428,6 +1654,8 @@
                 <narrative xml:lang="fr">Les régimes de pension des fonctionnaires.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16015</code>
@@ -1440,6 +1668,8 @@
                 <narrative xml:lang="fr">Protection sociale sous forme de prestations en espèces et en nature aux ménages ayant des enfants à charge, y compris les prestations de congé parental.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16020</code>
@@ -1452,6 +1682,8 @@
                 <narrative xml:lang="fr">Politique et planification de l'emploi; renforcement des capacités institutionnelles et conseils; programmes de création d'emplois et de revenus; y compris des activités spécialement conçues pour répondre aux besoins des groupes vulnérables.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16030</code>
@@ -1464,6 +1696,8 @@
                 <narrative xml:lang="fr">Politique du logement, planification et programmes ; à l'exclusion du logement à coût réduit (16040).</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16040</code>
@@ -1476,6 +1710,8 @@
                 <narrative xml:lang="fr">Y compris la suppression des bidonvilles.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16050</code>
@@ -1488,6 +1724,8 @@
                 <narrative xml:lang="fr">Les services sociaux de base incluent l'éducation de base, la santé de base, les activités en matière de population/santé et fertilité ainsi que les systèmes de distribution d'eau potable de base et assainissement de base.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16061</code>
@@ -1500,6 +1738,8 @@
                 <narrative xml:lang="fr">Programmes sociaux et culturels orientés vers le développement : - Programmes de renforcement du secteur culturel (cinéma, musique, danse, peinture, littérature, etc.) des pays en développement ; mesures visant à promouvoir ou à protéger la diversité des expressions culturelles. Cela comprend le soutien aux industries culturelles, à la construction et à la réparation des installations ; le renforcement des capacités des artistes et autres personnes travaillant dans le secteur culturel ; activités visant à soutenir la production ou la diffusion d’œuvres artistiques de ressortissants de pays en développement (par exemple événements artistiques ou musicaux). - Préservation du patrimoine culturel matériel (objets, monuments, sites, musées) et immatériel (arts, pratiques sociales, connaissances et compétences, valeurs partagées, traditions, performances) qui a une diversité de valeurs, notamment symboliques, historiques, artistiques, esthétiques, ethnologiques ou une signification anthropologique, scientifique et sociale. - Autres programmes sociaux et culturels axés sur le développement qui contribuent à promouvoir l'inclusion et l'autonomisation des ressortissants des pays en développement. Cela comprend la fourniture de matériel (par exemple livres, équipements sportifs), de services éducatifs (par exemple cours de langue), d'installations et d'équipements de loisirs, ainsi que l'organisation de tournois et d'événements sportifs ayant lieu dans les pays en développement avec la participation de leurs ressortissants. Utilisez le code 99820 – promotion de la sensibilisation au développement pour les activités dans le domaine de la culture dans le pays donateur qui sont conçues pour accroître le soutien du public et la sensibilisation aux efforts de coopération au développement dans le pays donateur.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16062</code>
@@ -1512,6 +1752,8 @@
                 <narrative xml:lang="fr">Toutes les activités statistiques, telles que la collecte, le traitement, la diffusion et l'analyse des données; appui au développement et à la gestion des statistiques officielles, y compris les statistiques démographiques, sociales, économiques, environnementales et multisectorielles; cadres de qualité des statistiques; développement des ressources humaines et technologiques pour la statistique, investissements dans l'innovation des données. Les activités liées aux données et aux statistiques dans les secteurs 120, 130 ou 150 devraient de préférence être codées sous les codes volontaire 12196, 13096 et 15196. Les activités ayant pour seul objectif de surveiller les activités de coopération au développement, y compris si elles sont menées par des tiers, devraient être codé sous 91010 (Frais administratifs).</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16063</code>
@@ -1524,6 +1766,8 @@
                 <narrative xml:lang="fr">Contrôles intérieurs et contrôles douaniers y compris la formation de la police, programmes d'éducation et de sensibilisation pour limiter le trafic de drogues et la distribution domestique. La comptabilisation dans l'APD des dépenses liées à la lutte contre le trafic de drogues est limitée aux activités qui se focalisent sur le développement économique et l'amélioration du niveau de vie, y compris les programmes de développement alternatifs et la substitution des plantations. Les activités financées par les donneurs pour interdire les provisions de drogues, détruire les plantations ou former ou financer le personnel militaire dans les activités de lutte contre la drogue ne sont pas comptabilisées dans l'APD.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16064</code>
@@ -1536,6 +1780,8 @@
                 <narrative xml:lang="fr">Programmes spéciaux visant les conséquences sociales du VIH/sida, par exemple assistance sociale, juridique et économique aux personnes vivant avec le VIH/sida y compris sécurité alimentaire et emploi ; soutien aux groupes vulnérables et aux enfants orphelins du sida ; droits de l'homme pour les personnes atteintes par le VIH/sida.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16065</code>
@@ -1548,6 +1794,8 @@
                 <narrative xml:lang="fr">Programmes sociaux et culturels axés sur le développement qui contribuent à promouvoir l’inclusion et l’autonomisation des ressortissants des pays en développement. Cela comprend la fourniture de matériel (par exemple livres, équipements sportifs), de services éducatifs (par exemple cours de langue), d'installations et d'équipements de loisirs, ainsi que l'organisation de tournois et d'événements sportifs ayant lieu dans les pays en développement avec la participation de leurs ressortissants.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16066</code>
@@ -1560,6 +1808,8 @@
                 <narrative xml:lang="fr">Programmes de renforcement du secteur culturel (cinéma, musique, danse, peinture, littérature, etc.) des pays en développement ; mesures visant à promouvoir ou à protéger la diversité des expressions culturelles. Cela comprend le soutien aux industries culturelles, à la construction et à la réparation des installations ; le renforcement des capacités des artistes et autres personnes travaillant dans le secteur culturel ; activités visant à soutenir la production ou la diffusion d’œuvres artistiques de ressortissants de pays en développement (par exemple événements artistiques ou musicaux). Préservation du patrimoine culturel matériel (objets, monuments, sites, musées) et immatériel (arts, pratiques sociales, connaissances et compétences, valeurs partagées, traditions, performances) qui a une diversité de valeurs, notamment symboliques, historiques, artistiques, esthétiques, ethnologiques ou une signification anthropologique, scientifique et sociale. Utilisez le code 99820 – promotion de la sensibilisation au développement pour les activités dans le domaine de la culture dans le pays donateur qui sont conçues pour accroître le soutien du public et la sensibilisation aux efforts de coopération au développement dans le pays donateur.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>16070</code>
@@ -1572,6 +1822,8 @@
                 <narrative xml:lang="fr">Plaidoyer en faveur des normes internationales du travail, du droit du travail, des principes et droits fondamentaux au travail (travail des enfants, travail forcé, non-discrimination sur le lieu de travail, liberté syndicale et négociation collective); formalisation du travail informel, de la sécurité et de la santé au travail.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>16080</code>
@@ -1584,6 +1836,8 @@
                 <narrative xml:lang="fr">Renforcement des capacités et conseils en faveur du dialogue social; soutien aux institutions, organes et mécanismes de dialogue social; renforcement des capacités des organisations de travailleurs et d'employeurs.</narrative>
             </description>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21010</code>
@@ -1596,6 +1850,8 @@
                 <narrative xml:lang="fr">Politique des transports, planification et programmes ; aide aux ministères du transport ; renforcement des capacités institutionnelles et conseils ; transports non spécifiés ; activités qui recouvrent le transport routier, le transport ferroviaire, le transport par voies d'eau et/ou le transport aérien. Inclut la prévention des accidents de la route. Autant que possible, notifier le transport de marchandises sous le secteur économique de la marchandise transportée.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21011</code>
@@ -1608,6 +1864,8 @@
                 <narrative xml:lang="fr">Administration et fonctionnement des services reliés aux politiques de transport.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21012</code>
@@ -1620,6 +1878,8 @@
                 <narrative xml:lang="fr">Administration des affaires et services concernant les transports en commun.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21013</code>
@@ -1632,6 +1892,8 @@
                 <narrative xml:lang="fr">Contrôle et réglementation des utilisateurs de systèmes de transport (immatriculation, permis, inspection du matériel, compétences et formation des agents, normes de sûreté, licences, tarifs, niveau des services, etc.).</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21020</code>
@@ -1644,6 +1906,8 @@
                 <narrative xml:lang="fr">Infrastructure routière, véhicules ; transport routier de voyageurs, voitures particulières.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21021</code>
@@ -1656,6 +1920,8 @@
                 <narrative xml:lang="fr">Construction ou exploitation des voies de desserte et systèmes afférents.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21022</code>
@@ -1668,6 +1934,8 @@
                 <narrative xml:lang="fr">Entretien des voies de desserte et systèmes afférents.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21023</code>
@@ -1680,6 +1948,8 @@
                 <narrative xml:lang="fr">Construction ou exploitation des routes nationales et systèmes afférents.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21024</code>
@@ -1692,6 +1962,8 @@
                 <narrative xml:lang="fr">Entretien des routes nationales et systèmes afférents.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21030</code>
@@ -1704,6 +1976,8 @@
                 <narrative xml:lang="fr">Infrastructure ferroviaire, matériel ferroviaire, locomotives, autre matériel roulant ; y compris les tramways et les métropolitains.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21040</code>
@@ -1716,6 +1990,8 @@
                 <narrative xml:lang="fr">Ports et docks, systèmes de guidage, navires et bateaux ; transport sur voies navigables intérieures, bateaux de voies d'eau intérieures.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21050</code>
@@ -1728,6 +2004,8 @@
                 <narrative xml:lang="fr">Aéroports, systèmes de guidage, avions, équipement d'entretien des avions.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21061</code>
@@ -1740,6 +2018,8 @@
                 <narrative xml:lang="fr">Associé ou non au transport. Autant que possible, notifier les projets de stockage sous le secteur économique de la ressource stockée.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>21081</code>
@@ -1748,6 +2028,8 @@
                 <narrative xml:lang="fr">Education/formation dans les transports et le stockage</narrative>
             </name>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22010</code>
@@ -1760,6 +2042,8 @@
                 <narrative xml:lang="fr">Politique des communications, planification et programmes ; renforcement des capacités institutionnelles et conseils ; y compris développement des services postaux ; activités de communications non spécifiées.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22011</code>
@@ -1768,6 +2052,8 @@
                 <narrative xml:lang="fr">Politiques, planification et administration des communications</narrative>
             </name>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22012</code>
@@ -1780,6 +2066,8 @@
                 <narrative xml:lang="fr">Développement et fonctionnement des services postaux.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22013</code>
@@ -1792,6 +2080,8 @@
                 <narrative xml:lang="fr">Prestation de services d'information.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22020</code>
@@ -1804,6 +2094,8 @@
                 <narrative xml:lang="fr">Réseaux de téléphones, satellites, stations terrestres.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22030</code>
@@ -1816,6 +2108,8 @@
                 <narrative xml:lang="fr">Liaisons, équipements et infrastructures de radio et de télévision ; journaux; impression et édition. La création d'informations (dans tous les médias) est enregistrée sous le code 15153.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>22040</code>
@@ -1828,6 +2122,8 @@
                 <narrative xml:lang="fr">Matériel informatique et logiciels ; accès Internet. Lorsque le secteur ne peut pas être spécifié.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2023-01-01">
             <code>22081</code>
@@ -1840,6 +2136,8 @@
                 <narrative xml:lang="fr">Appui à la formation technique dans les secteurs des TIC, des télécommunications et des médias ; Formation informatique lorsque le secteur ne peut être précisé. La formation à la création de contenu (par exemple journalisme, partage de connaissances) est déclarée sous le code 15153.</narrative>
             </description>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23010</code>
@@ -1852,6 +2150,8 @@
                 <narrative xml:lang="fr">Politique de l'énergie, planification et programmes ; aide aux ministères de l'énergie ; renforcement des capacités institutionnelles et conseils ; activités non spécifiées dans le domaine de l'énergie y compris les économies d'énergie.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23020</code>
@@ -1864,6 +2164,8 @@
                 <narrative xml:lang="fr">Centrales thermiques (lorsque la source de chaleur ne peut être déterminée) ; centrales alimentées au gaz et au charbon.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23030</code>
@@ -1876,6 +2178,8 @@
                 <narrative xml:lang="fr">Y compris politique et planification, programmes de développement, études et primes. Production de bois de chauffage et de charbon de bois devrait être incluse dans sylviculture (31261).</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23040</code>
@@ -1888,6 +2192,8 @@
                 <narrative xml:lang="fr">Distribution de la source d'énergie au consommateur ; lignes de transmission.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23050</code>
@@ -1900,6 +2206,8 @@
                 <narrative xml:lang="fr">Distribution au consommateur.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23061</code>
@@ -1912,6 +2220,8 @@
                 <narrative xml:lang="fr">Y compris les centrales alimentées au gas-oil.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23062</code>
@@ -1920,6 +2230,8 @@
                 <narrative xml:lang="fr">Centrales alimentées au gaz</narrative>
             </name>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23063</code>
@@ -1928,6 +2240,8 @@
                 <narrative xml:lang="fr">Centrales alimentées au charbon</narrative>
             </name>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23064</code>
@@ -1940,6 +2254,8 @@
                 <narrative xml:lang="fr">Y compris la sécurité nucléaire.L'aide visant à favoriser une utilisation pacifique de l'énergie nucléaire est comptabilisable dans l'APD. À titre d'exemples, on citera : la construction ou le déclassement de centrales nucléaires à des fins civiles, le développement ou la fourniture d'isotopes médicaux, l'irradiation des aliments et d'autres applications industrielles et commerciales. Sont par contre exclues les activités de recherche sur les armes nucléaires et les applications militaires de l</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23065</code>
@@ -1952,6 +2268,8 @@
                 <narrative xml:lang="fr">Y compris les installations sur les barges.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23066</code>
@@ -1960,6 +2278,8 @@
                 <narrative xml:lang="fr">Energie géothermique</narrative>
             </name>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23067</code>
@@ -1972,6 +2292,8 @@
                 <narrative xml:lang="fr">Y compris les cellules photovoltaïques et les pompes à énergie solaire.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23068</code>
@@ -1984,6 +2306,8 @@
                 <narrative xml:lang="fr">Énergie éolienne pour l'hydrodynamique et la production d'électricité.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23069</code>
@@ -1996,6 +2320,8 @@
                 <narrative xml:lang="fr">Y compris la conversion de l'énergie thermique marine, la puissance des marées et des vagues.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23070</code>
@@ -2008,6 +2334,8 @@
                 <narrative xml:lang="fr">Technologies de densification et utilisation de la biomasse pour la production d'énergie directe, y compris le gaz obtenu par fermentation de la canne à sucre et d'autres résidus végétaux, et par anaérobie.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23081</code>
@@ -2020,6 +2348,8 @@
                 <narrative xml:lang="fr">Se rapporte à tous les sous-secteurs de l'énergie et à tous les niveaux de formation.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23082</code>
@@ -2032,6 +2362,8 @@
                 <narrative xml:lang="fr">Y compris inventaires et études.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23110</code>
@@ -2044,6 +2376,8 @@
                 <narrative xml:lang="fr">Politique et planification du secteur de l'énergie ; aide aux ministères de l'énergie et autres institutions gouvernementales et non-gouvernementales pour les activités liées à l'ODD7 ; conseil et renforcement des capacités institutionnelles ; tarifs, construction du marché ; activités non précisées ou ne pouvant pas recevoir de code spécifique.</narrative>
             </description>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23111</code>
@@ -2052,6 +2386,8 @@
                 <narrative xml:lang="fr">Politiques, planification et administration du secteur de l'énergie</narrative>
             </name>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23112</code>
@@ -2064,6 +2400,8 @@
                 <narrative xml:lang="fr">Réglementation du secteur de l'énergie, y compris l'approvisionnement d'électricité en gros et au détail.</narrative>
             </description>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23181</code>
@@ -2076,6 +2414,8 @@
                 <narrative xml:lang="fr">Tous les niveaux de formation ne figurant pas sous un autre code.</narrative>
             </description>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23182</code>
@@ -2088,6 +2428,8 @@
                 <narrative xml:lang="fr">Y compris inventaires et études.</narrative>
             </description>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23183</code>
@@ -2100,6 +2442,8 @@
                 <narrative xml:lang="fr">Soutien à la réduction de la demande énergétique, par exemple : modernisation des bâtiments et des industries, réseaux intelligents, compteurs et tarifs. Pour l'usage des cuisinières efficaces utiliser le code 32174</narrative>
             </description>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23210</code>
@@ -2112,6 +2456,8 @@
                 <narrative xml:lang="fr">Programmes de production d'énergie d'origine renouvelable qui ne peuvent être attribués à une seule technologie (codes 23220 à 23280 ci-après). La production de bois de chauffage/charbon de bois devrait figurer sous la rubrique sylviculture 31261.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23220</code>
@@ -2124,6 +2470,8 @@
                 <narrative xml:lang="fr">Dont centrales flottantes.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23230</code>
@@ -2136,6 +2484,8 @@
                 <narrative xml:lang="fr">Comprend les panneaux photovoltaïques, les systèmes d'énergie solaire à concentration connectés au réseau principal ainsi que les solutions décentralisées équipées de compteurs à mesure nette.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>23231</code>
@@ -2148,6 +2498,8 @@
                 <narrative xml:lang="fr">Production électrique solaire pour réseau isolé et systèmes autonomes, systèmes solaires individuels (y compris câblage intégré et appareils liés), distribution et commercialisation de lampes solaires. Ce code traite exclusivement de production d'énergie.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>23232</code>
@@ -2160,6 +2512,8 @@
                 <narrative xml:lang="fr">Solutions solaires pour espaces intérieurs et chauffage de l'eau (sauf fours solaires 32174)</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23240</code>
@@ -2172,6 +2526,8 @@
                 <narrative xml:lang="fr">Éoliennes de pompage et production d'électricité.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23250</code>
@@ -2184,6 +2540,8 @@
                 <narrative xml:lang="fr">Énergie thermique des mers, énergie marémotrice et houlomotrice.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23260</code>
@@ -2196,6 +2554,8 @@
                 <narrative xml:lang="fr">Application de l'énergie géothermique pour produire de l'électricité ou production de chaleur à usage agricole, etc.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23270</code>
@@ -2208,6 +2568,8 @@
                 <narrative xml:lang="fr">Utilisation de matières solides et liquides issues de la biomasse pour la production directe d'électricité. Comprend également les biogaz produits par fermentation anaérobie (ex. : gaz de décharge, gaz issus des boues d'épuration, fermentation de végétaux des cultures énergétiques et de déjections animales) et par traitements thermiques (également connus sous l'appellation de gaz de synthèse) ; centrales brûlant des déchets municipaux biodégradables (déchets ménagers et déchets du tertiaire assimilables à des déchets ménagers, collectés dans des installations spécifiquement conçues pour leur élimination et leur récupération sous forme de liquides ou de gaz combustibles ou de chaleur). Voir code 23360 pour la production d'électricité, déchets non renouvelables.</narrative>
             </description>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23310</code>
@@ -2220,6 +2582,8 @@
                 <narrative xml:lang="fr">Centrales thermiques dont la source d'énergie est indéterminée ; centrales mixtes gaz-charbon.</narrative>
             </description>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23320</code>
@@ -2232,6 +2596,8 @@
                 <narrative xml:lang="fr">Centrales thermiques brûlant du charbon.</narrative>
             </description>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23330</code>
@@ -2244,6 +2610,8 @@
                 <narrative xml:lang="fr">Centrales thermiques brûlant du fioul ou du gazole.</narrative>
             </description>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23340</code>
@@ -2256,6 +2624,8 @@
                 <narrative xml:lang="fr">Centrales thermiques fonctionnant au gaz naturel. Infrastructures d'alimention (terminaux GNL, gazéifieurs, gazoducs d'alimentation de la centrale)</narrative>
             </description>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23350</code>
@@ -2268,6 +2638,8 @@
                 <narrative xml:lang="fr">Centrales thermiques classiques exploitant une technologie de captage et de stockage des émissions de carbone (CSC). Les techniques de CSC non associées à la production d'électricité devraient figurer sous la rubrique 41020. Les activités de CSC ne sont pas éligibles à l'APD.</narrative>
             </description>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23360</code>
@@ -2280,6 +2652,8 @@
                 <narrative xml:lang="fr">Centrales brûlant des déchets industriels et municipaux non biodégradables.</narrative>
             </description>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23410</code>
@@ -2292,6 +2666,8 @@
                 <narrative xml:lang="fr">Centrales fonctionnant avec des énergies renouvelables et non renouvelables.</narrative>
             </description>
             <category>234</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23510</code>
@@ -2304,6 +2680,8 @@
                 <narrative xml:lang="fr">Dont sûreté nucléaire. Voir la note sur l'éligibilité à l'APD de l'énergie nucléaire</narrative>
             </description>
             <category>235</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23610</code>
@@ -2316,6 +2694,8 @@
                 <narrative xml:lang="fr">Installations produisant uniquement de la chaleur.</narrative>
             </description>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23620</code>
@@ -2328,6 +2708,8 @@
                 <narrative xml:lang="fr">Distribution de chaleur produite dans une chaufferie unique, ou d'eau froide, à des fins de climatisation des locaux dans les secteurs résidentiel et tertiaire.</narrative>
             </description>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23630</code>
@@ -2340,6 +2722,8 @@
                 <narrative xml:lang="fr">Réseau de distribution d'électricité de la source d'énergie au consommateur final ; lignes de transport. Inclut également le stockage de l'énergie à des fins de production d'électricité (ex. : station de pompage, batteries) et l'extension de l'accès au réseau, souvent dans des zones rurales.</narrative>
             </description>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>23631</code>
@@ -2352,6 +2736,8 @@
                 <narrative xml:lang="fr">Comprend les réseaux villageois et autres technologies de distribution d'électricité à destination des consommateurs finals non connectés au  réseau national principal. Inclut également le stockage d'électricité. Ce code traite exclusivement de l'infrastructure du réseau indépendamment de la technologie de production.</narrative>
             </description>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>23640</code>
@@ -2364,6 +2750,8 @@
                 <narrative xml:lang="fr">Comprend l'infrastructure urbaine de livraison de gaz de ville et la production, distribution et recharge de bouteilles de GPL. Exclut l'acheminement de gaz à des fins de production électrique (23340) et les gazoducs (32262)</narrative>
             </description>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>23641</code>
@@ -2372,6 +2760,8 @@
                 <narrative xml:lang="fr">Distribution au détail de carburants fossiles liquide ou solides</narrative>
             </name>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>23642</code>
@@ -2384,6 +2774,8 @@
                 <narrative xml:lang="fr">Inclut les stations de recharge électrique ou à hydrogène pour les transports publics ou privés et infrastructures connexes (sauf transport ferrovaire 21030)</narrative>
             </description>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>24010</code>
@@ -2396,6 +2788,8 @@
                 <narrative xml:lang="fr">Politique des finances, planification et  programmes ; renforcement des capacités institutionnelles et conseils ; marchés et systèmes financiers.</narrative>
             </description>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>24020</code>
@@ -2408,6 +2802,8 @@
                 <narrative xml:lang="fr">Banques centrales.</narrative>
             </description>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>24030</code>
@@ -2420,6 +2816,8 @@
                 <narrative xml:lang="fr">Tous les intermédiaires financiers dans le secteur formel ; lignes de crédit ; assurance, crédit-bail, capital-risque, etc. (sauf ceux spécialisés dans un seul secteur).</narrative>
             </description>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>24040</code>
@@ -2432,6 +2830,8 @@
                 <narrative xml:lang="fr">Micro crédits, coopératives d'épargne et de crédit, etc.</narrative>
             </description>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2017-01-01">
             <code>24050</code>
@@ -2444,6 +2844,8 @@
                 <narrative xml:lang="fr">Comprend les programmes visant à réduire les coûts des transferts de fonds des migrants.</narrative>
             </description>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>24081</code>
@@ -2452,6 +2854,8 @@
                 <narrative xml:lang="fr">Education/formation bancaire et dans les services financiers</narrative>
             </name>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>25010</code>
@@ -2464,6 +2868,8 @@
                 <narrative xml:lang="fr">Politiques du secteur public et soutien des institutions à l'environnement des entreprises et au climat de l'investissement, y compris la réglementation des entreprises, les droits de propriété, la non-discrimination, la promotion de l'investissement, la politique de la concurrence, le droit des entreprises, les partenariats public-privé.</narrative>
             </description>
             <category>250</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>25020</code>
@@ -2476,6 +2882,8 @@
                 <narrative xml:lang="fr">Lorsque le secteur ne peut être spécifié. Y compris programmes de restructuration d'entreprises publiques et de démonopolisation ; planification, programmation, conseils.</narrative>
             </description>
             <category>250</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>25030</code>
@@ -2488,6 +2896,8 @@
                 <narrative xml:lang="fr">Fourniture de services publics et privés pour le développement des entreprises, par ex. incubateurs, stratégies d’entreprises, programmes de liens commerciaux et services de mise en relations. Cela comprend le soutien aux organisations privées représentant les entreprises, par ex. association d’entreprises ; chambres de commerce ; associations de producteurs ; fournisseurs de savoir faire et autres services d’aide au développement des entreprises. Pour les services financiers utiliser les codes 24030 ou 24040. Pour le développement des PME et pour le soutien aux sociétés dans le secteur industriel, utiliser les codes 32130 à 32172. Pour le soutien aux sociétés du secteur agricole utiliser le code 31120.</narrative>
             </description>
             <category>250</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>25040</code>
@@ -2500,6 +2910,8 @@
                 <narrative xml:lang="fr">Soutien aux réformes politiques, mise en œuvre et renforcement des principes et standards de conduite responsable des entreprises (CRE) ainsi que facilitation des pratiques d’entreprise responsables par les sociétés. Comprend l’établissement et le renforcement d’un cadre légal et de régulation pour protéger les droits des acteurs et de l’environnement, récompensant les meilleures performances ; mise en exergue des CRE dans les activités économiques gouvernementales, dans les opérations ou appels d’offre de entreprises d’état ; soutien à la mise en œuvre des directives de l’OCDE pour les multinationales, incluant la transparence, les droits humains, les relations dans l’emploi et l’industrie, l’environnement, la lutte contre la corruption, les intérêts des consommateurs, la science et la technologie, la concurrence et la fiscalité.</narrative>
             </description>
             <category>250</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31110</code>
@@ -2512,6 +2924,8 @@
                 <narrative xml:lang="fr">Politique agricole, planification et programmes ; aide aux ministères de l'agriculture ; renforcement des capacités institutionnelles et conseils ; activités d'agriculture non spécifiées.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31120</code>
@@ -2524,6 +2938,8 @@
                 <narrative xml:lang="fr">Projets intégrés ; développement d'exploitations agricoles.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31130</code>
@@ -2536,6 +2952,8 @@
                 <narrative xml:lang="fr">Y compris la lutte contre la dégradation des sols ; amélioration des sols ; drainage des zones inondées ; dessalage des sols ; études des terrains agricoles ; remise en état des sols ; lutte contre l'érosion, lutte contre la désertification.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31140</code>
@@ -2548,6 +2966,8 @@
                 <narrative xml:lang="fr">Irrigation, réservoirs, structures hydrauliques, exploitation de nappes phréatiques.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31150</code>
@@ -2560,6 +2980,8 @@
                 <narrative xml:lang="fr">Approvisionnement en semences, engrais, matériel et outillage agricoles.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31161</code>
@@ -2572,6 +2994,8 @@
                 <narrative xml:lang="fr">Y compris céréales (froment, riz, orge, maïs, seigle, avoine, millet, sorgho) ; horticulture ; légumes ; fruits et baies ; autres cultures annuelles et pluriannuelles. [Utiliser le code 32161 pour les agro-industries.]</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31162</code>
@@ -2584,6 +3008,8 @@
                 <narrative xml:lang="fr">Y compris sucre ; café, cacao, thé ; oléagineux, graines, noix, amandes ; fibres ; tabac ; caoutchouc. [Utiliser le  code 32161 pour les agro-industries.]</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31163</code>
@@ -2596,6 +3022,8 @@
                 <narrative xml:lang="fr">Toutes formes d'élevage ; aliments pour animaux.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31164</code>
@@ -2608,6 +3036,8 @@
                 <narrative xml:lang="fr">Y compris ajustement structurel dans le secteur agricole.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31165</code>
@@ -2620,6 +3050,8 @@
                 <narrative xml:lang="fr">Projets afin de réduire les cultures illicites (drogue) à travers d'autres opportunités de marketing et production agricoles (voir code 43050 pour développement alternatif non agricole).</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31166</code>
@@ -2632,6 +3064,8 @@
                 <narrative xml:lang="fr">Formation agricole non formelle.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31181</code>
@@ -2640,6 +3074,8 @@
                 <narrative xml:lang="fr">Education et formation dans le domaine agricole</narrative>
             </name>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31182</code>
@@ -2652,6 +3088,8 @@
                 <narrative xml:lang="fr">Étude des espèces végétales, physiologie, ressources génétiques, écologie, taxonomie, lutte contre les maladies, biotechnologie agricole ; y compris recherche vétérinaire (dans les domaines génétiques et sanitaires, nutrition, physiologie).</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31191</code>
@@ -2664,6 +3102,8 @@
                 <narrative xml:lang="fr">Organisation et politiques des marchés ; transport et stockage ; établissements de réserves stratégiques.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31192</code>
@@ -2676,6 +3116,8 @@
                 <narrative xml:lang="fr">Y compris la protection intégrée des plantes, les activités de protection biologique des plantes, la fourniture et la gestion de substances agrochimiques, l'approvisionnement en pesticides ; politique et législation de la protection des plantes.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31193</code>
@@ -2688,6 +3130,8 @@
                 <narrative xml:lang="fr">Intermédiaires financiers du secteur agricole, y compris les plans de crédit ; assurance récoltes.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31194</code>
@@ -2700,6 +3144,8 @@
                 <narrative xml:lang="fr">Y compris les organisations d'agriculteurs.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31195</code>
@@ -2712,6 +3158,8 @@
                 <narrative xml:lang="fr">Santé des animaux, ressources génétiques et nutritives.</narrative>
             </description>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31210</code>
@@ -2724,6 +3172,8 @@
                 <narrative xml:lang="fr">Politique de la sylviculture, planification et programmes ; renforcement des capacités institutionnelles et conseils ; études des forêts ; activités sylvicoles et agricoles liées à la sylviculture non spécifiées.</narrative>
             </description>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31220</code>
@@ -2736,6 +3186,8 @@
                 <narrative xml:lang="fr">Boisement pour consommation rurale et industrielle ; exploitation et utilisation ; lutte contre l'érosion, lutte contre la désertification ; projets intégrés.</narrative>
             </description>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31261</code>
@@ -2748,6 +3200,8 @@
                 <narrative xml:lang="fr">Développement sylvicole soutenable visant à la production de bois de chauffage et de charbon de bois. La transformation ultérieure de biomasse en biocarburants est codée 32173.</narrative>
             </description>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31281</code>
@@ -2756,6 +3210,8 @@
                 <narrative xml:lang="fr">Education et formation en sylviculture</narrative>
             </name>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31282</code>
@@ -2768,6 +3224,8 @@
                 <narrative xml:lang="fr">Y compris reproduction artificielle et amélioration des espèces, méthodes de production, engrais, coupe et ramassage du bois.</narrative>
             </description>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31291</code>
@@ -2776,6 +3234,8 @@
                 <narrative xml:lang="fr">Services sylvicoles</narrative>
             </name>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31310</code>
@@ -2788,6 +3248,8 @@
                 <narrative xml:lang="fr">Politique de la pêche, planification et programmes ; renforcement des capacités institutionnelles et conseils ; pêche hauturière et côtière ; évaluation, études et prospection du poisson en milieu marin et fluvial ; bateaux et équipements de pêche ; activités de pêche non spécifiées.</narrative>
             </description>
             <category>313</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31320</code>
@@ -2800,6 +3262,8 @@
                 <narrative xml:lang="fr">Exploitation et utilisation des pêcheries ; sauvegarde des bancs de poisson ; aquaculture ; projets intégrés.</narrative>
             </description>
             <category>313</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31381</code>
@@ -2808,6 +3272,8 @@
                 <narrative xml:lang="fr">Education et formation dans le domaine de la pêche</narrative>
             </name>
             <category>313</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31382</code>
@@ -2820,6 +3286,8 @@
                 <narrative xml:lang="fr">Pisciculture pilote ; recherche biologique aquatique.</narrative>
             </description>
             <category>313</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>31391</code>
@@ -2832,6 +3300,8 @@
                 <narrative xml:lang="fr">Ports de pêche ; vente des produits de la pêche ; transport et entreposage frigorifique du poisson.</narrative>
             </description>
             <category>313</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32110</code>
@@ -2844,6 +3314,8 @@
                 <narrative xml:lang="fr">Politique de l'industrie, planification et programmes ; renforcement des capacités institutionnelles et conseils ; activités industrielles non spécifiées ; industries manufacturières non spécifiées ci-dessous.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32120</code>
@@ -2852,6 +3324,8 @@
                 <narrative xml:lang="fr">Développement industriel</narrative>
             </name>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32130</code>
@@ -2864,6 +3338,8 @@
                 <narrative xml:lang="fr">Soutien direct à l'amélioration de la capacité de production et de la gestion commerciale des micro, petites et moyennes entreprises du secteur industriel, notamment la comptabilité, l'audit, les services de conseil, le transfert de technologie et le perfectionnement des compétences. Utilisez le code 25010 pour la politique commerciale et le soutien institutionnel. Pour les services de développement des entreprises par l'intermédiaire d'organisations intermédiaires (associations de commerce, chambres de commerce, associations de producteurs, incubateurs, fournisseurs de savoir-faire et autres services de développement commercial), utilisez le code CRS 25030. et code de développement agricole 31120.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32140</code>
@@ -2872,6 +3348,8 @@
                 <narrative xml:lang="fr">Artisanat</narrative>
             </name>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32161</code>
@@ -2884,6 +3362,8 @@
                 <narrative xml:lang="fr">Industries alimentaires de base, abattoirs et équipements nécessaires, industrie laitière et conserves de viande et de poisson, industries des corps gras, sucreries, production de boissons, tabac, production d'aliments pour animaux.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32162</code>
@@ -2896,6 +3376,8 @@
                 <narrative xml:lang="fr">Industrie et travail du bois, production de papier et pâte à papier.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32163</code>
@@ -2908,6 +3390,8 @@
                 <narrative xml:lang="fr">Y compris bonneterie.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32164</code>
@@ -2920,6 +3404,8 @@
                 <narrative xml:lang="fr">Production industrielle et non industrielle ; y compris fabrication des pesticides.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32165</code>
@@ -2928,6 +3414,8 @@
                 <narrative xml:lang="fr">Production d'engrais chimiques</narrative>
             </name>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32166</code>
@@ -2936,6 +3424,8 @@
                 <narrative xml:lang="fr">Ciment, chaux et plâtre</narrative>
             </name>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32167</code>
@@ -2948,6 +3438,8 @@
                 <narrative xml:lang="fr">Y compris liquéfaction du gaz ; raffineries de pétrole, distribution en gros de carburants fossiles. (Utiliser 23640 pour la distribution au détail de gaz et 23461 pour la distribution au détail de carburant fossiles liquides ou solides.)</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32168</code>
@@ -2960,6 +3452,8 @@
                 <narrative xml:lang="fr">Matériel médical et fournitures médicales ; médicaments et vaccins ; produits d'hygiène corporelle.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32169</code>
@@ -2972,6 +3466,8 @@
                 <narrative xml:lang="fr">Sidérurgie, éléments de construction métallique.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32170</code>
@@ -2980,6 +3476,8 @@
                 <narrative xml:lang="fr">Industries des métaux non ferreux</narrative>
             </name>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32171</code>
@@ -2992,6 +3490,8 @@
                 <narrative xml:lang="fr">Fabrication de machines électriques et non électriques, moteurs et turbines.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32172</code>
@@ -3004,6 +3504,8 @@
                 <narrative xml:lang="fr">Construction de navires, construction de bateaux de pêche ; construction de matériel ferroviaire ; véhicules automobiles et voitures particulières ; construction aéronautique ; systèmes de navigation et de guidage.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>32173</code>
@@ -3016,6 +3518,8 @@
                 <narrative xml:lang="fr">Comprend le biogaz, les biocarburant liquides et les pellets à usage domestique ou non. Exclut le bois de chauffe brut et le charbon de bois (32161)</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>32174</code>
@@ -3028,6 +3532,8 @@
                 <narrative xml:lang="fr">Comprend la fabrication et la distribution de fours efficaces à biomasse, gazéifieurs, fours à biocarburants liquides, fours solaires, fours à gaz et bio gaz fours électriques</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32182</code>
@@ -3040,6 +3546,8 @@
                 <narrative xml:lang="fr">Y compris les standards industriels ; gestion et contrôle de qualité ; métrologie ; accréditation ; certification.</narrative>
             </description>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32210</code>
@@ -3052,6 +3560,8 @@
                 <narrative xml:lang="fr">Politique du secteur des industries extractives, planification et programmes ; législation et cadastre, recensement des richesses minérales, systèmes d'information ; renforcement des capacités institutionnelles et conseils ; exploitation des ressources minérales non spécifiées.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32220</code>
@@ -3064,6 +3574,8 @@
                 <narrative xml:lang="fr">Géologie, géophysique et géochimie ; à l'exclusion de hydrogéologie (14010) et géologie de l'environnement (41010), production et extraction minérales, infrastructure, technologie, économie, sécurité et gestion de l'environnement.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32261</code>
@@ -3076,6 +3588,8 @@
                 <narrative xml:lang="fr">Y compris lignite et la tourbe.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32262</code>
@@ -3088,6 +3602,8 @@
                 <narrative xml:lang="fr">Pétrole, gaz naturel, condensés , GPL (Gaz de pétrole liquéfié), GNL (Gaz naturel liquéfié); y compris derricks et plates-formes de forage, et oléoducs et gazoducs.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32263</code>
@@ -3100,6 +3616,8 @@
                 <narrative xml:lang="fr">Fer et alliages.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32264</code>
@@ -3112,6 +3630,8 @@
                 <narrative xml:lang="fr">Aluminium, cuivre, plomb, nickel, étain et zinc.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32265</code>
@@ -3124,6 +3644,8 @@
                 <narrative xml:lang="fr">Or, argent, platine, diamant et pierres précieuses.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32266</code>
@@ -3136,6 +3658,8 @@
                 <narrative xml:lang="fr">Baryte, chaux, feldspath, kaolin, sable, gypse, gravier, pierres d'ornement.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32267</code>
@@ -3148,6 +3672,8 @@
                 <narrative xml:lang="fr">Phosphates, potasse.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32268</code>
@@ -3160,6 +3686,8 @@
                 <narrative xml:lang="fr">Nodules métalliques, phosphorites, sédiments marins.</narrative>
             </description>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>32310</code>
@@ -3172,6 +3700,8 @@
                 <narrative xml:lang="fr">Politique du secteur de la construction, planification ; ne comprend pas les activités de construction identifiables par secteur (par exemple, construction d'hôpitaux ou de bâtiments scolaires).</narrative>
             </description>
             <category>323</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33110</code>
@@ -3184,6 +3714,8 @@
                 <narrative xml:lang="fr">Politique commerciale et planification ; soutien aux ministères et départements responsables de la politique commerciale ; législation et réformes réglementaires dans le domaine du commerce ; analyse politique et mise en œuvre des accords commerciaux multilatéraux ex. sur les obstacles techniques au commerce et les mesures sanitaires et phytosanitaires sauf au niveau régional (voir 33130) ; intégration du commerce dans les stratégies nationales de développement (ex cadres stratégiques de la lutte contre la pauvreté) ; commerce de gros et de détail ; activités non spécifiées dans le domaine du commerce et de la promotion du commerce.</narrative>
             </description>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33120</code>
@@ -3196,6 +3728,8 @@
                 <narrative xml:lang="fr">Simplification et harmonisation des procédures internationales d'importation et d'exportation (ex. évaluations de douane, procédures de licences, formalités de transport, paiements, assurances) ; soutien aux départements douaniers et autres agences frontalières y compris et en particulier la mise en oeuvre des dispositions de l'Accord sur la facilitation des échanges de l'OMC ; réformes tarifaires.</narrative>
             </description>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33130</code>
@@ -3208,6 +3742,8 @@
                 <narrative xml:lang="fr">Soutien aux accords commerciaux régionaux [ex. Southern African Development Community (SADC), Association of Southeast Asian Nations (ASEAN), Zone de libre-échange des Amériques (ZLEA), Pays d'Afrique, des Caraïbes et du Pacifique/Union européenne (ACP/UE)] ; y compris le travail sur les obstacles techniques au commerce et les mesures sanitaires et phytosanitaires au niveau régional ; élaboration de règles d'origine et introduction de traitement spécial et différencié dans les accords commerciaux régionaux.</narrative>
             </description>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33140</code>
@@ -3220,6 +3756,8 @@
                 <narrative xml:lang="fr">Soutien à la participation effective des pays en développement aux négociations commerciales multilatérales, y compris la formation de négociateurs, l'évaluation de l'impact des négociations ; accession à l'Organisation Mondiale du Commerce (OMC) et aux autres organisations multilatérales liées au commerce.</narrative>
             </description>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33150</code>
@@ -3232,6 +3770,8 @@
                 <narrative xml:lang="fr">Contributions au budget du gouvernement non réservées afin de soutenir la mise en œuvre des propres réformes commerciales du bénéficiaire et de ses ajustements aux politiques commerciales des autres pays ; assistance à la gestion des déficits de la balance des paiements dus au changement de l'environnement mondial du commerce.</narrative>
             </description>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33181</code>
@@ -3244,6 +3784,8 @@
                 <narrative xml:lang="fr">Développement des ressources humaines dans le domaine du commerce non compris dans les codes ci-dessous.  Comprend les programmes universitaires dans le domaine du commerce.</narrative>
             </description>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>33210</code>
@@ -3252,6 +3794,8 @@
                 <narrative xml:lang="fr">Politique du tourisme et gestion administrative</narrative>
             </name>
             <category>332</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41010</code>
@@ -3264,6 +3808,8 @@
                 <narrative xml:lang="fr">Politique de l'environnement, lois et réglementations environnementales ; institutions et pratiques administratives ; planification de l'environnement et de l'utilisation des terres, procédures de décisions ; séminaires, réunions ; actions de préservation et de protection non spécifiées ci-dessous.</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41020</code>
@@ -3276,6 +3822,8 @@
                 <narrative xml:lang="fr">Lutte contre la pollution de l'air, protection de la couche d'ozone ; lutte contre la pollution marine.</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41030</code>
@@ -3288,6 +3836,8 @@
                 <narrative xml:lang="fr">Y compris réserves naturelles et actions dans les régions environnantes ; autres mesures visant à protéger les espèces menacées dans leur habitat naturel (par exemple la protection des marécages).</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41040</code>
@@ -3300,6 +3850,8 @@
                 <narrative xml:lang="fr">S’applique aux sites du patrimoine naturel, caractérisés par leur beauté naturelle ou leur exceptionnelle biodiversité, leurs écosystèmes et valeurs géologiques exceptionnelles (y compris certains paysages culturels uniques). Pour la préservation du patrimoine culturel matériel et immatériel, utilisez le code-objet 16061 – Culture et diversité culturelle ou 16066 – Culture.</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2017-12-31">
             <code>41050</code>
@@ -3312,6 +3864,8 @@
                 <narrative xml:lang="fr">Inondations de la mer et des rivières ; y compris la lutte contre l'avancée et la montée du niveau de l'eau de la mer.</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41081</code>
@@ -3320,6 +3874,8 @@
                 <narrative xml:lang="fr">Education et formation environnementales</narrative>
             </name>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>41082</code>
@@ -3332,6 +3888,8 @@
                 <narrative xml:lang="fr">Y compris établissement de bases de données, inventaires et estimations des ressources naturelles et physiques ; profils environnementaux et études d'impact lorsque le secteur ne peut être déterminé.</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43010</code>
@@ -3340,6 +3898,8 @@
                 <narrative xml:lang="fr">Aide plurisectorielle</narrative>
             </name>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43030</code>
@@ -3352,6 +3912,8 @@
                 <narrative xml:lang="fr">Projets intégrés de développement urbain ; développement local et gestion urbaine ; infrastructure et services urbains ; gestion municipale ; gestion de l'environnement urbain ; planification ; rénovation urbaine, habitat ; informations sur l'occupation des sols.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43031</code>
@@ -3364,6 +3926,8 @@
                 <narrative xml:lang="fr">Planification et gestion du territoire urbain; gestion urbaine, systèmes d'information.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43032</code>
@@ -3376,6 +3940,8 @@
                 <narrative xml:lang="fr">Projets intégrés de développement urbain; développement local; infrastructure et services urbains; finances municipales; gestion environnementale urbaine; rénovation urbaine, habitat.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43040</code>
@@ -3388,6 +3954,8 @@
                 <narrative xml:lang="fr">Projets intégrés de développement rural, par exemple, planification du développement régional ; encouragement à la décentralisation des compétences plurisectorielles concernant la planification, la coordination et la gestion ; mise en œuvre du développement régional et des mesures d'accompagnement (telle que gestion des ressources naturelles) ; gestion et planification des terres ; peuplement des terres et activités de réinstallation des peuples [à l'exclusion de la réinstallation des réfugiés et des personnes déplacées à  l'intérieur  du  pays  (72010)]  projets  d'intégration des  zones rurales et urbaines ; systèmes d'information des zones géographiques.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43041</code>
@@ -3400,6 +3968,8 @@
                 <narrative xml:lang="fr">Planification du développement régional; encouragement à la décentralisation des compétences plurisectorielles concernant la planification, la coordination et la gestion; gestion des terres; systèmes d'information géographique.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43042</code>
@@ -3412,6 +3982,8 @@
                 <narrative xml:lang="fr">Projets intégrés de développement rural; mise en oeuvre du développement régional (y compris la gestion des réserves naturelles) ; peuplement et réinstallation [à l'exclusion de la réinstallation des réfugiés et des personnes déplacées à l'intérieur du pays (72030)]; intégration des zones rurales et urbaines.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43050</code>
@@ -3424,6 +3996,8 @@
                 <narrative xml:lang="fr">Projets visant à réduire les cultures illicites (drogue) à travers, par exemple, des activités créatrices de revenu non agricoles, des infrastructures sociales et physiques (voir code 31165 pour le développement alternatif agricole).</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>43060</code>
@@ -3436,6 +4010,8 @@
                 <narrative xml:lang="fr">Activités de réduction des risques de catastrophe si elles ne sont pas spécifiques à un secteur. Comprend des évaluations des risques, des mesures structurelles de prévention (infrastructure de prévention des inondations, par exemple), des mesures de préparation (systèmes d'alerte, par exemple), des mesures de prévention normatives (codes du bâtiment, planification de l'utilisation des sols, etc.) et des systèmes de transfert de risques (systèmes d'assurance, fonds de risque, par exemple). Cela inclut également le renforcement des capacités locales et nationales et l'appui à la mise en place de structures nationales efficaces et durables capables de promouvoir la réduction des risques de catastrophe.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>43071</code>
@@ -3448,6 +4024,8 @@
                 <narrative xml:lang="fr">Politiques, programmes et activités de sécurité alimentaire ; renforcement des capacités institutionnelles ; politiques et programmes de réduction de gaspillage alimentaire ; systèmes d’information de sécurité alimentaire, collecte de données, statistiques, analyses, outils, méthodes s’y rapportant ; mécanismes de coordination et de gouvernance ; autres activités indéfinies de sécurité alimentaire.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>43072</code>
@@ -3460,6 +4038,8 @@
                 <narrative xml:lang="fr">Programmes de court ou long terme de sécurité alimentaire et activités améliorant l’accès des ménages à des régimes alimentaires équilibrés (à l’exclusion de tout transfert monétaire de programmes de protection sociale n’ayant pas d’optique spécifique de sécurité alimentaire, d’achat d’alimentation ou de nutrition, qui devrait être rapporté sous le code 16010).</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>43073</code>
@@ -3472,6 +4052,8 @@
                 <narrative xml:lang="fr">Salubrité alimentaire et politiques de qualité, programmes et activités, comprenant contrôle sanitaire, et certification ; renforcement des capacités de contrôle de qualité/salubrité alimentaire développement de standard tout au long de la chaine de valeur ; contrôle/surveillance et capacités des laboratoires ; et diffusion d’information, communication, éducation.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43081</code>
@@ -3484,6 +4066,8 @@
                 <narrative xml:lang="fr">Y compris les bourses.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>43082</code>
@@ -3496,6 +4080,8 @@
                 <narrative xml:lang="fr">Quand le secteur ne peut être déterminé.</narrative>
             </description>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>51010</code>
@@ -3508,6 +4094,8 @@
                 <narrative xml:lang="fr">Contributions au budget du gouvernement non réservées ; soutien à la mise en œuvre des réformes macroéconomiques (programmes d'ajustement structurel, stratégies de réduction de la pauvreté) ; y compris l'aide-programme générale (ne pouvant être ventilée par secteur).</narrative>
             </description>
             <category>510</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>52010</code>
@@ -3520,6 +4108,8 @@
                 <narrative xml:lang="fr">Fourniture nationale ou internationale de produits alimentaires y compris frais de transport ; paiements comptants pour la fourniture de produits alimentaires ; projets d'aide alimentaire et aide alimentaire destinée à la vente quand le secteur bénéficiaire ne peut être précisé ; à l'exclusion de l'aide alimentaire d'urgence. Notifier comme multilatéral : i) l'aide alimentaire consentie par l'UE et financée sur son budget propre puis répartie entre les États membres au pro rata de leur contribution à ce budget ; et ii) les contributions au budget central du PAM.</narrative>
             </description>
             <category>520</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>53030</code>
@@ -3532,6 +4122,8 @@
                 <narrative xml:lang="fr">Biens d'équipement et services ; lignes de crédit.</narrative>
             </description>
             <category>530</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>53040</code>
@@ -3544,6 +4136,8 @@
                 <narrative xml:lang="fr">Produits, biens d'ordre général, importations de pétrole.</narrative>
             </description>
             <category>530</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60010</code>
@@ -3556,6 +4150,8 @@
                 <narrative xml:lang="fr">Actions non spécifiées ci-dessous.</narrative>
             </description>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60020</code>
@@ -3564,6 +4160,8 @@
                 <narrative xml:lang="fr">Annulation de la dette</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60030</code>
@@ -3576,6 +4174,8 @@
                 <narrative xml:lang="fr">Dons ou prêts affectés au remboursement d'échéances dues à des institutions financières multilatérales ; y compris les contributions au fonds spécial pour les Pays pauvres très endettés (PPTE).</narrative>
             </description>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60040</code>
@@ -3584,6 +4184,8 @@
                 <narrative xml:lang="fr">Rééchelonnement d'échéances et refinancement</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60061</code>
@@ -3596,6 +4198,8 @@
                 <narrative xml:lang="fr">Affectation de créances à des fins de développement (par exemple dette pour l'éducation, dette pour l'environnement, etc.)</narrative>
             </description>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60062</code>
@@ -3608,6 +4212,8 @@
                 <narrative xml:lang="fr">Lorsque l'échange de dette profite à un agent extérieur, i.e. n'est pas spécifiquement opéré à des fins de développement.</narrative>
             </description>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>60063</code>
@@ -3620,6 +4226,8 @@
                 <narrative xml:lang="fr">Achat de la dette en vue de son annulation.</narrative>
             </description>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>72010</code>
@@ -3632,6 +4240,8 @@
                 <narrative xml:lang="fr">Abris, eau, assainissement, éducation, services de santé, y compris la fourniture de médicaments et la gestion de la malnutrition, y compris la gestion de la nutrition médicale;  fourniture d'autres articles de secours non alimentaires (y compris les modalités de remise en espèces et de bons) au profit des personnes touchées par la crise, notamment des réfugiés et des personnes déplacées dans les pays en developement. Comprend l'assistance fournie ou coordonnée par les unités internationales de la protection civile immédiatement après une catastrophe (assistance en nature, déploiement d'équipes spécialement équipées, logistique et transport, ou évaluation et coordination d'experts envoyés sur le terrain). Comprend également des mesures visant à promouvoir et à protéger la sécurité, le bien-être, la dignité et l'intégrité des personnes touchées par la crise, y compris des réfugiés et des personnes déplacées dans les pays en développement. (Les activités conçues pour protéger la sécurité des personnes ou des biens en recourant à la force ou à l'aide de la force ne sonpas déclarables en tant qu'APD.)</narrative>
             </description>
             <category>720</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>72011</code>
@@ -3644,6 +4254,8 @@
                 <narrative xml:lang="fr">Prestation de services de santé (services de santé de base, santé mentale, santé sexuelle et génésique), intervention nutritionnelle médicale (alimentation thérapeutique et interventions médicales pour traiter la malnutrition) et fourniture de médicaments au profit des personnes touchées. Exclut l'alimentation complémentaire (72040).</narrative>
             </description>
             <category>720</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>72012</code>
@@ -3656,6 +4268,8 @@
                 <narrative xml:lang="fr">Soutien aux établissements d'enseignement (y compris la restauration des infrastructures essentielles et des installations scolaires préexistantes), du matériel d'enseignement, de formation et d'apprentissage (y compris les technologies numériques, le cas échéant) et un accès immédiat à une éducation de base et primaire de qualité (y compris l'éducation formelle et non formelle), et l'enseignement secondaire (y compris la formation professionnelle et l'enseignement technique de niveau secondaire) dans les situations d'urgence au profit des enfants et des jeunes touchés, en ciblant en particulier les filles et les femmes et les réfugiés, les compétences de vie pour les jeunes et les adultes, et la formation professionnelle pour les jeunes et les adultes</narrative>
             </description>
             <category>720</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>72040</code>
@@ -3668,6 +4282,8 @@
                 <narrative xml:lang="fr">Fourniture et distribution de nourriture; de l'argent et des bons pour l'achat de nourriture; interventions nutritionnelles non médicales au profit des personnes touchées par la crise, notamment des réfugiés et des personnes déplacées à l'intérieur de leur propre pays, dans des pays en développement en situation d'urgence. Comprend les coûts logistiques. Sont exclus l'assistance alimentaire non urgente (52010), la politique de sécurité alimentaire et la gestion administrative (43071), les programmes alimentaires des ménages (43072) et les interventions de nutrition médicale (alimentation thérapeutique) (72010 et 72011).</narrative>
             </description>
             <category>720</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>72050</code>
@@ -3680,6 +4296,8 @@
                 <narrative xml:lang="fr">Mesures visant à coordonner l'évaluation et la livraison en toute sécurité de l'aide humanitaire, y compris des systèmes de logistique, de transport et de communication; soutien financier ou technique direct aux gouvernements nationaux des pays touchés pour gérer une situation de catastrophe; activités visant à constituer une base de preuves pour le financement et les opérations humanitaires, à partager ces informations et à élaborer des normes et des directives pour une réponse plus efficace; financement pour identifier et partager des solutions innovantes et évolutives afin de fournir une aide humanitaire efficace.</narrative>
             </description>
             <category>720</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>73010</code>
@@ -3692,6 +4310,8 @@
                 <narrative xml:lang="fr">Réhabilitation sociale et économique à la suite des situations d'urgence pour faciliter le rétablissement et le renforcement de la résilience et permettre aux populations de retrouver leurs moyens de subsistance à la suite d'une situation d'urgence (par exemple, conseils et traitements en traumatologie, programmes d'emploi). Comprend les infrastructures nécessaires à la livraison de l'aide humanitaire; la restauration des infrastructures et des installations essentielles préexistantes (par exemple, eau et assainissement, abris, services de soins de santé, éducation); la réhabilitation des intrants agricoles de base et du bétail. Ne comprend pas la reconstruction à plus long terme («reconstruire mieux») qui doit être rapportée dans les secteurs pertinents.</narrative>
             </description>
             <category>730</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2017-12-31">
             <code>74010</code>
@@ -3704,6 +4324,8 @@
                 <narrative xml:lang="fr">Activités visant à réduire les risques liés aux catastrophes (par exemple développement des connaissances, établissement d'une cartographie des risques naturels, de normes juridiques pour les constructions) ; systèmes d'alerte précoce, stocks d'urgence et planification d'urgence, y compris préparation à une évacuation.</narrative>
             </description>
             <category>740</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>74020</code>
@@ -3716,6 +4338,8 @@
                 <narrative xml:lang="fr">Renforcer la réactivité, les capacités et les capacités des acteurs humanitaires internationaux, régionaux et nationaux face aux catastrophes. Soutien aux capacités institutionnelles des gouvernements nationaux et locaux, des organismes humanitaires spécialisés et des organisations de la société civile pour anticiper, réagir et récupérer de l'impact d'événements dangereux potentiels, imminents ou actuels, et de situations d'urgence qui posent des menaces humanitaires et pourraient appeler une réponse humanitaire. Cela inclut l'analyse et l'évaluation des risques, l'atténuation, la préparation, telles que le stockage d'éléments d'urgence et la formation et le renforcement des capacités visant à accroître la rapidité et l'efficacité de l'assistance vitale apportée lors d'une crise.</narrative>
             </description>
             <category>740</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>91010</code>
@@ -3724,6 +4348,8 @@
                 <narrative xml:lang="fr">Frais administratifs (non alloués par secteur)</narrative>
             </name>
             <category>910</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>92010</code>
@@ -3763,6 +4389,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois, quand les coûts ne peuvent pas être désagrégés. Voir section II.6 et Annexe 17.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93011</code>
@@ -3775,6 +4403,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois – nourriture et hébergement : - Nourriture et autres éléments essentiels pour l'entretien temporaire, tels qu'habillement. - Installations temporaires d'hébergement (par exemple, centres d'accueil, conteneurs, camps de tentes). S'agissant des bâtiments, seuls les coûts d'entretien et de maintenance peuvent être comptabilisés dans l'APD. Les coûts liés à la location de locaux d'hébergement temporaire sont éligibles. (Tous les coûts de construction sont exclus).</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93012</code>
@@ -3787,6 +4417,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois – formation: - Éducation de la petite enfance, enseignement primaire et enseignement secondaire pour les enfants (dont les coûts liés à la scolarité, hors formation professionnelle), dans le cadre de l'entretien temporaire. - Formation linguistique et autre formation spécifique pour les réfugiés, par exemple, compétences nécessaires à la vie courante pour les jeunes et les adultes (cours d'alphabétisation et de maîtrise des chiffres).</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93013</code>
@@ -3799,6 +4431,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois : soins de santé de base et soutien psychosocial pour les personnes présentant des besoins spécifiques, par exemple les mineurs non accompagnés, les personnes souffrant d'un handicap, les personnes ayant survécu à des actes de violence et de torture.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93014</code>
@@ -3811,6 +4445,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois : entretien temporaire autre que nourriture et hébergement (code 93011), formation (93012) et santé (93013), i.e. « argent de poche » en espèces pour la prise en charge des frais d'entretien et accompagnement lors de la procédure de demande d'asile : traduction des documents, conseil juridique et administratif, services d'interprétation.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93015</code>
@@ -3823,6 +4459,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois : dépenses liées au retour volontaire des réfugiés vers un pays en développement au cours des douze premiers mois.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93016</code>
@@ -3835,6 +4473,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois : transport vers le pays d'accueil dans le cas des programmes de réinstallation et transport au sein du pays d'accueil.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93017</code>
@@ -3847,6 +4487,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois : opérations de sauvetage de réfugiés en mer dans le cadre d'interventions dédiées. Seuls les coûts supplémentaires liés à ces interventions peuvent être comptabilisés.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>93018</code>
@@ -3859,6 +4501,8 @@
                 <narrative xml:lang="fr">Coûts encourus dans les pays donneurs au titre de l'aide de base apportée aux demandeurs d'asile et aux réfugiés en provenance des pays en développement pendant une période pouvant aller jusqu'à 12 mois : coûts administratifs. Seuls les frais généraux en lien avec la mise à disposition directe d'un entretien temporaire aux réfugiés sont admissibles. Il s'agit notamment des coûts du personnel affecté à la fourniture des services aux réfugiés (services éligibles uniquement), mais pas des coûts du personnel qui n'intervient pas dans la fourniture directe de ces services, à savoir, les effectifs affectés à la gestion, aux ressources humaines ou aux technologies de l'information.</narrative>
             </description>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>99810</code>
@@ -3871,6 +4515,8 @@
                 <narrative xml:lang="fr">Les contributions au développement général du pays bénéficiaire devraient être incluses dans l'aide programme (51010).</narrative>
             </description>
             <category>998</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>99820</code>
@@ -3883,6 +4529,8 @@
                 <narrative xml:lang="fr">Dépenses dans le pays donneur afin de renforcer la sensibilisation et l'intérêt dans la coopération pour le développement (brochures, exposés, projets spéciaux de recherche, etc.).</narrative>
             </description>
             <category>998</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/Sector.xml
+++ b/xml/Sector.xml
@@ -1,4 +1,4 @@
-<codelist name="Sector" xml:lang="en" category-codelist="SectorCategory" complete="1" embedded="0">
+<codelist name="Sector" xml:lang="en" complete="1" category-codelist="SectorCategory" embedded="0">
     <metadata>
         <name>
             <narrative>DAC 5 Digit Sector</narrative>
@@ -895,6 +895,42 @@
             </description>
             <category>151</category>
         </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1513010</code>
+            <name>
+                <narrative>Fight against transnational organised crime</narrative>
+                <narrative xml:lang="fr">Fight against transnational organised crime</narrative>
+            </name>
+            <description>
+                <narrative>Activities that support law enforcement agencies in the fight against all forms of transnational organised crime, including trafficking in cultural property, money laundering and illicit financial flows; trafficking of wild fauna and flora and forest products; maritime piracy; illegal mining, trafficking in precious metals; crimes related to fishing; illicit trafficking in firearms; human trafficking and migrant smuggling. Activities should be aligned with the United Nations Convention against Transnational Organised Crime (UNTOC). The provision, or training on the use, of lethal equipment is excluded even if related to the above-mentioned crimes. [Use code 16063 for counter-narcotics and code 1513030 for cyber security].</narrative>
+                <narrative xml:lang="fr">Activities that support law enforcement agencies in the fight against all forms of transnational organised crime, including trafficking in cultural property, money laundering and illicit financial flows; trafficking of wild fauna and flora and forest products; maritime piracy; illegal mining, trafficking in precious metals; crimes related to fishing; illicit trafficking in firearms; human trafficking and migrant smuggling. Activities should be aligned with the United Nations Convention against Transnational Organised Crime (UNTOC). The provision, or training on the use, of lethal equipment is excluded even if related to the above-mentioned crimes. [Use code 16063 for counter-narcotics and code 1513030 for cyber security].</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1513020</code>
+            <name>
+                <narrative>Countering violent extremism</narrative>
+                <narrative xml:lang="fr">Countering violent extremism</narrative>
+            </name>
+            <description>
+                <narrative>Activities aimed at combating terrorism. The activities reported here should be aligned with the United Nations Global Counter-Terrorism Strategy and the 19 international legal instruments to prevent terrorist acts. Examples include the facilitation of the implementation of the relevant legal instruments, combating money laundering and financing of terrorism, capacity-building programmes to strengthen transport security and border management systems, and assistance in developing an effective and rule of law-based criminal justice system. The provision, or training on the use, of lethal equipment is excluded.</narrative>
+                <narrative xml:lang="fr">Activities aimed at combating terrorism. The activities reported here should be aligned with the United Nations Global Counter-Terrorism Strategy and the 19 international legal instruments to prevent terrorist acts. Examples include the facilitation of the implementation of the relevant legal instruments, combating money laundering and financing of terrorism, capacity-building programmes to strengthen transport security and border management systems, and assistance in developing an effective and rule of law-based criminal justice system. The provision, or training on the use, of lethal equipment is excluded.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1513030</code>
+            <name>
+                <narrative>Cyber security</narrative>
+                <narrative xml:lang="fr">Cyber security</narrative>
+            </name>
+            <description>
+                <narrative>Operational policing to protect computer systems from theft or damage covering hardware, software and electronic data.</narrative>
+                <narrative xml:lang="fr">Operational policing to protect computer systems from theft or damage covering hardware, software and electronic data.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
         <codelist-item status="active">
             <code>15131</code>
             <name>
@@ -1064,8 +1100,8 @@
                 <narrative xml:lang="fr">Médias et liberté de l'information</narrative>
             </name>
             <description>
-                <narrative>Activities that support free and uncensored flow of information on public issues; activities that increase the editorial and technical skills and the integrity of the print and broadcast media, e.g. training of journalists. (Use codes 22010-22040 for provision of equipment and capital assistance to media.)</narrative>
-                <narrative xml:lang="fr">Activités qui favorisent une diffusion libre et non censurée de l'information sur les questions publiques ; activités visant à améliorer les compétences rédactionnelles et techniques, et l'intégrité des médias – presse écrite, radio et télévision – par exemple, formation des journalistes. (Utiliser les codes 22010-22040 pour la fourniture d'équipements et d'une aide financière aux médias.)</narrative>
+                <narrative>Activities that support free and uncensored flow of information on public issues; activities that increase the editorial and technical skills and the integrity of the print, broadcast and online media, e.g. training of journalists and information professionals. Use codes in sector 220 for provision of equipment and capital assistance to media.</narrative>
+                <narrative xml:lang="fr">Activités qui favorisent une diffusion libre et non censurée de l'information sur les questions publiques ; activités visant à améliorer les compétences rédactionnelles et techniques, et l'intégrité des médias imprimés, audiovisuels et en ligne, par exemple, formation des journalistes. (Utiliser les codes du secteur 220 pour la fourniture d'équipements et d'une aide financière aux médias.)</narrative>
             </description>
             <category>151</category>
         </codelist-item>
@@ -1108,8 +1144,32 @@
                 <narrative xml:lang="fr">Droits de la personne</narrative>
             </name>
             <description>
-                <narrative>Measures to support specialised official human rights institutions and mechanisms at universal, regional, national and local levels in their statutory roles to promote and protect civil and political, economic, social and cultural rights as defined in international conventions and covenants; translation of international human rights commitments into national legislation; reporting and follow-up; human rights dialogue. Human rights defenders and human rights NGOs; human rights advocacy, activism, mobilisation; awareness raising and public human rights education. Human rights programming targeting specific groups, e.g. children, persons with disabilities, migrants, ethnic, religious, linguistic and sexual minorities, indigenous people and those suffering from caste discrimination, victims of trafficking, victims of torture. (Use code 15230 when in the context of a peacekeeping operation and code 15180 for ending violence against women and girls. Use code 15190 for human rights programming for refugees or migrants, including when they are victims of trafficking.Use code 16070 for Fundamental Principles and Rights at Work, i.e. Child Labour, Forced Labour, Non-discrimination in employment and occupation, Freedom of Association and Collective Bargaining.)</narrative>
-                <narrative xml:lang="fr">Mesures visant à aider les institutions et mécanismes spécialisés dans les droits de la personne opérant aux niveaux mondial, régional, national ou local, dans leur mission officielle de promotion et de protection des droits civils et politiques, économiques, sociaux et culturels tels que définis dans les conventions et pactes internationaux; transposition dans la législation nationale des engagements internationaux concernant les droits de la personne; notification et suivi; dialogue sur les droits de la personne. Défenseurs des droits de la personne et ONG oeuvrant dans ce domaine ; promotion des droits de la personne, défense active, mobilisation ; sensibilisation et éducation des citoyens aux droits de la personne.  Élaboration de programmes concernant les droits de la personne ciblés sur des groupes particuliers comme les enfants, les individus en situation de handicap, les migrants, les minorités ethniques, religieuses, linguistiques et sexuelles, les populations autochtones et celles qui sont victimes de discrimination fondée sur la caste, les victimes de la traite d'êtres humains, les victimes de la torture. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d'une opération internationale de maintien de la paix et le code 15180 pour les activités visant l'élimination de la violence à l'égard des femmes et des filles. Utiliser le code 15190 pour la programmation des droits de l'homme des réfugiés ou des migrants, y compris lorsqu'ils sont victimes de la traite d'êtres humains. Utiliser le code 16070 pour les activités concernant les Principes fondamentaux et Droits au travail, c'est-à-dire travail des enfants, travail forcé, non-discrimination dans l'emploi et le travail, liberté syndicale et négociation collective.)</narrative>
+                <narrative>Measures to support specialised official human rights institutions and mechanisms at universal, regional, national and local levels in their statutory roles to promote and protect civil and political, economic, social and cultural rights as defined in international conventions and covenants; translation of international human rights commitments into national legislation; reporting and follow-up; human rights dialogue. Human rights defenders and human rights NGOs; human rights advocacy, activism, mobilisation; awareness raising and public human rights education. Human rights programming targeting specific groups, e.g. children, persons with disabilities, ethnic, religious, linguistic and sexual minorities, indigenous people and those suffering from caste discrimination, victims of trafficking, victims of torture. (Use code 15230 when in the context of a peacekeeping operation and code 15180 for ending violence against women and girls. Use code 15190 for human rights programming for refugees or migrants, including when they are victims of trafficking. Use code 16070 for Fundamental Principles and Rights at Work, i.e. Child Labour, Forced Labour, Non-discrimination in employment and occupation, Freedom of Association and Collective Bargaining.)</narrative>
+                <narrative xml:lang="fr">Mesures visant à aider les institutions et mécanismes spécialisés dans les droits de la personne opérant aux niveaux mondial, régional, national ou local, dans leur mission officielle de promotion et de protection des droits civils et politiques, économiques, sociaux et culturels tels que définis dans les conventions et pactes internationaux; transposition dans la législation nationale des engagements internationaux concernant les droits de la personne; notification et suivi; dialogue sur les droits de la personne. Défenseurs des droits de la personne et ONG oeuvrant dans ce domaine ; promotion des droits de la personne, défense active, mobilisation ; sensibilisation et éducation des citoyens aux droits de la personne.  Élaboration de programmes concernant les droits de la personne ciblés sur des groupes particuliers comme les enfants, les individus en situation de handicap, les minorités ethniques, religieuses, linguistiques et sexuelles, les populations autochtones et celles qui sont victimes de discrimination fondée sur la caste, les victimes de la traite d'êtres humains, les victimes de la torture. (Utiliser le code 15230 lorsque les activités se déroulent dans le cadre d'une opération internationale de maintien de la paix et le code 15180 pour les activités visant l'élimination de la violence à l'égard des femmes et des filles. Utiliser le code 15190 pour la programmation des droits de l'homme des réfugiés ou des migrants, y compris lorsqu'ils sont victimes de la traite d'êtres humains. Utiliser le code 16070 pour les activités concernant les Principes fondamentaux et Droits au travail, c'est-à-dire travail des enfants, travail forcé, non-discrimination dans l'emploi et le travail, liberté syndicale et négociation collective.)</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1516010</code>
+            <name>
+                <narrative>Transitional justice</narrative>
+                <narrative xml:lang="fr">Transitional justice</narrative>
+            </name>
+            <description>
+                <narrative>Support beyond the regular justice system to address large-scale or systematic human rights violations.</narrative>
+                <narrative xml:lang="fr">Support beyond the regular justice system to address large-scale or systematic human rights violations.</narrative>
+            </description>
+            <category>151</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1516020</code>
+            <name>
+                <narrative>International criminal justice</narrative>
+                <narrative xml:lang="fr">International criminal justice</narrative>
+            </name>
+            <description>
+                <narrative>Support to international mechanisms aimed at ensuring accountability for serious crimes such as genocide, crimes against humanity and war crimes as defined in international law.</narrative>
+                <narrative xml:lang="fr">Support to international mechanisms aimed at ensuring accountability for serious crimes such as genocide, crimes against humanity and war crimes as defined in international law.</narrative>
             </description>
             <category>151</category>
         </codelist-item>
@@ -1213,6 +1273,30 @@
             </description>
             <category>151</category>
         </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1520010</code>
+            <name>
+                <narrative>Disarmament of Weapons of Mass Destruction (WMD)</narrative>
+                <narrative xml:lang="fr">Disarmament of Weapons of Mass Destruction (WMD)</narrative>
+            </name>
+            <description>
+                <narrative>Activities intended at supporting disarmament and non-proliferation of biological, chemical and nuclear weapons.</narrative>
+                <narrative xml:lang="fr">Activities intended at supporting disarmament and non-proliferation of biological, chemical and nuclear weapons.</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
+        <codelist-item status="active" activation-date="2019-01-01">
+            <code>1520020</code>
+            <name>
+                <narrative>Prevention of Violent Extremism</narrative>
+                <narrative xml:lang="fr">Prevention of Violent Extremism</narrative>
+            </name>
+            <description>
+                <narrative>Actions intended at addressing the drivers of violent extremism such as those outlined in the United Nations Secretary General Plan of Action to Prevent Violent Extremism: dialogue and conflict prevention; strengthening good governance, human rights and the rule of law; engaging communities; empowering youth; gender equality and empowering women; education, skills development and employment facilitation; strategic communications, the Internet and social media.</narrative>
+                <narrative xml:lang="fr">Actions intended at addressing the drivers of violent extremism such as those outlined in the United Nations Secretary General Plan of Action to Prevent Violent Extremism: dialogue and conflict prevention; strengthening good governance, human rights and the rule of law; engaging communities; empowering youth; gender equality and empowering women; education, skills development and employment facilitation; strategic communications, the Internet and social media.</narrative>
+            </description>
+            <category>152</category>
+        </codelist-item>
         <codelist-item status="active">
             <code>15210</code>
             <name>
@@ -1256,8 +1340,8 @@
                 <narrative xml:lang="fr">Réintégration et contrôle des armes légères et de petit calibre</narrative>
             </name>
             <description>
-                <narrative>Reintegration of demobilised military personnel into the economy; conversion of production facilities from military to civilian outputs; technical co-operation to control, prevent and/or reduce the proliferation of small arms and light weapons (SALW) – see para. 80 of the Directives for definition of SALW activities covered. [Other than in the context of an international peacekeeping operation (15230) or child soldiers (15261)].</narrative>
-                <narrative xml:lang="fr">Réinsertion du personnel militaire démobilisé dans la vie économique et civile ; conversion des usines d'armes en usines de produits à usage civil ; coopération technique destinée à contrôler, prévenir et/ou réduire la prolifération d'armes légères et de petit calibre – voir le paragraphe 80 des Directives pour la définition des activités couvertes. [Autre que dans le cadre d'une opération internationale de maintien de la paix (15230) ou  enfants soldats (15261)].</narrative>
+                <narrative>Reintegration of demobilised military personnel into the economy; conversion of production facilities from military to civilian outputs; technical co-operation to control, prevent and/or reduce the proliferation of small arms and light weapons (SALW) – see para. 120 of the Directives for definition of SALW activities covered. [Other than in the context of an international peacekeeping operation (15230) or child soldiers (15261)].</narrative>
+                <narrative xml:lang="fr">Réinsertion du personnel militaire démobilisé dans la vie économique et civile ; conversion des usines d'armes en usines de produits à usage civil ; coopération technique destinée à contrôler, prévenir et/ou réduire la prolifération d'armes légères et de petit calibre – voir le paragraphe 120 des Directives pour la définition des activités couvertes. [Autre que dans le cadre d'une opération internationale de maintien de la paix (15230) ou enfants soldats (15261)].</narrative>
             </description>
             <category>152</category>
         </codelist-item>
@@ -1408,12 +1492,12 @@
         <codelist-item status="active">
             <code>16061</code>
             <name>
-                <narrative>Culture and recreation</narrative>
-                <narrative xml:lang="fr">Culture et loisirs</narrative>
+                <narrative>Culture and cultural diversity</narrative>
+                <narrative xml:lang="fr">Culture et diversité culturelle</narrative>
             </name>
             <description>
-                <narrative>Including libraries and museums.</narrative>
-                <narrative xml:lang="fr">Y compris bibliothèques et musées.</narrative>
+                <narrative>Development-oriented social and cultural programmes: - Programmes to strengthen the cultural sector (cinema, music, dance, painting, literature, etc.) of developing countries; measures to promote or protect the diversity of cultural expressions. This includes support to cultural industries, construction and reparation of facilities; capacity building for artists and other persons working in the cultural sector; activities to support the production or the dissemination of artistic works of developing country nationals (e.g. artistic or musical events). - Preservation of tangible (artefacts, monuments, sites, museums) and intangible (arts, social practices, knowledge and skills, shared values, traditions, performances) cultural heritage that has a diversity of values including symbolic, historic, artistic, aesthetic, ethnological or anthropological, scientific and social significance. - Other development-oriented social and cultural programmes that contribute to promote inclusion and empowerment of nationals of developing countries. This includes the provision of materials (e.g. books, sport equipment), educational services (e.g. language courses), recreational facilities and equipment, as well as the organisation of tournaments and sporting events taking place in developing countries with participation of their nationals. Use code 99820 – promotion of development awareness for activities in the field of culture in the donor country that are designed to increase public support and awareness of development co-operation efforts in the donor country.</narrative>
+                <narrative xml:lang="fr">Programmes sociaux et culturels orientés vers le développement : - Programmes de renforcement du secteur culturel (cinéma, musique, danse, peinture, littérature, etc.) des pays en développement ; mesures visant à promouvoir ou à protéger la diversité des expressions culturelles. Cela comprend le soutien aux industries culturelles, à la construction et à la réparation des installations ; le renforcement des capacités des artistes et autres personnes travaillant dans le secteur culturel ; activités visant à soutenir la production ou la diffusion d’œuvres artistiques de ressortissants de pays en développement (par exemple événements artistiques ou musicaux). - Préservation du patrimoine culturel matériel (objets, monuments, sites, musées) et immatériel (arts, pratiques sociales, connaissances et compétences, valeurs partagées, traditions, performances) qui a une diversité de valeurs, notamment symboliques, historiques, artistiques, esthétiques, ethnologiques ou une signification anthropologique, scientifique et sociale. - Autres programmes sociaux et culturels axés sur le développement qui contribuent à promouvoir l'inclusion et l'autonomisation des ressortissants des pays en développement. Cela comprend la fourniture de matériel (par exemple livres, équipements sportifs), de services éducatifs (par exemple cours de langue), d'installations et d'équipements de loisirs, ainsi que l'organisation de tournois et d'événements sportifs ayant lieu dans les pays en développement avec la participation de leurs ressortissants. Utilisez le code 99820 – promotion de la sensibilisation au développement pour les activités dans le domaine de la culture dans le pays donateur qui sont conçues pour accroître le soutien du public et la sensibilisation aux efforts de coopération au développement dans le pays donateur.</narrative>
             </description>
             <category>160</category>
         </codelist-item>
@@ -1459,6 +1543,10 @@
                 <narrative>Recreation and sport</narrative>
                 <narrative xml:lang="fr">Récréation et sport</narrative>
             </name>
+            <description>
+                <narrative>Development-oriented social and cultural programmes that contribute to promote inclusion and empowerment of nationals of developing countries. This includes the provision of materials (e.g. books, sport equipment), educational services (e.g. language courses), recreational facilities and equipment, as well as the organisation of tournaments and sporting events taking place in developing countries with participation of their nationals.</narrative>
+                <narrative xml:lang="fr">Programmes sociaux et culturels axés sur le développement qui contribuent à promouvoir l’inclusion et l’autonomisation des ressortissants des pays en développement. Cela comprend la fourniture de matériel (par exemple livres, équipements sportifs), de services éducatifs (par exemple cours de langue), d'installations et d'équipements de loisirs, ainsi que l'organisation de tournois et d'événements sportifs ayant lieu dans les pays en développement avec la participation de leurs ressortissants.</narrative>
+            </description>
             <category>160</category>
         </codelist-item>
         <codelist-item status="active">
@@ -1467,6 +1555,10 @@
                 <narrative>Culture</narrative>
                 <narrative xml:lang="fr">Culture</narrative>
             </name>
+            <description>
+                <narrative>Programmes to strengthen the cultural sector (cinema, music, dance, painting, literature, etc.) of developing countries; measures to promote or protect the diversity of cultural expressions. This includes support to cultural industries, construction and reparation of facilities; capacity-building for artists and other persons working in the cultural sector; activities to support the production or the dissemination of artistic works of developing country nationals (e.g. artistic or musical events). Preservation of tangible (artefacts, monuments, sites, museums) and intangible (arts, social practices, knowledge and skills, shared values, traditions, performances) cultural heritage that has a diversity of values including symbolic, historic, artistic, aesthetic, ethnological or anthropological, scientific and social significance. Use code 99820 – promotion of development awareness for activities in the field of culture in the donor country that are designed to increase public support and awareness of development co-operation efforts in the donor country.</narrative>
+                <narrative xml:lang="fr">Programmes de renforcement du secteur culturel (cinéma, musique, danse, peinture, littérature, etc.) des pays en développement ; mesures visant à promouvoir ou à protéger la diversité des expressions culturelles. Cela comprend le soutien aux industries culturelles, à la construction et à la réparation des installations ; le renforcement des capacités des artistes et autres personnes travaillant dans le secteur culturel ; activités visant à soutenir la production ou la diffusion d’œuvres artistiques de ressortissants de pays en développement (par exemple événements artistiques ou musicaux). Préservation du patrimoine culturel matériel (objets, monuments, sites, musées) et immatériel (arts, pratiques sociales, connaissances et compétences, valeurs partagées, traditions, performances) qui a une diversité de valeurs, notamment symboliques, historiques, artistiques, esthétiques, ethnologiques ou une signification anthropologique, scientifique et sociale. Utilisez le code 99820 – promotion de la sensibilisation au développement pour les activités dans le domaine de la culture dans le pays donateur qui sont conçues pour accroître le soutien du public et la sensibilisation aux efforts de coopération au développement dans le pays donateur.</narrative>
+            </description>
             <category>160</category>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
@@ -1716,12 +1808,12 @@
         <codelist-item status="active">
             <code>22030</code>
             <name>
-                <narrative>Radio/television/print media</narrative>
-                <narrative xml:lang="fr">Radio, télévision, presse écrite</narrative>
+                <narrative>Radio, television, print and online media</narrative>
+                <narrative xml:lang="fr">Radio, télévision, médias imprimés et en ligne</narrative>
             </name>
             <description>
-                <narrative>Radio and TV links, equipment; newspapers; printing and publishing.</narrative>
-                <narrative xml:lang="fr">Liaisons et équipement ; journaux ; imprimerie et édition.</narrative>
+                <narrative>Radio and TV links, equipment and infrastructure; newspapers; printing and publishing. Information creation (in any media) is recorded under code 15153.</narrative>
+                <narrative xml:lang="fr">Liaisons, équipements et infrastructures de radio et de télévision ; journaux; impression et édition. La création d'informations (dans tous les médias) est enregistrée sous le code 15153.</narrative>
             </description>
             <category>220</category>
         </codelist-item>
@@ -1732,169 +1824,212 @@
                 <narrative xml:lang="fr">Technologies de l'information et de la communication (TIC)</narrative>
             </name>
             <description>
-                <narrative>Computer hardware and software; internet access; IT training.  When sector cannot be specified.</narrative>
-                <narrative xml:lang="fr">Matériel informatique et logiciels ; accès Internet ; formations aux TI. Lorsque le secteur ne peut pas être spécifié.</narrative>
+                <narrative>Computer hardware and software; internet access, when sector cannot be specified.</narrative>
+                <narrative xml:lang="fr">Matériel informatique et logiciels ; accès Internet. Lorsque le secteur ne peut pas être spécifié.</narrative>
             </description>
             <category>220</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="active" activation-date="2023-01-01">
+            <code>22081</code>
+            <name>
+                <narrative>Education and training in ICT, telecommunications and media</narrative>
+                <narrative xml:lang="fr">Éducation et formation en TIC, télécommunications et médias</narrative>
+            </name>
+            <description>
+                <narrative>Support for technical training in the sectors of ICT, telecommunications and media; IT training when the sector cannot be specified. Training on content creation (e.g. journalism, knowledge sharing) is reported under code 15153.</narrative>
+                <narrative xml:lang="fr">Appui à la formation technique dans les secteurs des TIC, des télécommunications et des médias ; Formation informatique lorsque le secteur ne peut être précisé. La formation à la création de contenu (par exemple journalisme, partage de connaissances) est déclarée sous le code 15153.</narrative>
+            </description>
+            <category>220</category>
+        </codelist-item>
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23010</code>
             <name>
                 <narrative>Energy policy and administrative management</narrative>
+                <narrative xml:lang="fr">Politique de l'énergie et gestion administrative</narrative>
             </name>
             <description>
                 <narrative>Energy sector policy, planning and programmes; aid to energy ministries; institution capacity building and advice; unspecified energy activities including energy conservation.</narrative>
+                <narrative xml:lang="fr">Politique de l'énergie, planification et programmes ; aide aux ministères de l'énergie ; renforcement des capacités institutionnelles et conseils ; activités non spécifiées dans le domaine de l'énergie y compris les économies d'énergie.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23020</code>
             <name>
                 <narrative>Power generation/non-renewable sources</narrative>
+                <narrative xml:lang="fr">Production d'énergie (sources non renouvelables)</narrative>
             </name>
             <description>
                 <narrative>Thermal power plants including when heat source cannot be determined; combined gas-coal power plants.</narrative>
+                <narrative xml:lang="fr">Centrales thermiques (lorsque la source de chaleur ne peut être déterminée) ; centrales alimentées au gaz et au charbon.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23030</code>
             <name>
                 <narrative>Power generation/renewable sources</narrative>
+                <narrative xml:lang="fr">Production d'énergie (sources renouvelables)</narrative>
             </name>
             <description>
                 <narrative>Including policy, planning, development programmes, surveys and incentives. Fuelwood/ charcoal production should be included under forestry (31261).</narrative>
+                <narrative xml:lang="fr">Y compris politique et planification, programmes de développement, études et primes. Production de bois de chauffage et de charbon de bois devrait être incluse dans sylviculture (31261).</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23040</code>
             <name>
-                <narrative>Electrical transmission/ distribution</narrative>
+                <narrative>Electrical transmission/distribution</narrative>
+                <narrative xml:lang="fr">Transmission et distribution d'électricité</narrative>
             </name>
             <description>
                 <narrative>Distribution from power source to end user; transmission lines.</narrative>
+                <narrative xml:lang="fr">Distribution de la source d'énergie au consommateur ; lignes de transmission.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23050</code>
             <name>
                 <narrative>Gas distribution</narrative>
+                <narrative xml:lang="fr">Distribution de gaz</narrative>
             </name>
             <description>
                 <narrative>Delivery for use by ultimate consumer.</narrative>
+                <narrative xml:lang="fr">Distribution au consommateur.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23061</code>
             <name>
                 <narrative>Oil-fired power plants</narrative>
+                <narrative xml:lang="fr">Centrales alimentées au fuel</narrative>
             </name>
             <description>
                 <narrative>Including diesel power plants.</narrative>
+                <narrative xml:lang="fr">Y compris les centrales alimentées au gas-oil.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23062</code>
             <name>
                 <narrative>Gas-fired power plants</narrative>
+                <narrative xml:lang="fr">Centrales alimentées au gaz</narrative>
             </name>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23063</code>
             <name>
                 <narrative>Coal-fired power plants</narrative>
+                <narrative xml:lang="fr">Centrales alimentées au charbon</narrative>
             </name>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23064</code>
             <name>
                 <narrative>Nuclear power plants</narrative>
+                <narrative xml:lang="fr">Centrales nucléaires</narrative>
             </name>
             <description>
-                <narrative>Including nuclear safety.</narrative>
+                <narrative>Including nuclear safety. Assistance towards the peaceful use of nuclear energy is reportable as ODA. This includes the construction and decommissioning of nuclear power reactors for civilian power supply, the development or supply of medical isotopes, and food irradiation and other industrial and commercial applications. Nuclear weapons research and other military applications of nuclear technology are excluded.</narrative>
+                <narrative xml:lang="fr">Y compris la sécurité nucléaire.L'aide visant à favoriser une utilisation pacifique de l'énergie nucléaire est comptabilisable dans l'APD. À titre d'exemples, on citera : la construction ou le déclassement de centrales nucléaires à des fins civiles, le développement ou la fourniture d'isotopes médicaux, l'irradiation des aliments et d'autres applications industrielles et commerciales. Sont par contre exclues les activités de recherche sur les armes nucléaires et les applications militaires de l</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23065</code>
             <name>
                 <narrative>Hydro-electric power plants</narrative>
+                <narrative xml:lang="fr">Centrales et barrages hydroélectriques</narrative>
             </name>
             <description>
                 <narrative>Including power-generating river barges.</narrative>
+                <narrative xml:lang="fr">Y compris les installations sur les barges.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23066</code>
             <name>
                 <narrative>Geothermal energy</narrative>
+                <narrative xml:lang="fr">Energie géothermique</narrative>
             </name>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23067</code>
             <name>
                 <narrative>Solar energy</narrative>
+                <narrative xml:lang="fr">Energie solaire</narrative>
             </name>
             <description>
                 <narrative>Including photo-voltaic cells, solar thermal applications and solar heating.</narrative>
+                <narrative xml:lang="fr">Y compris les cellules photovoltaïques et les pompes à énergie solaire.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23068</code>
             <name>
                 <narrative>Wind power</narrative>
+                <narrative xml:lang="fr">Energie éolienne</narrative>
             </name>
             <description>
                 <narrative>Wind energy for water lifting and electric power generation.</narrative>
+                <narrative xml:lang="fr">Énergie éolienne pour l'hydrodynamique et la production d'électricité.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23069</code>
             <name>
                 <narrative>Ocean power</narrative>
+                <narrative xml:lang="fr">Energie marémotrice</narrative>
             </name>
             <description>
                 <narrative>Including ocean thermal energy conversion, tidal and wave power.</narrative>
+                <narrative xml:lang="fr">Y compris la conversion de l'énergie thermique marine, la puissance des marées et des vagues.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23070</code>
             <name>
                 <narrative>Biomass</narrative>
+                <narrative xml:lang="fr">Biomasse</narrative>
             </name>
             <description>
                 <narrative>Densification technologies and use of biomass for direct power generation including biogas, gas obtained from sugar cane and other plant residues, anaerobic digesters.</narrative>
+                <narrative xml:lang="fr">Technologies de densification et utilisation de la biomasse pour la production d'énergie directe, y compris le gaz obtenu par fermentation de la canne à sucre et d'autres résidus végétaux, et par anaérobie.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23081</code>
             <name>
                 <narrative>Energy education/training</narrative>
+                <narrative xml:lang="fr">Education et formation dans le domaine de l'énergie</narrative>
             </name>
             <description>
                 <narrative>Applies to all energy sub-sectors; all levels of training.</narrative>
+                <narrative xml:lang="fr">Se rapporte à tous les sous-secteurs de l'énergie et à tous les niveaux de formation.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="withdrawn" withdrawal-date="2014-12-31">
             <code>23082</code>
             <name>
                 <narrative>Energy research</narrative>
+                <narrative xml:lang="fr">Recherche dans le domaine de l'énergie</narrative>
             </name>
             <description>
                 <narrative>Including general inventories, surveys.</narrative>
+                <narrative xml:lang="fr">Y compris inventaires et études.</narrative>
             </description>
             <category>230</category>
         </codelist-item>
@@ -2306,7 +2441,7 @@
             </name>
             <description>
                 <narrative>Includes programmes aiming at reducing the sending costs of remittances.</narrative>
-                <narrative xml:lang="fr">Comprend les programmes visant à réduire les coûts des transferts de fonds des migrants, dont les coûts d'envoi, de transmission et de réception ainsi que les programmes les encourageant et/ou augmentant leur impact sur le développement. Le soutien au renforcement des capacités statistiques visant à en améliorer les données est à enregistrer sous le code 16062. La recherche sur le potentiel de développement des transferts de fonds des migrants est à enregistrer sous le code 43082.</narrative>
+                <narrative xml:lang="fr">Comprend les programmes visant à réduire les coûts des transferts de fonds des migrants.</narrative>
             </description>
             <category>240</category>
         </codelist-item>
@@ -2346,11 +2481,11 @@
             <code>25030</code>
             <name>
                 <narrative>Business development services</narrative>
-                <narrative xml:lang="fr">Business development services</narrative>
+                <narrative xml:lang="fr">Services pour le développement des entreprises</narrative>
             </name>
             <description>
                 <narrative>Public and private provision of business development services, e.g. incubators, business strategies, commercial linkages programmes and matchmaking services. Includes support to private organisations representing businesses, e.g. business associations; chambers of commerce; producer associations; providers of know-how and other business development services. For financial services use CRS codes 24030 or 24040. For SME development and for support to companies in the industrial sector use codes 32130 through 32172. For support to companies in the agricultural sector use code 31120.</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Fourniture de services publics et privés pour le développement des entreprises, par ex. incubateurs, stratégies d’entreprises, programmes de liens commerciaux et services de mise en relations. Cela comprend le soutien aux organisations privées représentant les entreprises, par ex. association d’entreprises ; chambres de commerce ; associations de producteurs ; fournisseurs de savoir faire et autres services d’aide au développement des entreprises. Pour les services financiers utiliser les codes 24030 ou 24040. Pour le développement des PME et pour le soutien aux sociétés dans le secteur industriel, utiliser les codes 32130 à 32172. Pour le soutien aux sociétés du secteur agricole utiliser le code 31120.</narrative>
             </description>
             <category>250</category>
         </codelist-item>
@@ -2362,7 +2497,7 @@
             </name>
             <description>
                 <narrative>Support to policy reform, implementation and enforcement of responsible business conduct (RBC) principles and standards as well as facilitation of responsible business practices by companies. Includes establishing and enforcing a legal and regulatory framework to protect stakeholder rights and the environment, rewarding best performers; exemplifying RBC in government economic activities, such as state-owned enterprises' operations or public procurement; support to the implementation of the OECD Guidelines for MNEs, including disclosure, human rights, employment and industrial relations, environment, combating bribery, consumer interests, science and technology, competition and taxation.</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Soutien aux réformes politiques, mise en œuvre et renforcement des principes et standards de conduite responsable des entreprises (CRE) ainsi que facilitation des pratiques d’entreprise responsables par les sociétés. Comprend l’établissement et le renforcement d’un cadre légal et de régulation pour protéger les droits des acteurs et de l’environnement, récompensant les meilleures performances ; mise en exergue des CRE dans les activités économiques gouvernementales, dans les opérations ou appels d’offre de entreprises d’état ; soutien à la mise en œuvre des directives de l’OCDE pour les multinationales, incluant la transparence, les droits humains, les relations dans l’emploi et l’industrie, l’environnement, la lutte contre la corruption, les intérêts des consommateurs, la science et la technologie, la concurrence et la fiscalité.</narrative>
             </description>
             <category>250</category>
         </codelist-item>
@@ -2885,8 +3020,8 @@
         <codelist-item status="active" activation-date="2019-01-01">
             <code>32174</code>
             <name>
-                <narrative>Clean cooking appliances manufacturing</narrative>
-                <narrative xml:lang="fr">Production d'appareils de cuisine propres</narrative>
+                <narrative>Clean cooking appliances manufacturing, market development and distribution</narrative>
+                <narrative xml:lang="fr">Production d'appareils de cuisine propres, développement du marché et distribution</narrative>
             </name>
             <description>
                 <narrative>Includes manufacturing and distribution of efficient biomass cooking stoves, gasifiers, liquid biofuels stoves, solar stoves, gas and biogas stoves, electric stoves.</narrative>
@@ -3161,8 +3296,8 @@
                 <narrative xml:lang="fr">Protection des sites</narrative>
             </name>
             <description>
-                <narrative>Applies to unique cultural landscape; including sites/objects of historical, archeological, aesthetic, scientific or educational value.</narrative>
-                <narrative xml:lang="fr">Se rapporte à un paysage culturel exceptionnel ; y compris des sites et des objets d'une valeur historique, archéologique, esthétique, scientifique ou éducative.</narrative>
+                <narrative>Applies to sites of natural heritage, characterised by their natural beauty or outstanding biodiversity, ecosystem and geological values (including some unique cultural landscapes). For tangible and intangible cultural heritage preservation use purpose code 16061 - Culture and cultural diversity or 16066 – Culture.</narrative>
+                <narrative xml:lang="fr">S’applique aux sites du patrimoine naturel, caractérisés par leur beauté naturelle ou leur exceptionnelle biodiversité, leurs écosystèmes et valeurs géologiques exceptionnelles (y compris certains paysages culturels uniques). Pour la préservation du patrimoine culturel matériel et immatériel, utilisez le code-objet 16061 – Culture et diversité culturelle ou 16066 – Culture.</narrative>
             </description>
             <category>410</category>
         </codelist-item>
@@ -3310,7 +3445,7 @@
             </name>
             <description>
                 <narrative>Food security policy, programmes and activities; institution capacity strengthening; policies, programmes for the reduction of food loss/waste; food security information systems, data collection, statistics, analysis, tools, methods; coordination and governance mechanisms; other unspecified food security activities.</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Politiques, programmes et activités de sécurité alimentaire ; renforcement des capacités institutionnelles ; politiques et programmes de réduction de gaspillage alimentaire ; systèmes d’information de sécurité alimentaire, collecte de données, statistiques, analyses, outils, méthodes s’y rapportant ; mécanismes de coordination et de gouvernance ; autres activités indéfinies de sécurité alimentaire.</narrative>
             </description>
             <category>430</category>
         </codelist-item>
@@ -3322,7 +3457,7 @@
             </name>
             <description>
                 <narrative>Short or longer term household food security programmes and activities that improve the access of households to nutritionally adequate diets (excluding any cash transfers within broader social welfare programmes that do not have a specific food security, food acquisition or nutrition focus which should be reported under code 16010).</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Programmes de court ou long terme de sécurité alimentaire et activités améliorant l’accès des ménages à des régimes alimentaires équilibrés (à l’exclusion de tout transfert monétaire de programmes de protection sociale n’ayant pas d’optique spécifique de sécurité alimentaire, d’achat d’alimentation ou de nutrition, qui devrait être rapporté sous le code 16010).</narrative>
             </description>
             <category>430</category>
         </codelist-item>
@@ -3334,7 +3469,7 @@
             </name>
             <description>
                 <narrative>Food safety and quality policies, programmes and activities, including food inspection and certification; strengthening food safety/quality capacities and development of standards along the value chain; monitoring/surveillance and laboratory capacities; and delivery of information, communication, education.</narrative>
-                <narrative xml:lang="fr"/>
+                <narrative xml:lang="fr">Salubrité alimentaire et politiques de qualité, programmes et activités, comprenant contrôle sanitaire, et certification ; renforcement des capacités de contrôle de qualité/salubrité alimentaire développement de standard tout au long de la chaine de valeur ; contrôle/surveillance et capacités des laboratoires ; et diffusion d’information, communication, éducation.</narrative>
             </description>
             <category>430</category>
         </codelist-item>

--- a/xml/Sector.xml
+++ b/xml/Sector.xml
@@ -1459,7 +1459,7 @@
             </description>
             <category>151</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2019-01-01">
             <code>15196</code>
@@ -1767,7 +1767,7 @@
             </description>
             <category>160</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>16064</code>
@@ -1809,7 +1809,7 @@
             </description>
             <category>160</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>16070</code>
@@ -4530,7 +4530,7 @@
             </description>
             <category>998</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/SectorCategory.xml
+++ b/xml/SectorCategory.xml
@@ -9,334 +9,425 @@
         </category>
     </metadata>
     <codelist-items>
-        <codelist-item>
+        <codelist-item status="active">
+            <code>110</code>
+            <name>
+                <narrative>I.1. Education</narrative>
+                <narrative xml:lang="fr">I.1. Education</narrative>
+            </name>
+            <category>110</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>111</code>
             <name>
-                <narrative>Education, Level Unspecified</narrative>
-                <narrative xml:lang="fr">Education, Niveau non spécifié</narrative>
+                <narrative>I.1.a. Education, level nnspecified</narrative>
+                <narrative xml:lang="fr">I.1.a. Education, niveau non spécifié</narrative>
             </name>
             <description>
                 <narrative>The codes in this category are to be used only when level of education is unspecified or unknown (e.g. training of primary school teachers should be coded under 11220).</narrative>
                 <narrative xml:lang="fr">Les codes de cette catégorie doivent être utilisés seulement si le niveau d'éducation n'est pas spécifié ou connu (par exemple la formation d'enseignants d'écoles primaires devrait être codée sous 11220).</narrative>
             </description>
+            <category>111</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>112</code>
             <name>
-                <narrative>Basic Education</narrative>
-                <narrative xml:lang="fr">Education de Base</narrative>
+                <narrative>I.1.b. Basic education</narrative>
+                <narrative xml:lang="fr">I.1.b. Education de base</narrative>
             </name>
+            <category>112</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>113</code>
             <name>
-                <narrative>Secondary Education</narrative>
-                <narrative xml:lang="fr">Education Secondaire</narrative>
+                <narrative>I.1.c. Upper secondary education</narrative>
+                <narrative xml:lang="fr">I.1.c. Education secondaire</narrative>
             </name>
+            <category>113</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>114</code>
             <name>
-                <narrative>Post-Secondary Education</narrative>
-                <narrative xml:lang="fr">Education Post Secondaire</narrative>
+                <narrative>I.1.d. Post-secondary education</narrative>
+                <narrative xml:lang="fr">I.1.d. Education post secondaire</narrative>
             </name>
+            <category>114</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
+            <code>120</code>
+            <name>
+                <narrative>I.2. Health</narrative>
+                <narrative xml:lang="fr">I.2. Santé</narrative>
+            </name>
+            <category>120</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>121</code>
             <name>
-                <narrative>Health, General</narrative>
-                <narrative xml:lang="fr">Santé, Général</narrative>
+                <narrative>I.2.a. Health, general</narrative>
+                <narrative xml:lang="fr">I.2.a. Santé, général</narrative>
             </name>
+            <category>121</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>122</code>
             <name>
-                <narrative>Basic Health</narrative>
-                <narrative xml:lang="fr">Santé de Base</narrative>
+                <narrative>I.2.b. Basic health</narrative>
+                <narrative xml:lang="fr">I.2.b. Santé de Base</narrative>
             </name>
+            <category>122</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active" activation-date="2018-01-01">
             <code>123</code>
             <name>
-                <narrative>Non-communicable diseases (NCDs)</narrative>
-                <narrative xml:lang="fr">Maladies non-transmissibles (MNT)</narrative>
+                <narrative>I.2.c. Non-communicable diseases (NCDs)</narrative>
+                <narrative xml:lang="fr">I.2.c. Maladies non-transmissibles (MNT)</narrative>
             </name>
+            <category>123</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>130</code>
             <name>
-                <narrative>Population Policies/Programmes &amp; Reproductive Health</narrative>
-                <narrative xml:lang="fr">Politique en Matière de Population/Santé&amp;Fertilité</narrative>
+                <narrative>I.3. Population policies/programmes and reproductive health</narrative>
+                <narrative xml:lang="fr">I.3. Politique en Matière de Population/Santé&amp;Fertilité</narrative>
             </name>
+            <category>130</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>140</code>
             <name>
-                <narrative>Water Supply &amp; Sanitation</narrative>
-                <narrative xml:lang="fr">Distribution d'Eau et Assainissement</narrative>
+                <narrative>I.4. Water supply and sanitation</narrative>
+                <narrative xml:lang="fr">I.4. Distribution d'Eau et Assainissement</narrative>
             </name>
+            <category>140</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
+            <code>150</code>
+            <name>
+                <narrative>I.5. Government and civil society</narrative>
+                <narrative xml:lang="fr">I.5. Gouvernement &amp; société civile</narrative>
+            </name>
+            <category>150</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>151</code>
             <name>
-                <narrative>Government &amp; Civil Society-general</narrative>
-                <narrative xml:lang="fr">Gouvernement &amp; Société Civile-général</narrative>
+                <narrative>I.5.a. Government and civil society, general</narrative>
+                <narrative xml:lang="fr">I.5.a. Gouvernement &amp; société civile, général</narrative>
             </name>
             <description>
                 <narrative>N.B. Use code 51010 for general budget support.</narrative>
                 <narrative xml:lang="fr">N.B. Utiliser le code 51010 pour le soutien budgétaire général.</narrative>
             </description>
+            <category>151</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>152</code>
             <name>
-                <narrative>Conflict, Peace &amp; Security</narrative>
-                <narrative xml:lang="fr">Conflits, Paix et Sécurité</narrative>
+                <narrative>I.5.b. Conflict, peace and security</narrative>
+                <narrative xml:lang="fr">I.5.b. Conflits, paix et sécurité</narrative>
             </name>
             <description>
                 <narrative>N.B. Further notes on ODA eligibility (and exclusions) of conflict, peace and security related activities are given in paragraphs 76-81 of the Directives.</narrative>
                 <narrative xml:lang="fr">N.B.  Des notes supplémentaires sur l'éligibilité au titre de l'APD (et les exclusions) des activités liées aux conflits, la paix et la sécurité sont données dans les paragraphes 76-81 des Directives.</narrative>
             </description>
+            <category>152</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>160</code>
             <name>
-                <narrative>Other Social Infrastructure &amp; Services</narrative>
-                <narrative xml:lang="fr">Infrastructure et Services Sociaux Divers</narrative>
+                <narrative>I.6. Other social infrastructure and services</narrative>
+                <narrative xml:lang="fr">I.6. Infrastructure et services sociaux divers</narrative>
             </name>
+            <category>160</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>210</code>
             <name>
-                <narrative>Transport &amp; Storage</narrative>
-                <narrative xml:lang="fr">Transports et Entreposage</narrative>
+                <narrative>II.1. Transport and storage</narrative>
+                <narrative xml:lang="fr">II.1. Transports et entreposage</narrative>
             </name>
             <description>
                 <narrative>Note: Manufacturing of transport equipment should be included under code 32172.</narrative>
                 <narrative xml:lang="fr">Nota bene : La fabrication de matériel de transport devrait être incluse dans le code 32172.</narrative>
             </description>
+            <category>210</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>220</code>
             <name>
-                <narrative>Communications</narrative>
-                <narrative xml:lang="fr">Communications</narrative>
+                <narrative>II.2. Communications</narrative>
+                <narrative xml:lang="fr">II.2. Communications</narrative>
             </name>
+            <category>220</category>
         </codelist-item>
-        <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
+        <codelist-item status="active">
             <code>230</code>
             <name>
-                <narrative>ENERGY GENERATION AND SUPPLY</narrative>
+                <narrative>II.3. Energy</narrative>
+                <narrative xml:lang="fr">II.3. Energie</narrative>
             </name>
             <description>
-                <narrative>Energy sector policy, planning and programmes; aid to energy ministries; institution capacity building and advice; unspecified energy activities including energy conservation.</narrative>
+                <narrative>Categories 231 through 235 include both electric power plants and combined heat and power (CHP) plants. Heat-only plants, whatever the type of fuel, are reportable under category 236. Activities relating to fuelwood/charcoal production, energy manufacturing and natural resources extraction (including oil and gas pipelines) are reportable under categories 312, 321 and 322 respectively.</narrative>
+                <narrative xml:lang="fr">Dans les catégories 231 à 235 inclus figurent tant les centrales  électriques  que  les  centrales  de cogénération. Les installations produisant uniquement de la chaleur, quelle que soit la nature du combustible utilisé, sont à notifier dans la catégorie 236. Les activités liées à la production de bois de chauffage ou de charbon de bois, la fabrication d'énergie et l'extraction de ressources naturelles (y compris les oléoducs et gazoducs) sont à notifier respectivement sous les catégories 312, 321 et 322.</narrative>
             </description>
+            <category>230</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>231</code>
             <name>
-                <narrative>Energy Policy</narrative>
-                <narrative xml:lang="fr">Politique de l'énergie</narrative>
+                <narrative>II.3.a. Energy policy</narrative>
+                <narrative xml:lang="fr">II.3.a. Politique de l'énergie</narrative>
             </name>
+            <category>231</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>232</code>
             <name>
-                <narrative>Energy generation, renewable sources</narrative>
-                <narrative xml:lang="fr">Production d'électricité, sources renouvelables</narrative>
+                <narrative>II.3.b. Energy generation, renewable sources</narrative>
+                <narrative xml:lang="fr">II.3.b. Production d'électricité, sources renouvelables</narrative>
             </name>
+            <category>232</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>233</code>
             <name>
-                <narrative>Energy generation, non-renewable sources</narrative>
-                <narrative xml:lang="fr">Production d'électricité, sources non renouvelables</narrative>
+                <narrative>II.3.c. Energy generation, non-renewable sources</narrative>
+                <narrative xml:lang="fr">II.3.c. Production d'électricité, sources non renouvelables</narrative>
             </name>
+            <category>233</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>234</code>
             <name>
-                <narrative>Hybrid energy plants</narrative>
-                <narrative xml:lang="fr">Centrales hybrides</narrative>
+                <narrative>II.3.d. Hybrid energy plants</narrative>
+                <narrative xml:lang="fr">II.3.d. Centrales hybrides</narrative>
             </name>
+            <category>234</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>235</code>
             <name>
-                <narrative>Nuclear energy plants</narrative>
-                <narrative xml:lang="fr">Centrales nucléaires</narrative>
+                <narrative>II.3.e. Nuclear energy plants</narrative>
+                <narrative xml:lang="fr">II.3.e. Centrales nucléaires</narrative>
             </name>
+            <category>235</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>236</code>
             <name>
-                <narrative>Energy distribution</narrative>
-                <narrative xml:lang="fr">Distribution de l'énergie</narrative>
+                <narrative>II.3.f. Energy distribution</narrative>
+                <narrative xml:lang="fr">II.3.f. Distribution de l'énergie</narrative>
             </name>
+            <category>236</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>240</code>
             <name>
-                <narrative>Banking &amp; Financial Services</narrative>
-                <narrative xml:lang="fr">Banques et Services Financiers</narrative>
+                <narrative>II.4. Banking and financial services</narrative>
+                <narrative xml:lang="fr">II.4. Banques et services financiers</narrative>
             </name>
+            <category>240</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>250</code>
             <name>
-                <narrative>Business &amp; Other Services</narrative>
-                <narrative xml:lang="fr">Entreprises et Autres Services</narrative>
+                <narrative>II.5. Business and other services</narrative>
+                <narrative xml:lang="fr">II.5. Entreprises et Autres Services</narrative>
             </name>
+            <category>250</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
+            <code>310</code>
+            <name>
+                <narrative>III.1. Agriculture, forestry, fishing</narrative>
+                <narrative xml:lang="fr">III.1. Agriculture, sylviculture, pêche</narrative>
+            </name>
+            <category>310</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>311</code>
             <name>
-                <narrative>Agriculture</narrative>
-                <narrative xml:lang="fr">Agriculture</narrative>
+                <narrative>III.1.a. Agriculture</narrative>
+                <narrative xml:lang="fr">III.1.a. Agriculture</narrative>
             </name>
+            <category>311</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>312</code>
             <name>
-                <narrative>Forestry</narrative>
-                <narrative xml:lang="fr">Sylviculture</narrative>
+                <narrative>III.1.b. Forestry</narrative>
+                <narrative xml:lang="fr">III.1.b. Sylviculture</narrative>
             </name>
+            <category>312</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>313</code>
             <name>
-                <narrative>Fishing</narrative>
-                <narrative xml:lang="fr">Pêche</narrative>
+                <narrative>III.1.c. Fishing</narrative>
+                <narrative xml:lang="fr">III.1.c. Pêche</narrative>
             </name>
+            <category>313</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
+            <code>320</code>
+            <name>
+                <narrative>III.2. Industry, mining, construction</narrative>
+                <narrative xml:lang="fr">III.2. Industries manufacturières, extractives, construction</narrative>
+            </name>
+            <category>320</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>321</code>
             <name>
-                <narrative>Industry</narrative>
-                <narrative xml:lang="fr">Industries Manufacturières</narrative>
+                <narrative>III.2.a. Industry</narrative>
+                <narrative xml:lang="fr">III.2.a. Industries manufacturières</narrative>
             </name>
+            <category>321</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>322</code>
             <name>
-                <narrative>Mineral Resources &amp; Mining</narrative>
-                <narrative xml:lang="fr">Industries Extractives</narrative>
+                <narrative>III.2.b. Mineral resources and mining</narrative>
+                <narrative xml:lang="fr">III.2.b. Industries extractives</narrative>
             </name>
+            <category>322</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>323</code>
             <name>
-                <narrative>Construction</narrative>
-                <narrative xml:lang="fr">Construction</narrative>
+                <narrative>III.2.c. Construction</narrative>
+                <narrative xml:lang="fr">III.2.c. Construction</narrative>
             </name>
+            <category>323</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
+            <code>330</code>
+            <name>
+                <narrative>III.3.a. Trade Policies and Regulations</narrative>
+                <narrative xml:lang="fr">III.3.a. Politique Commerciale et Réglementations</narrative>
+            </name>
+            <category>330</category>
+        </codelist-item>
+        <codelist-item status="active">
             <code>331</code>
             <name>
-                <narrative>Trade Policies &amp; Regulations</narrative>
-                <narrative xml:lang="fr">Politique Commerciale et Réglementations</narrative>
+                <narrative>III.3.a. Trade Policies and Regulations</narrative>
+                <narrative xml:lang="fr">III.3.a. Politique Commerciale et Réglementations</narrative>
             </name>
+            <category>331</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>332</code>
             <name>
-                <narrative>Tourism</narrative>
-                <narrative xml:lang="fr">Tourisme</narrative>
+                <narrative>III.3.b. Tourism</narrative>
+                <narrative xml:lang="fr">III.3.b. Tourisme</narrative>
             </name>
+            <category>332</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>410</code>
             <name>
-                <narrative>General Environment Protection</narrative>
-                <narrative xml:lang="fr">Protection de l'Environnement Général</narrative>
+                <narrative>IV.1. General Environment Protection</narrative>
+                <narrative xml:lang="fr">IV.1. Protection de l'Environnement Général</narrative>
             </name>
             <description>
                 <narrative>Covers activities concerned with conservation, protection or amelioration of the physical environment without sector allocation.</narrative>
                 <narrative xml:lang="fr">Secteur non spécifié.</narrative>
             </description>
+            <category>410</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>430</code>
             <name>
-                <narrative>Other Multisector</narrative>
-                <narrative xml:lang="fr">Autres Multisecteurs</narrative>
+                <narrative>IV.2. Other Multisector</narrative>
+                <narrative xml:lang="fr">IV.2. Autres Multisecteurs</narrative>
             </name>
+            <category>430</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>510</code>
             <name>
-                <narrative>General Budget Support</narrative>
-                <narrative xml:lang="fr">Soutien Budgétaire</narrative>
+                <narrative>VI.1. General Budget Support</narrative>
+                <narrative xml:lang="fr">VI.1. Soutien Budgétaire</narrative>
             </name>
             <description>
                 <narrative>Budget support in the form of sector-wide approaches (SWAps) should be included in the respective sectors.</narrative>
                 <narrative xml:lang="fr">Les soutiens budgétaires sous la forme d'approches sectorielles devraient être inclus dans les secteurs respectifs.</narrative>
             </description>
+            <category>510</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>520</code>
             <name>
-                <narrative>Development Food Assistance</narrative>
-                <narrative xml:lang="fr">Aide Alimentaire Dévelopmentale</narrative>
+                <narrative>VI.2. Development Food Assistance</narrative>
+                <narrative xml:lang="fr">VI.2. Aide Alimentaire Dévelopmentale</narrative>
             </name>
+            <category>520</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>530</code>
             <name>
-                <narrative>Other Commodity Assistance</narrative>
-                <narrative xml:lang="fr">Aide sous forme de Produits, Autre</narrative>
+                <narrative>VI.3. Other Commodity Assistance</narrative>
+                <narrative xml:lang="fr">VI.3. Aide sous forme de Produits, Autre</narrative>
             </name>
             <description>
                 <narrative>Non-food commodity assistance (when benefiting sector not specified).</narrative>
                 <narrative xml:lang="fr">Aide sous forme de produits non alimentaires (quand le secteur bénéficiaire ne peut être précisé).</narrative>
             </description>
+            <category>530</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>600</code>
             <name>
-                <narrative>Action Relating to Debt</narrative>
-                <narrative xml:lang="fr">Actions se Rapportant a la Dette</narrative>
+                <narrative>VII. Action Relating to Debt</narrative>
+                <narrative xml:lang="fr">VII. Actions se Rapportant a la Dette</narrative>
             </name>
+            <category>600</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>720</code>
             <name>
-                <narrative>Emergency Response</narrative>
-                <narrative xml:lang="fr">Intervention d'Urgence</narrative>
+                <narrative>VIII.1. Emergency Response</narrative>
+                <narrative xml:lang="fr">VIII.1. Intervention d'Urgence</narrative>
             </name>
             <description>
                 <narrative>An emergency is a situation which results from man made crises and/or natural disasters.</narrative>
                 <narrative xml:lang="fr">Une situation d'urgence a pour origine une crise provoquée par des actions humaines ou par une catastrophe naturelle.</narrative>
             </description>
+            <category>720</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>730</code>
             <name>
-                <narrative>Reconstruction Relief &amp; Rehabilitation</narrative>
-                <narrative xml:lang="fr">Reconstruction &amp; Réhabilitation</narrative>
+                <narrative>VIII.2. Reconstruction and Rehabilitation</narrative>
+                <narrative xml:lang="fr">VIII.2. Reconstruction &amp; Réhabilitation</narrative>
             </name>
             <description>
                 <narrative>This relates to activities during and in the aftermath of an emergency situation.  Longer-term activities to improve the level of infrastructure or social services should be reported under the relevant economic and social sector codes. See also guideline on distinguishing humanitarian from sector-allocable aid.</narrative>
                 <narrative xml:lang="fr">Activités menées pendant et après une situation d'urgence. Les activités à plus long terme destinées à améliorer le niveau d'infrastructure ou de services sociaux doivent être rapportées sous les codes correspondants des secteurs économiques et sociaux pertinents. Voir également les orientations sur la distinction entre l'aide humanitaire et l'aide ventilable par secteur.</narrative>
             </description>
+            <category>730</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>740</code>
             <name>
-                <narrative>Disaster Prevention &amp; Preparedness</narrative>
-                <narrative xml:lang="fr">Prévention catastrophes/Préparation à leur survenue</narrative>
+                <narrative>VIII.3. Disaster Preparedness</narrative>
+                <narrative xml:lang="fr">VIII.3. Prévention catastrophes/Préparation à leur survenue</narrative>
             </name>
             <description>
                 <narrative>See code 43060 for disaster risk reduction.</narrative>
                 <narrative xml:lang="fr">Voir code 43060 pour la réduction des risques de catastrophes.</narrative>
             </description>
+            <category>740</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>910</code>
             <name>
-                <narrative>Administrative Costs of Donors</narrative>
-                <narrative xml:lang="fr">Frais Administratifs des Donneurs</narrative>
+                <narrative>IX. Administrative Costs of Donors</narrative>
+                <narrative xml:lang="fr">IX. Frais Administratifs des Donneurs</narrative>
             </name>
+            <category>910</category>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>920</code>
@@ -347,23 +438,25 @@
                 <narrative>In the donor country.</narrative>
             </description>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>930</code>
             <name>
-                <narrative>Refugees in Donor Countries</narrative>
-                <narrative xml:lang="fr">Refugiés dans les Pays Donneurs</narrative>
+                <narrative>XI. Refugees/Asylum Seekers in Donor Countries</narrative>
+                <narrative xml:lang="fr">XI. Refugiés dans les Pays Donneurs</narrative>
             </name>
+            <category>930</category>
         </codelist-item>
-        <codelist-item>
+        <codelist-item status="active">
             <code>998</code>
             <name>
-                <narrative>Unallocated / Unspecified</narrative>
-                <narrative xml:lang="fr">Non Affecté / Non Specifié</narrative>
+                <narrative>XII. Unallocated / Unspecified</narrative>
+                <narrative xml:lang="fr">XII. Non Affecté / Non Specifié</narrative>
             </name>
             <description>
                 <narrative>Contributions to general development of the recipient should be included under programme assistance (51010).</narrative>
                 <narrative xml:lang="fr"/>
             </description>
+            <category>998</category>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/SectorCategory.xml
+++ b/xml/SectorCategory.xml
@@ -1,4 +1,4 @@
-<codelist name="SectorCategory" xml:lang="en" complete="1" embedded="0">
+<codelist xmlns:extras="https://namespaces.iatistandard.org/codelist_extras" name="SectorCategory" xml:lang="en" complete="1" embedded="0">
     <metadata>
         <name>
             <narrative>DAC 3 Digit Sector</narrative>
@@ -16,6 +16,8 @@
                 <narrative xml:lang="fr">I.1. Education</narrative>
             </name>
             <category>110</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>111</code>
@@ -28,6 +30,8 @@
                 <narrative xml:lang="fr">Les codes de cette catégorie doivent être utilisés seulement si le niveau d'éducation n'est pas spécifié ou connu (par exemple la formation d'enseignants d'écoles primaires devrait être codée sous 11220).</narrative>
             </description>
             <category>111</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>112</code>
@@ -36,6 +40,8 @@
                 <narrative xml:lang="fr">I.1.b. Education de base</narrative>
             </name>
             <category>112</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>113</code>
@@ -44,6 +50,8 @@
                 <narrative xml:lang="fr">I.1.c. Education secondaire</narrative>
             </name>
             <category>113</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>114</code>
@@ -52,6 +60,8 @@
                 <narrative xml:lang="fr">I.1.d. Education post secondaire</narrative>
             </name>
             <category>114</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>120</code>
@@ -60,6 +70,8 @@
                 <narrative xml:lang="fr">I.2. Santé</narrative>
             </name>
             <category>120</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>121</code>
@@ -68,6 +80,8 @@
                 <narrative xml:lang="fr">I.2.a. Santé, général</narrative>
             </name>
             <category>121</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>122</code>
@@ -76,6 +90,8 @@
                 <narrative xml:lang="fr">I.2.b. Santé de Base</narrative>
             </name>
             <category>122</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active" activation-date="2018-01-01">
             <code>123</code>
@@ -84,6 +100,8 @@
                 <narrative xml:lang="fr">I.2.c. Maladies non-transmissibles (MNT)</narrative>
             </name>
             <category>123</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>130</code>
@@ -92,6 +110,8 @@
                 <narrative xml:lang="fr">I.3. Politique en Matière de Population/Santé&amp;Fertilité</narrative>
             </name>
             <category>130</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>140</code>
@@ -100,6 +120,8 @@
                 <narrative xml:lang="fr">I.4. Distribution d'Eau et Assainissement</narrative>
             </name>
             <category>140</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>150</code>
@@ -108,6 +130,8 @@
                 <narrative xml:lang="fr">I.5. Gouvernement &amp; société civile</narrative>
             </name>
             <category>150</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>151</code>
@@ -120,6 +144,8 @@
                 <narrative xml:lang="fr">N.B. Utiliser le code 51010 pour le soutien budgétaire général.</narrative>
             </description>
             <category>151</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>152</code>
@@ -132,6 +158,8 @@
                 <narrative xml:lang="fr">N.B.  Des notes supplémentaires sur l'éligibilité au titre de l'APD (et les exclusions) des activités liées aux conflits, la paix et la sécurité sont données dans les paragraphes 76-81 des Directives.</narrative>
             </description>
             <category>152</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>160</code>
@@ -140,6 +168,8 @@
                 <narrative xml:lang="fr">I.6. Infrastructure et services sociaux divers</narrative>
             </name>
             <category>160</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>210</code>
@@ -152,6 +182,8 @@
                 <narrative xml:lang="fr">Nota bene : La fabrication de matériel de transport devrait être incluse dans le code 32172.</narrative>
             </description>
             <category>210</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>220</code>
@@ -160,6 +192,8 @@
                 <narrative xml:lang="fr">II.2. Communications</narrative>
             </name>
             <category>220</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>230</code>
@@ -172,6 +206,8 @@
                 <narrative xml:lang="fr">Dans les catégories 231 à 235 inclus figurent tant les centrales  électriques  que  les  centrales  de cogénération. Les installations produisant uniquement de la chaleur, quelle que soit la nature du combustible utilisé, sont à notifier dans la catégorie 236. Les activités liées à la production de bois de chauffage ou de charbon de bois, la fabrication d'énergie et l'extraction de ressources naturelles (y compris les oléoducs et gazoducs) sont à notifier respectivement sous les catégories 312, 321 et 322.</narrative>
             </description>
             <category>230</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>231</code>
@@ -180,6 +216,8 @@
                 <narrative xml:lang="fr">II.3.a. Politique de l'énergie</narrative>
             </name>
             <category>231</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>232</code>
@@ -188,6 +226,8 @@
                 <narrative xml:lang="fr">II.3.b. Production d'électricité, sources renouvelables</narrative>
             </name>
             <category>232</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>233</code>
@@ -196,6 +236,8 @@
                 <narrative xml:lang="fr">II.3.c. Production d'électricité, sources non renouvelables</narrative>
             </name>
             <category>233</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>234</code>
@@ -204,6 +246,8 @@
                 <narrative xml:lang="fr">II.3.d. Centrales hybrides</narrative>
             </name>
             <category>234</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>235</code>
@@ -212,6 +256,8 @@
                 <narrative xml:lang="fr">II.3.e. Centrales nucléaires</narrative>
             </name>
             <category>235</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>236</code>
@@ -220,6 +266,8 @@
                 <narrative xml:lang="fr">II.3.f. Distribution de l'énergie</narrative>
             </name>
             <category>236</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>240</code>
@@ -228,6 +276,8 @@
                 <narrative xml:lang="fr">II.4. Banques et services financiers</narrative>
             </name>
             <category>240</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>250</code>
@@ -236,6 +286,8 @@
                 <narrative xml:lang="fr">II.5. Entreprises et Autres Services</narrative>
             </name>
             <category>250</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>310</code>
@@ -244,6 +296,8 @@
                 <narrative xml:lang="fr">III.1. Agriculture, sylviculture, pêche</narrative>
             </name>
             <category>310</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>311</code>
@@ -252,6 +306,8 @@
                 <narrative xml:lang="fr">III.1.a. Agriculture</narrative>
             </name>
             <category>311</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>312</code>
@@ -260,6 +316,8 @@
                 <narrative xml:lang="fr">III.1.b. Sylviculture</narrative>
             </name>
             <category>312</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>313</code>
@@ -268,6 +326,8 @@
                 <narrative xml:lang="fr">III.1.c. Pêche</narrative>
             </name>
             <category>313</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>320</code>
@@ -276,6 +336,8 @@
                 <narrative xml:lang="fr">III.2. Industries manufacturières, extractives, construction</narrative>
             </name>
             <category>320</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>321</code>
@@ -284,6 +346,8 @@
                 <narrative xml:lang="fr">III.2.a. Industries manufacturières</narrative>
             </name>
             <category>321</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>322</code>
@@ -292,6 +356,8 @@
                 <narrative xml:lang="fr">III.2.b. Industries extractives</narrative>
             </name>
             <category>322</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>323</code>
@@ -300,6 +366,8 @@
                 <narrative xml:lang="fr">III.2.c. Construction</narrative>
             </name>
             <category>323</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>330</code>
@@ -308,6 +376,8 @@
                 <narrative xml:lang="fr">III.3.a. Politique Commerciale et Réglementations</narrative>
             </name>
             <category>330</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>331</code>
@@ -316,6 +386,8 @@
                 <narrative xml:lang="fr">III.3.a. Politique Commerciale et Réglementations</narrative>
             </name>
             <category>331</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>332</code>
@@ -324,6 +396,8 @@
                 <narrative xml:lang="fr">III.3.b. Tourisme</narrative>
             </name>
             <category>332</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>410</code>
@@ -336,6 +410,8 @@
                 <narrative xml:lang="fr">Secteur non spécifié.</narrative>
             </description>
             <category>410</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>430</code>
@@ -344,6 +420,8 @@
                 <narrative xml:lang="fr">IV.2. Autres Multisecteurs</narrative>
             </name>
             <category>430</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>510</code>
@@ -356,6 +434,8 @@
                 <narrative xml:lang="fr">Les soutiens budgétaires sous la forme d'approches sectorielles devraient être inclus dans les secteurs respectifs.</narrative>
             </description>
             <category>510</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>520</code>
@@ -364,6 +444,8 @@
                 <narrative xml:lang="fr">VI.2. Aide Alimentaire Dévelopmentale</narrative>
             </name>
             <category>520</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>530</code>
@@ -376,6 +458,8 @@
                 <narrative xml:lang="fr">Aide sous forme de produits non alimentaires (quand le secteur bénéficiaire ne peut être précisé).</narrative>
             </description>
             <category>530</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>600</code>
@@ -384,6 +468,8 @@
                 <narrative xml:lang="fr">VII. Actions se Rapportant a la Dette</narrative>
             </name>
             <category>600</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>720</code>
@@ -396,6 +482,8 @@
                 <narrative xml:lang="fr">Une situation d'urgence a pour origine une crise provoquée par des actions humaines ou par une catastrophe naturelle.</narrative>
             </description>
             <category>720</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>730</code>
@@ -408,6 +496,8 @@
                 <narrative xml:lang="fr">Activités menées pendant et après une situation d'urgence. Les activités à plus long terme destinées à améliorer le niveau d'infrastructure ou de services sociaux doivent être rapportées sous les codes correspondants des secteurs économiques et sociaux pertinents. Voir également les orientations sur la distinction entre l'aide humanitaire et l'aide ventilable par secteur.</narrative>
             </description>
             <category>730</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>740</code>
@@ -420,6 +510,8 @@
                 <narrative xml:lang="fr">Voir code 43060 pour la réduction des risques de catastrophes.</narrative>
             </description>
             <category>740</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>910</code>
@@ -428,6 +520,8 @@
                 <narrative xml:lang="fr">IX. Frais Administratifs des Donneurs</narrative>
             </name>
             <category>910</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>920</code>
@@ -445,6 +539,8 @@
                 <narrative xml:lang="fr">XI. Refugiés dans les Pays Donneurs</narrative>
             </name>
             <category>930</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="active">
             <code>998</code>
@@ -457,6 +553,8 @@
                 <narrative xml:lang="fr"/>
             </description>
             <category>998</category>
+            <extras:crs>1</extras:crs>
+            <extras:tossd>1</extras:tossd>
         </codelist-item>
     </codelist-items>
 </codelist>

--- a/xml/SectorCategory.xml
+++ b/xml/SectorCategory.xml
@@ -521,7 +521,7 @@
             </name>
             <category>910</category>
             <extras:crs>1</extras:crs>
-            <extras:tossd>1</extras:tossd>
+            <extras:tossd>0</extras:tossd>
         </codelist-item>
         <codelist-item status="withdrawn" withdrawal-date="2020-02-28">
             <code>920</code>


### PR DESCRIPTION
The corresponding PR for our import scripts is https://github.com/IATI/DAC-Codelists/pull/14

This uses the new OECD development-finance-codelists: https://development-finance-codelists.oecd.org/CodesList.aspx